### PR TITLE
v0.2.1: revert broken refactor + fix skeleton path matching

### DIFF
--- a/neuralmind/__init__.py
+++ b/neuralmind/__init__.py
@@ -67,7 +67,24 @@ Token Budget:
 
 from .context_selector import ContextSelector
 from .core import NeuralMind
-from .embedder import KnowledgeSearcher
+from .embedder import GraphEmbedder
+from .compressors import (
+    compress_bash,
+    compress_read,
+    cap_search_results,
+    offload_if_large,
+)
+from .hooks import install_hooks
 
-__version__ = "0.1.0"
-__all__ = ["NeuralMind", "KnowledgeSearcher", "ContextSelector"]
+__version__ = "0.2.0"
+__all__ = [
+    "NeuralMind",
+    "GraphEmbedder",
+    "ContextSelector",
+    # Output compression (v0.2.0)
+    "compress_bash",
+    "compress_read",
+    "cap_search_results",
+    "offload_if_large",
+    "install_hooks",
+]

--- a/neuralmind/cli.py
+++ b/neuralmind/cli.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from neuralmind.core import NeuralMind
+from neuralmind.core import NeuralMind, create_mind
 
 
 def cmd_build(args):
@@ -33,7 +33,7 @@ def cmd_build(args):
 
 
 def cmd_query(args):
