### PR TITLE
v0.2.2: declare toml dep so CI test job stops failing at collection

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "neuralmind"
-version = "0.2.1"
+version = "0.2.2"
 description = "Adaptive Neural Knowledge System + PostToolUse compression hooks. Two-phase token optimization (retrieval + consumption) for Claude Code."
 readme = "README.md"
 license = "MIT"
@@ -47,7 +47,8 @@ classifiers = [
 requires-python = ">=3.10"
 dependencies = [
     "chromadb>=0.4.0",
-    "pyyaml>=6.0"
+    "pyyaml>=6.0",
+    "toml>=0.10"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary

`neuralmind/config.py:2` does `import toml` at module load, but `toml` was never declared in `pyproject.toml` dependencies. Locally it was masked by environments where `toml` was pulled in transitively; in CI it broke `pytest` collection for `tests/test_compressors.py` and `tests/test_hooks.py` with:

```
neuralmind/config.py:2: in <module>
    import toml
E   ModuleNotFoundError: No module named 'toml'
```

`pytest` exits with code 2 on "interrupted during collection", the `test` job in `release.yml` fails, and `build`/`publish-pypi`/`github-release` all skip. This is why `v0.1.7` was the last version that made it to PyPI — `v0.2.0` and `v0.2.1` both published GitHub releases but never made it to PyPI.

## Fix

Add `toml>=0.10` to `[project].dependencies` and bump version to `0.2.2`.

Verified locally:
```
128 passed, 16 skipped in 68.55s
exit=0
```

## Test plan

- [ ] CI `test` job passes on this PR (first time since v0.1.7)
- [ ] After merge: create `v0.2.2` release → `release.yml` runs → PyPI publish succeeds
- [ ] `pip install neuralmind==0.2.2` works and `import neuralmind` succeeds in a clean env

https://claude.ai/code/session_01UJMKwZSSEbgKK367SqUgHE