-    mind = NeuralMind(args.project_path)
+    mind = create_mind(args.project_path, auto_build=True)
     result = mind.query(args.question)
     if args.json:
         output = {
@@ -53,7 +53,7 @@ def cmd_query(args):
 
 
 def cmd_wakeup(args):
-    mind = NeuralMind(args.project_path)
+    mind = create_mind(args.project_path, auto_build=True)
     result = mind.wakeup()
     if args.json:
         output = {
@@ -71,7 +71,7 @@ def cmd_wakeup(args):
 
 def cmd_benchmark(args):
     print(f"Running benchmark for: {args.project_path}")
-    mind = NeuralMind(args.project_path)
+    mind = create_mind(args.project_path, auto_build=True)
     result = mind.benchmark()
     if args.json:
         print(json.dumps(result, indent=2))
@@ -84,7 +84,7 @@ def cmd_benchmark(args):
 
 
 def cmd_search(args):
-    mind = NeuralMind(args.project_path)
+    mind = create_mind(args.project_path, auto_build=True)
     results = mind.search(args.query, n=args.n)
     if args.json:
         print(json.dumps(results, indent=2))
@@ -120,7 +120,8 @@ def cmd_stats(args):
 
 def cmd_skeleton(args):
     """Return a graph-backed compact view of a file."""
-    mind = NeuralMind(args.project_path)
+    from .core import create_mind
+    mind = create_mind(args.project_path, auto_build=True)
     skeleton = mind.skeleton(args.file_path)
     if not skeleton:
         if args.json:

--- a/neuralmind/config.py
+++ b/neuralmind/config.py
@@ -19,7 +19,6 @@ DEFAULT_CONFIG = {
 }
 
 def find_config_file() -> Optional[Path]:
-    """Find the user's config file."""
     config_home = Path(os.environ.get('XDG_CONFIG_HOME', '~/.config')).expanduser()
     config_path = config_home / 'neuralmind' / 'config.toml'
     if config_path.exists():
@@ -27,12 +26,10 @@ def find_config_file() -> Optional[Path]:
     return None
 
 def load_config() -> Dict[str, Any]:
-    """Load configuration from file or return defaults."""
     config_file = find_config_file()
     if config_file:
         try:
             user_config = toml.load(config_file)
-            # Simple merge, user config overrides defaults
             config = DEFAULT_CONFIG.copy()
             config.update(user_config)
             return config

--- a/neuralmind/core.py
+++ b/neuralmind/core.py
@@ -3,18 +3,39 @@ core.py — NeuralMind Core System
 =================================
 
 Main entry point for the NeuralMind adaptive knowledge system.
-Orchestrates the knowledge searcher and context selector.
+Orchestrates embedder and context selector for massive token reduction.
+
+Usage:
+    from neuralmind import NeuralMind
+
+    # Initialize for a project
+    mind = NeuralMind("/path/to/project")
+    mind.build()  # Generate embeddings from graph.json
+
+    # Wake-up context (~600 tokens)
+    wakeup = mind.wakeup()
+    print(wakeup.context)
+
+    # Query context (~1500 tokens with relevant results)
+    result = mind.query("How does authentication work?")
+    print(result.context)
+    print(f"Token reduction: {result.reduction_ratio:.1f}x")
 """
 
+from datetime import datetime
 from pathlib import Path
 
 from .context_selector import ContextResult, ContextSelector
-from types import SimpleNamespace
-from .embedder import KnowledgeSearcher
+from .config import CONFIG
+from .embedder import GraphEmbedder
+
 
 class NeuralMind:
     """
     Adaptive Neural Knowledge System.
+
+    Replaces static Obsidian wiki with intelligent, query-aware context.
+    Achieves 6-49x token reduction through progressive disclosure.
     """
 
     def __init__(self, project_path: str, db_path: str = None):
@@ -22,81 +43,418 @@ class NeuralMind:
         Initialize NeuralMind for a project.
 
         Args:
-            project_path: Path to project root
+            project_path: Path to project root (where graphify-out/ lives)
             db_path: Optional custom path for ChromaDB storage
         """
         self.project_path = Path(project_path)
         self.db_path = db_path
 
         # Initialize components
-        self.searcher = KnowledgeSearcher(project_path, db_path)
-        # The selector now needs to be initialized differently, or its role re-evaluated.
-        # For now, we'll simplify and focus on the searcher.
-        self.selector = None # To be refactored
+        self.embedder = GraphEmbedder(project_path, db_path)
+        self.selector: ContextSelector | None = None
 
-    def query(self, question: str) -> str:
+        # State tracking
+        self._built = False
+        self._build_stats: dict = {}
+
+    def build(self, force: bool = False) -> dict:
+        """
+        Build or update the neural knowledge base.
+
+        Loads graph.json, generates embeddings, and prepares for queries.
+
+        Args:
+            force: If True, regenerate all embeddings even if unchanged
+
+        Returns:
+            Build statistics including nodes processed and time taken
+        """
+        start_time = datetime.now()
+
+        # Load graph
+        if not self.embedder.load_graph():
+            return {
+                "success": False,
+                "error": f"Could not load graph from {self.embedder.graph_path}",
+                "duration_seconds": 0,
+            }
+
+        # Embed nodes
+        embed_stats = self.embedder.embed_nodes(force=force)
+
+        # Initialize selector
+        self.selector = ContextSelector(self.embedder, str(self.project_path))
+
+        # Get final stats
+        final_stats = self.embedder.get_stats()
+
+        duration = (datetime.now() - start_time).total_seconds()
+
+        self._build_stats = {
+            "success": True,
+            "project": self.project_path.name,
+            "nodes_total": final_stats.get("total_nodes", 0),
+            "communities": final_stats.get("communities", 0),
+            "nodes_added": embed_stats.get("added", 0),
+            "nodes_updated": embed_stats.get("updated", 0),
+            "nodes_skipped": embed_stats.get("skipped", 0),
+            "db_path": final_stats.get("db_path", ""),
+            "duration_seconds": round(duration, 2),
+            "built_at": datetime.now().isoformat(),
+        }
+
+        self._built = True
+        return self._build_stats
+
+    def _ensure_built(self):
+        """Ensure the system is built before queries."""
+        if not self._built or self.selector is None:
+            self.build()
+
+    def wakeup(self) -> ContextResult:
+        """
+        Get minimal wake-up context for starting a conversation.
+
+        Returns L0 (identity) + L1 (summary) = ~600 tokens.
+        Use this when initializing a new chat about the project.
+
+        Returns:
+            ContextResult with essential project context
+        """
+        self._ensure_built()
+        return self.selector.get_wakeup_context()
+
+    def query(self, question: str) -> ContextResult:
         """
         Get optimized context for answering a question.
-        """
-        # This is a simplified query method. The complex context layering
-        # of the original design is removed, as it depended on a graph structure
-        # that does not exist.
-        search_results = self.searcher.search(question, n=15)
-        
-        # Combine the search result documents into a single context string
-        context = "\n\n---\n\n".join([result['document'] for result in search_results])
-        
-        # Create a simplified response. The original ContextResult is too complex.
-        header = f"## Project: {self.project_path.name}\n\n"
-        stats = self.get_stats()
-        knowledge_info = f"Knowledge Base: {stats.get('total_drawers', 0)} text chunks (drawers) available.\n\n"
 
-        return header + knowledge_info + "## Relevant Information\n\n" + context
+        Returns all relevant layers based on the query.
+        Typically ~1000-1500 tokens with 30-50x reduction.
+
+        Args:
+            question: Natural language question about the codebase
+
+        Returns:
+            ContextResult with relevant context and token budget
+        """
+        self._ensure_built()
+        return self.selector.get_query_context(question)
+
+    def skeleton(self, file_path: str) -> str:
+        """Return a compact skeleton view of a file using graph data.
+
+        The skeleton contains:
+        - File header (community, function count)
+        - Function list with line numbers and one-line rationale from the graph
+        - Internal call graph (within the file)
+        - Cross-file relationships (shares_data_with, imports_from edges)
+        - Pointer to bypass for full source
+
+        Args:
+            file_path: Path to the source file (absolute or project-relative)
+
+        Returns:
+            Formatted skeleton text, or empty string if file is not indexed
+        """
+        self._ensure_built()
+
+        nodes = self.embedder.get_file_nodes(file_path)
+        if not nodes:
+            return ""
+
+        node_ids = {n["id"] for n in nodes}
+        edges = self.embedder.get_file_edges(file_path, node_ids=node_ids)
+
+        # Partition nodes
+        code_nodes = [n for n in nodes if n.get("file_type") == "code"]
+        rationale_nodes = [n for n in nodes if n.get("file_type") == "rationale"]
+
+        # Map code node id → rationale text (via rationale_for edges)
+        # Edge shape: {relation: "rationale_for", _src: rationale_id, _tgt: code_id, ...}
+        rationale_map: dict[str, str] = {}
+        for e in edges:
+            if e.get("relation") != "rationale_for":
+                continue
+            src = e.get("_src") or e.get("source")
+            tgt = e.get("_tgt") or e.get("target")
+            # Find the rationale node
+            rationale_node = next(
+                (rn for rn in rationale_nodes if rn["id"] in (src, tgt)),
+                None,
+            )
+            code_node = next(
+                (cn for cn in code_nodes if cn["id"] in (src, tgt)),
+                None,
+            )
+            if rationale_node and code_node:
+                label = rationale_node.get("label", "").strip()
+                # Rationale labels are sometimes truncated docstrings; strip trailing ellipsis
+                if label:
+                    rationale_map[code_node["id"]] = label[:120]
+
+        # Separate the file-level node (source_location "L1" or label matching filename)
+        file_node = next(
+            (n for n in code_nodes
+             if n.get("source_location") == "L1"
+             or n.get("label", "").endswith((".py", ".ts", ".js", ".go", ".rs"))),
+            None,
+        )
+        function_nodes = [n for n in code_nodes if n is not file_node]
+
+        # Sort functions by line number
+        def _line_no(node: dict) -> int:
+            loc = node.get("source_location", "L0")
+            try:
+                return int(loc.lstrip("L"))
+            except ValueError:
+                return 0
+
+        function_nodes.sort(key=_line_no)
+
+        # Build call graph (within-file calls)
+        calls_map: dict[str, list[str]] = {}
+        for e in edges:
+            if e.get("relation") != "calls":
+                continue
+            # Graph stores calls as target calls source (reversed semantics per exploration)
+            src = e.get("_src") or e.get("source")
+            tgt = e.get("_tgt") or e.get("target")
+            if src in node_ids and tgt in node_ids:
+                # Display direction: caller → callee
+                # Per graphify convention, _src is caller, _tgt is callee
+                caller_id = src
+                callee_id = tgt
+                callee_node = next((n for n in function_nodes if n["id"] == callee_id), None)
+                caller_node = next((n for n in function_nodes if n["id"] == caller_id), None)
+                if caller_node and callee_node:
+                    calls_map.setdefault(
+                        caller_node.get("label", caller_id),
+                        []
+                    ).append(callee_node.get("label", callee_id))
+
+        # Cross-file edges
+        cross_edges = [
+            e for e in edges
+            if e.get("relation") in ("shares_data_with", "imports_from", "implements", "uses")
+            and (
+                (e.get("_src") in node_ids) != (e.get("_tgt") in node_ids)
+            )  # exactly one endpoint inside
+        ]
+
+        # Format output
+        lines: list[str] = []
+        community = nodes[0].get("community", "?")
+        lines.append(f"# {file_path}  (community {community}, {len(function_nodes)} functions)")
+        lines.append("")
+        lines.append("## Functions")
+
+        # Compute padding for nice alignment
+        max_label = max((len(n.get("label", "")) for n in function_nodes), default=12)
+        for n in function_nodes:
+            loc = n.get("source_location", "L?")
+            label = n.get("label", "?")
+            rat = rationale_map.get(n["id"])
+            if rat:
+                lines.append(f"{loc:<5} {label:<{max_label}}  — {rat}")
+            else:
+                lines.append(f"{loc:<5} {label}")
+
+        if calls_map:
+            lines.append("")
+            lines.append("## Call graph (within this file)")
+            for caller, callees in calls_map.items():
+                unique = sorted(set(callees))
+                lines.append(f"{caller} → {', '.join(unique)}")
+
+        if cross_edges:
+            lines.append("")
+            lines.append("## Cross-file")
+            seen_pairs: set[tuple[str, str, str]] = set()
+            for e in cross_edges[:10]:  # cap to avoid bloat
+                rel = e.get("relation", "?")
+                src = e.get("_src") or e.get("source")
+                tgt = e.get("_tgt") or e.get("target")
+                conf = e.get("confidence", "")
+                score = e.get("confidence_score", "")
+                pair = (src, tgt, rel)
+                if pair in seen_pairs:
+                    continue
+                seen_pairs.add(pair)
+                # Name the out-of-file endpoint
+                our_ids = node_ids
+                inside_id = src if src in our_ids else tgt
+                outside_id = tgt if src in our_ids else src
+                inside_label = next(
+                    (n.get("label", inside_id) for n in nodes if n["id"] == inside_id),
+                    inside_id,
+                )
+                score_str = f" {score}" if score else ""
+                lines.append(
+                    f"{inside_label} {rel} → {outside_id} ({conf}{score_str})"
+                )
+
+        lines.append("")
+        lines.append("[Full source available: Read this file with NEURALMIND_BYPASS=1]")
+
+        return "\n".join(lines)
+
+    def search(self, query: str, n: int = 10, **filters) -> list[dict]:
+        """
+        Direct semantic search without context formatting.
+
+        Args:
+            query: Search query
+            n: Number of results
+            **filters: Optional filters (file_type, community)
+
+        Returns:
+            List of matching nodes with scores
+        """
+        self._ensure_built()
+        return self.embedder.search(query, n=n, **filters)
 
     def get_stats(self) -> dict:
         """
         Get current system statistics.
-        """
-        return self.searcher.get_stats()
-    def build(self, force: bool = False) -> dict:
-        """
-        Build the knowledge base.
-        This is a placeholder as build logic is not in KnowledgeSearcher.
-        """
-        print("Build method called, but not implemented in KnowledgeSearcher.")
-        return {"success": True, "message": "Build process initiated (placeholder)."}
 
-    def wakeup(self) -> ContextResult:
+        Returns:
+            Dict with node counts, communities, and build info
         """
-        Provide a wakeup context.
-        Placeholder implementation.
-        """
-        stats = self.get_stats()
-        context = f"## Project: {self.project_path.name}\n\nKnowledge Base: {stats.get('total_drawers', 0)} text chunks (drawers) available."
-        return ContextResult(context=context, budget=SimpleNamespace(total=len(context.split())), reduction_ratio=1.0, layers_used=[], search_hits=0, communities_loaded=[])
+        if not self._built:
+            return {"built": False, "project": self.project_path.name}
 
-    def benchmark(self) -> dict:
-        """
-        Run a benchmark.
-        Placeholder implementation.
-        """
+        embed_stats = self.embedder.get_stats()
         return {
+            "built": True,
             "project": self.project_path.name,
-            "wakeup_tokens": 100,
-            "avg_query_tokens": 200,
-            "avg_reduction_ratio": 10.0,
-            "summary": "Benchmark complete (placeholder)."
+            "nodes": embed_stats.get("total_nodes", 0),
+            "communities": embed_stats.get("communities", 0),
+            "db_path": embed_stats.get("db_path", ""),
+            "build_stats": self._build_stats,
         }
 
-    def search(self, query: str, n: int = 10, **filters) -> list[dict]:
+    def benchmark(self, sample_queries: list[str] = None) -> dict:
         """
-        Delegate search to the KnowledgeSearcher.
+        Run a benchmark to measure token reduction.
+
+        Args:
+            sample_queries: Optional list of queries to test.
+                           If None, uses default queries.
+
+        Returns:
+            Benchmark results with average reduction ratio
         """
-        return self.searcher.search(query, n=n, **filters)
-    
-    def skeleton(self, file_path: str) -> str:
+        self._ensure_built()
+
+        if sample_queries is None:
+            sample_queries = [
+                "How does authentication work?",
+                "What are the main API endpoints?",
+                "How is the database structured?",
+                "What frontend components exist?",
+                "How are errors handled?",
+            ]
+
+        results = []
+
+        # Wakeup benchmark
+        wakeup = self.wakeup()
+        results.append(
+            {
+                "type": "wakeup",
+                "query": None,
+                "tokens": wakeup.budget.total,
+                "reduction": wakeup.reduction_ratio,
+            }
+        )
+
+        # Query benchmarks
+        for q in sample_queries:
+            result = self.query(q)
+            results.append(
+                {
+                    "type": "query",
+                    "query": q,
+                    "tokens": result.budget.total,
+                    "reduction": result.reduction_ratio,
+                    "layers": result.layers_used,
+                }
+            )
+
+        # Calculate averages
+        query_results = [r for r in results if r["type"] == "query"]
+        avg_tokens = sum(r["tokens"] for r in query_results) / len(query_results)
+        avg_reduction = sum(r["reduction"] for r in query_results) / len(query_results)
+
+        return {
+            "project": self.project_path.name,
+            "wakeup_tokens": wakeup.budget.total,
+            "avg_query_tokens": round(avg_tokens, 1),
+            "avg_reduction_ratio": round(avg_reduction, 1),
+            "estimated_full_codebase_tokens": 50000,
+            "results": results,
+            "summary": f"{avg_reduction:.1f}x average token reduction",
+        }
+
+    def export_context(self, query: str = None, output_path: str = None) -> str:
         """
-        Return a skeleton view of a file.
-        Placeholder implementation.
+        Export context to a file for use with other tools.
+
+        Args:
+            query: Optional query for full context. If None, exports wakeup only.
+            output_path: Optional output path. Defaults to project/neuralmind_context.md
+
+        Returns:
+            Path to exported file
         """
-        return f"Skeleton for {file_path} (placeholder)."
+        self._ensure_built()
+
+        if query:
+            result = self.query(query)
+            context_type = "query"
+        else:
+            result = self.wakeup()
+            context_type = "wakeup"
+
+        if output_path is None:
+            output_path = str(self.project_path / "neuralmind_context.md")
+
+        # Build export content
+        lines = [
+            "# NeuralMind Context Export",
+            "",
+            f"**Project:** {self.project_path.name}",
+            f"**Type:** {context_type}",
+            f"**Query:** {query or 'N/A'}",
+            f"**Tokens:** {result.budget.total}",
+            f"**Reduction:** {result.reduction_ratio:.1f}x",
+            f"**Layers:** {', '.join(result.layers_used)}",
+            f"**Generated:** {datetime.now().isoformat()}",
+            "",
+            "---",
+            "",
+            result.context,
+        ]
+
+        with open(output_path, "w") as f:
+            f.write("\n".join(lines))
+
+        return output_path
+
+
+# Convenience function for quick usage
+def create_mind(project_path: str, auto_build: bool = True) -> NeuralMind:
+    """
+    Create and optionally build a NeuralMind instance.
+
+    Args:
+        project_path: Path to project root
+        auto_build: If True, automatically build embeddings
+
+    Returns:
+        Configured NeuralMind instance
+    """
+    mind = NeuralMind(project_path)
+    if auto_build:
+        mind.build()
+    return mind

--- a/neuralmind/embedder.py
+++ b/neuralmind/embedder.py
@@ -297,6 +297,14 @@ class GraphEmbedder:
         except Exception:
             pass
 
+        # Also try absolute forms — graphify stores absolute paths in
+        # source_file, so relative inputs never match without these.
+        try:
+            candidates.add(str(Path(source_file).resolve()))
+            candidates.add(str((self.project_path / p).resolve()))
+        except Exception:
+            pass
+
         matched = [
             n for n in self.nodes
             if any(c == n.get("source_file", "") for c in candidates)

--- a/neuralmind/embedder.py
+++ b/neuralmind/embedder.py
@@ -1,41 +1,59 @@
 """
-embedder.py — Knowledge Base Search System
+embedder.py — Graph Node Embedding System
 ==========================================
 
-Provides an interface to search the ChromaDB created by the `mempalace` tool.
+Converts graphify graph.json nodes into vector embeddings for semantic search.
+Uses ChromaDB's native embedding functions (no external dependencies required).
+
+Key Features:
+- Embeds code entities (functions, classes, files, models)
+- Preserves graph structure (community, relationships)
+- Supports incremental updates (only re-embed changed nodes)
+- Stores metadata for filtering (file_type, community, source_file)
 """
 
+import hashlib
+import json
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 
 import chromadb
 from chromadb.config import Settings
 
-class KnowledgeSearcher:
+
+class GraphEmbedder:
     """
-    Provides a search interface to the ChromaDB created by `mempalace`.
+    Embeds graphify graph.json nodes into ChromaDB for semantic search.
 
     Usage:
-        searcher = KnowledgeSearcher("/path/to/project")
-        results = searcher.search("authentication logic", n=5)
+        embedder = GraphEmbedder("/path/to/project")
+        embedder.load_graph()
+        embedder.embed_nodes()
+        results = embedder.search("authentication logic", n=5)
     """
 
-    COLLECTION_NAME = "mempalace_drawers"  # THIS IS THE CORRECTED NAME
+    COLLECTION_NAME = "neuralmind_nodes"
 
     def __init__(self, project_path: str, db_path: str = None):
         """
-        Initialize the searcher for a project.
+        Initialize the embedder for a project.
 
         Args:
-            project_path: Path to project root
+            project_path: Path to project root (where graphify-out/ lives)
             db_path: Optional custom path for ChromaDB storage
         """
         self.project_path = Path(project_path)
+        self.graph_path = self.project_path / "graphify-out" / "graph.json"
 
+        # Default DB path in project's graphify-out
         if db_path is None:
-            db_path = str(Path.home() / ".mempalace" / "palace")
+            db_path = str(self.project_path / "graphify-out" / "neuralmind_db")
 
         self.db_path = db_path
+        self.graph: dict = {}
+        self.nodes: list[dict] = []
+        self.edges: list[dict] = []
 
         # Initialize ChromaDB
         self.client = chromadb.PersistentClient(
@@ -53,44 +71,333 @@ class KnowledgeSearcher:
             )
         return self._collection
 
-    def search(self, query: str, n: int = 10, **filters) -> list[dict]:
+    def load_graph(self) -> bool:
         """
-        Perform semantic search on the knowledge base.
+        Load graph.json from graphify output.
+
+        Returns:
+            True if loaded successfully, False otherwise
         """
+        if not self.graph_path.exists():
+            print(f"Graph not found: {self.graph_path}")
+            return False
+
+        with open(self.graph_path) as f:
+            self.graph = json.load(f)
+
+        self.nodes = self.graph.get("nodes", [])
+        self.edges = self.graph.get("edges", self.graph.get("links", []))
+
+        print(f"Loaded graph: {len(self.nodes)} nodes, {len(self.edges)} edges")
+        return True
+
+    def _node_to_text(self, node: dict) -> str:
+        """
+        Convert a node to searchable text representation.
+
+        Combines label, file_type, source_file, and community info
+        into a rich text description for embedding.
+        """
+        parts = []
+
+        # Primary identifier
+        label = node.get("label", node.get("id", "unknown"))
+        parts.append(f"Entity: {label}")
+
+        # Type information
+        file_type = node.get("file_type", "unknown")
+        parts.append(f"Type: {file_type}")
+
+        # Source location
+        source_file = node.get("source_file", "")
+        if source_file:
+            parts.append(f"File: {source_file}")
+
+        source_loc = node.get("source_location", "")
+        if source_loc:
+            parts.append(f"Location: {source_loc}")
+
+        # Community/cluster info
+        community = node.get("community", -1)
+        if community >= 0:
+            parts.append(f"Community: {community}")
+
+        # Normalized label (often more descriptive)
+        norm_label = node.get("norm_label", "")
+        if norm_label and norm_label != label:
+            parts.append(f"Normalized: {norm_label}")
+
+        return "\n".join(parts)
+
+    def _node_metadata(self, node: dict) -> dict[str, Any]:
+        """
+        Extract metadata from node for filtering.
+        """
+        return {
+            "label": str(node.get("label", node.get("id", "unknown"))),
+            "file_type": str(node.get("file_type", "unknown")),
+            "source_file": str(node.get("source_file", "")),
+            "community": int(node.get("community", -1)),
+            "node_id": str(node.get("id", "")),
+        }
+
+    def _content_hash(self, text: str) -> str:
+        """Generate hash of content for change detection."""
+        return hashlib.sha256(text.encode()).hexdigest()[:16]
+
+    def embed_nodes(self, force: bool = False) -> dict[str, int]:
+        """
+        Embed all nodes into ChromaDB.
+
+        Args:
+            force: If True, re-embed all nodes. Otherwise, skip unchanged.
+
+        Returns:
+            Dict with counts: {"added": N, "updated": N, "skipped": N}
+        """
+        if not self.nodes:
+            if not self.load_graph():
+                return {
+                    "added": 0,
+                    "updated": 0,
+                    "skipped": 0,
+                    "error": "No graph loaded",
+                }
+
+        stats = {"added": 0, "updated": 0, "skipped": 0}
+
+        # Batch process for efficiency
+        batch_ids = []
+        batch_docs = []
+        batch_metas = []
+
+        for node in self.nodes:
+            node_id = str(node.get("id", node.get("label", "")))
+            if not node_id:
+                continue
+
+            text = self._node_to_text(node)
+            meta = self._node_metadata(node)
+            meta["content_hash"] = self._content_hash(text)
+            meta["embedded_at"] = datetime.now().isoformat()
+
+            # Check if we need to update
+            if not force:
+                try:
+                    existing = self.collection.get(ids=[node_id], include=["metadatas"])
+                    if existing["ids"] and existing["metadatas"]:
+                        old_hash = existing["metadatas"][0].get("content_hash", "")
+                        if old_hash == meta["content_hash"]:
+                            stats["skipped"] += 1
+                            continue
+                        stats["updated"] += 1
+                    else:
+                        stats["added"] += 1
+                except Exception:
+                    stats["added"] += 1
+            else:
+                stats["added"] += 1
+
+            batch_ids.append(node_id)
+            batch_docs.append(text)
+            batch_metas.append(meta)
+
+            # Process in batches of 100
+            if len(batch_ids) >= 100:
+                self.collection.upsert(ids=batch_ids, documents=batch_docs, metadatas=batch_metas)
+                batch_ids, batch_docs, batch_metas = [], [], []
+
+        # Final batch
+        if batch_ids:
+            self.collection.upsert(ids=batch_ids, documents=batch_docs, metadatas=batch_metas)
+
+        print(f"Embedding complete: {stats}")
+        return stats
+
+    def search(
+        self, query: str, n: int = 10, file_type: str = None, community: int = None
+    ) -> list[dict]:
+        """
+        Semantic search for relevant nodes.
+
+        Args:
+            query: Natural language query
+            n: Number of results to return
+            file_type: Optional filter by file type
+            community: Optional filter by community ID
+
+        Returns:
+            List of matching nodes with scores
+        """
+        where_filter = None
+        conditions = []
+
+        if file_type:
+            conditions.append({"file_type": file_type})
+        if community is not None:
+            conditions.append({"community": community})
+
+        if len(conditions) == 1:
+            where_filter = conditions[0]
+        elif len(conditions) > 1:
+            where_filter = {"$and": conditions}
+
         results = self.collection.query(
             query_texts=[query],
             n_results=n,
-            where=filters if filters else None,
-            include=["metadatas", "documents", "distances"],
+            where=where_filter,
+            include=["documents", "metadatas", "distances"],
         )
-        formatted_results = []
-        ids = results.get("ids", [[]])[0]
-        documents = results.get("documents", [[]])[0]
-        metadatas = results.get("metadatas", [[]])[0]
-        distances = results.get("distances", [[]])[0]
 
-        for i in range(len(ids)):
-            formatted_results.append({
-                "id": ids[i],
-                "document": documents[i],
-                "metadata": metadatas[i],
-                "distance": distances[i],
-            })
-        return formatted_results
+        # Format results
+        formatted = []
+        if results["ids"] and results["ids"][0]:
+            for i, node_id in enumerate(results["ids"][0]):
+                formatted.append(
+                    {
+                        "id": node_id,
+                        "document": (results["documents"][0][i] if results["documents"] else ""),
+                        "metadata": (results["metadatas"][0][i] if results["metadatas"] else {}),
+                        "distance": (results["distances"][0][i] if results["distances"] else 0),
+                        "score": 1
+                        - (
+                            results["distances"][0][i] if results["distances"] else 0
+                        ),  # Convert distance to similarity
+                    }
+                )
+
+        return formatted
+
+    def get_file_nodes(self, source_file: str) -> list[dict]:
+        """Return all graph nodes whose source_file matches the given path.
+
+        Path matching is flexible: we try exact match, then a normalized
+        match that handles windows/posix slashes and the repo-relative
+        vs absolute variance that ships across graph builders.
+
+        Args:
+            source_file: File path (absolute or relative to project root)
+
+        Returns:
+            List of node dicts (empty if graph not loaded or no matches)
+        """
+        if not self.nodes:
+            if not self.load_graph():
+                return []
+
+        # Build multiple candidate keys to match against node.source_file
+        p = str(source_file).replace("\\", "/").lstrip("./")
+        candidates = {p, p.replace("/", "\\")}
+        # If it's under project_path, also try the relative form
+        try:
+            rel = str(Path(source_file).resolve().relative_to(self.project_path.resolve()))
+            candidates.add(rel)
+            candidates.add(rel.replace("\\", "/"))
+            candidates.add(rel.replace("/", "\\"))
+        except Exception:
+            pass
+
+        matched = [
+            n for n in self.nodes
+            if any(c == n.get("source_file", "") for c in candidates)
+        ]
+        return matched
+
+    def get_file_edges(self, source_file: str, node_ids: set[str] | None = None) -> list[dict]:
+        """Return edges where either endpoint belongs to the given file.
+
+        Args:
+            source_file: File path to filter by
+            node_ids: Optional pre-computed set of node ids for this file
+                      (pass in from get_file_nodes to avoid recomputation)
+
+        Returns:
+            List of edge dicts
+        """
+        if not self.edges:
+            if not self.load_graph():
+                return []
+
+        if node_ids is None:
+            node_ids = {n["id"] for n in self.get_file_nodes(source_file)}
+
+        if not node_ids:
+            return []
+
+        return [
+            e for e in self.edges
+            if (e.get("_src") in node_ids or e.get("_tgt") in node_ids
+                or e.get("source") in node_ids or e.get("target") in node_ids)
+        ]
+
+    def get_community_summary(self, community_id: int, max_nodes: int = 20) -> dict:
+        """
+        Get a summary of nodes in a community for context injection.
+
+        Args:
+            community_id: The community/cluster ID
+            max_nodes: Maximum nodes to include
+
+        Returns:
+            Dict with community summary and key nodes
+        """
+        results = self.collection.get(
+            where={"community": community_id},
+            include=["documents", "metadatas"],
+            limit=max_nodes,
+        )
+
+        if not results["ids"]:
+            return {
+                "community": community_id,
+                "nodes": [],
+                "summary": "Empty community",
+            }
+
+        nodes = []
+        for i, node_id in enumerate(results["ids"]):
+            nodes.append(
+                {
+                    "id": node_id,
+                    "label": results["metadatas"][i].get("label", node_id),
+                    "file_type": results["metadatas"][i].get("file_type", "unknown"),
+                    "source_file": results["metadatas"][i].get("source_file", ""),
+                }
+            )
+
+        # Generate compact summary
+        file_types = {}
+        for n in nodes:
+            ft = n["file_type"]
+            file_types[ft] = file_types.get(ft, 0) + 1
+
+        type_summary = ", ".join(f"{v} {k}s" for k, v in file_types.items())
+
+        return {
+            "community": community_id,
+            "node_count": len(nodes),
+            "type_summary": type_summary,
+            "nodes": nodes,
+        }
 
     def get_stats(self) -> dict:
         """
-        Get statistics about the knowledge base collection.
+        Get embedding statistics.
         """
-        try:
-            count = self.collection.count()
-            return {
-                "db_path": self.db_path,
-                "total_drawers": count,
-            }
-        except Exception as e:
-            return {
-                "db_path": self.db_path,
-                "total_drawers": 0,
-                "error": str(e),
-            }
+        count = self.collection.count()
+
+        # Get community distribution
+        communities = {}
+        if count > 0:
+            # Sample to get community distribution
+            sample = self.collection.get(include=["metadatas"], limit=min(count, 1000))
+            for meta in sample["metadatas"]:
+                c = meta.get("community", -1)
+                communities[c] = communities.get(c, 0) + 1
+
+        return {
+            "total_nodes": count,
+            "communities": len(communities),
+            "community_distribution": communities,
+            "db_path": self.db_path,
+        }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,8 +47,7 @@ classifiers = [
 requires-python = ">=3.10"
 dependencies = [
     "chromadb>=0.4.0",
-    "pyyaml>=6.0",
-    "toml>=0.10.2"
+    "pyyaml>=6.0"
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "neuralmind"
-version = "0.2.0"
+version = "0.2.1"
 description = "Adaptive Neural Knowledge System + PostToolUse compression hooks. Two-phase token optimization (retrieval + consumption) for Claude Code."
 readme = "README.md"
 license = "MIT"

--- a/tests/test_embedder.py
+++ b/tests/test_embedder.py
@@ -297,3 +297,39 @@ class TestCommunitySummary:
 
         assert isinstance(summary, dict)
         assert summary["nodes"] == []
+
+
+class TestGetFileNodes:
+    """Tests for GraphEmbedder.get_file_nodes path matching."""
+
+    def _make_embedder(self, project_path, abs_source):
+        from neuralmind.embedder import GraphEmbedder
+
+        embedder = GraphEmbedder(str(project_path))
+        embedder.nodes = [{"id": "x", "source_file": abs_source}]
+        return embedder
+
+    def test_matches_relative_path_against_absolute_node(self, temp_project):
+        """Graphify stores absolute paths; users pass relative paths."""
+        abs_source = str((temp_project / "src" / "foo.py").resolve())
+        embedder = self._make_embedder(temp_project, abs_source)
+
+        assert len(embedder.get_file_nodes("src/foo.py")) == 1
+
+    def test_matches_dot_slash_prefixed_path(self, temp_project):
+        abs_source = str((temp_project / "src" / "foo.py").resolve())
+        embedder = self._make_embedder(temp_project, abs_source)
+
+        assert len(embedder.get_file_nodes("./src/foo.py")) == 1
+
+    def test_matches_absolute_path(self, temp_project):
+        abs_source = str((temp_project / "src" / "foo.py").resolve())
+        embedder = self._make_embedder(temp_project, abs_source)
+
+        assert len(embedder.get_file_nodes(abs_source)) == 1
+
+    def test_nonexistent_file_returns_empty(self, temp_project):
+        abs_source = str((temp_project / "src" / "foo.py").resolve())
+        embedder = self._make_embedder(temp_project, abs_source)
+
+        assert embedder.get_file_nodes("src/does_not_exist.py") == []


### PR DESCRIPTION
## Summary

- Revert the chunk-based refactor (`fe2c6d5` + merge `9fae38b`) that left `main` with placeholder `core.py` methods, broken `cli.py` attribute access, and a test suite still pinned to `GraphEmbedder`. Restore `neuralmind/{__init__,cli,config,core,embedder}.py` and `pyproject.toml` to pre-refactor (`5125a0c`) state so users of the published package have a working CLI.
- Apply the 2-line `get_file_nodes` fix from the bug report: relative path inputs (e.g. `src/foo.py`) never matched because graphify stores absolute paths in `node["source_file"]`. Adds the absolute resolved path and the project-path-joined path to the candidate set.
- Add `TestGetFileNodes` regression tests covering relative, `./`-prefixed, and absolute input forms against an absolute-source-file node.
- Bump version `0.2.0` → `0.2.1`.

Files added by the refactor (`benchmark.py`, `neuralmind/local_client.py`, `optimization/`) are left in place — they're unused by the restored package code and can be removed in a follow-up.

The chunk-based rearchitecture should be redone properly on a feature branch. Tracking issue: #10.

## Test plan

- [ ] `pip install -e ".[dev]" && pytest tests/ -v` passes locally
- [ ] CI green on this PR
- [ ] After merge: tag `v0.2.1` → release workflow publishes to PyPI
- [ ] `pip install neuralmind==0.2.1 && neuralmind skeleton <indexed-file>` returns real output instead of "No graph nodes found"

https://claude.ai/code/session_01UJMKwZSSEbgKK367SqUgHE