### PR TITLE
Add comparison pages, use cases, and broadened SEO

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,50 @@ You: "How does authentication work in my codebase?"
 
 ---
 
+## 🚨 When do I reach for NeuralMind?
+
+Two ways to decide: start with what's annoying you (**symptoms**), or start with what you're trying to achieve (**goals**).
+
+### Symptoms — "This is happening to me"
+
+| What you notice | Reach for | Why it fixes it |
+|---|---|---|
+| Claude Code hits context limits mid-task | `neuralmind install-hooks .` | Auto-compresses Read/Bash/Grep **before** the agent sees them (~88–91%) |
+| My monthly LLM bill is climbing | `neuralmind query` + hooks | 40–70× fewer tokens per code question |
+| I start every session re-pasting project structure | `neuralmind wakeup .` | ~400 tokens of orientation; pipe into any chat |
+| Agent reads a 2,000-line file to answer about one function | `neuralmind skeleton <file>` | Functions + call graph, no body; ~88% cheaper than `Read` |
+| `grep` floods the agent with hundreds of matches | `neuralmind install-hooks .` | Caps at 25 matches with "N more hidden" pointer |
+| The agent is confidently wrong about what my code does | Start session with `wakeup`; ask with `query` | Grounds the model in real structure instead of guessing |
+| I want to query my codebase from ChatGPT / Gemini | `neuralmind wakeup . \| pbcopy` | Model-agnostic output; paste into any chat |
+| Retrieval feels random across similar questions | `neuralmind learn .` | Cooccurrence-based reranking adapts to your patterns |
+| Index feels out of date after a refactor | `neuralmind build .` (or `init-hook` once) | Incremental — only re-embeds changed nodes |
+
+### Goals — "What am I trying to solve for?"
+
+| If your goal is… | Do this | Expected outcome |
+|---|---|---|
+| **Cut LLM spend** on code Q&A | `install-hooks` + use `query` for questions | 5–10× total reduction vs baseline agent |
+| **Faster, more grounded** agent responses | `wakeup` at session start → `query` / `skeleton` during | Fewer hallucinations; less re-exploration |
+| **Keep all code local** (no SaaS, no telemetry) | Default install — no extra config | 100% offline; nothing leaves the machine |
+| **Work across Claude + GPT + Gemini** with one index | Build once, pipe output into any model | Same context quality, model-agnostic |
+| **Make retrieval adapt** to how your team queries | Enable memory (TTY prompt) + `neuralmind learn .` | Relevance improves on repeat patterns |
+| **Measure savings** for a manager or stakeholder | `neuralmind benchmark . --json` | Per-query tokens, reduction ratios, dollar estimate |
+| **Auto-refresh** the index as code changes | `neuralmind init-hook .` (git post-commit) | Every commit rebuilds incrementally |
+
+### Still not sure?
+
+You **probably don't need NeuralMind** if:
+
+- Your codebase is under ~5K tokens total (just paste the whole thing in).
+- You don't use an AI coding agent.
+- You only want inline completions — use [Copilot](docs/comparisons/vs-github-copilot.md) or [Cursor](docs/comparisons/vs-cursor-codebase.md) directly.
+
+You **almost certainly want NeuralMind** if any row above describes a recurring frustration, or if your LLM bill has crossed the point where a 40–70× reduction is worth 5 minutes of setup.
+
+See the [use-case walkthroughs](docs/use-cases/README.md) for step-by-step guides matched to your situation.
+
+---
+
 ## 👤 Who is NeuralMind for?
 
 | You are… | NeuralMind gives you… |
@@ -1000,7 +1044,8 @@ Only if you install the git post-commit hook with `neuralmind init-hook .`. Othe
 | **[Integration Guide](https://github.com/dfrostar/neuralmind/wiki/Integration-Guide)** | MCP, CI/CD, VS Code, JetBrains |
 | **[Troubleshooting](https://github.com/dfrostar/neuralmind/wiki/Troubleshooting)** | Common issues and fixes |
 | **[Brain-like Learning](docs/brain_like_learning.md)** | Design rationale for the learning system |
-| **[Comparisons](docs/comparisons/README.md)** | NeuralMind vs. Cursor, Aider, Cody, LangChain, long context, RAG, tree-sitter |
+| **[Use Cases](docs/use-cases/README.md)** | Step-by-step walkthroughs: Claude Code, cost optimization, any-LLM, offline/regulated, growing monorepo |
+| **[Comparisons](docs/comparisons/README.md)** | NeuralMind vs. Cursor, Copilot, Cody, Aider, Claude Projects, LangChain, long context, prompt caching, RAG, tree-sitter |
 | **[USAGE.md](USAGE.md)** | Extended usage examples |
 
 ---

--- a/README.md
+++ b/README.md
@@ -262,6 +262,25 @@ If your priority is strict zero-dependency operation, heuristic-only is the simp
 
 ---
 
+## ⚖️ NeuralMind vs. Alternatives
+
+Short answers to "why not just use X?". Each row links to a deeper page.
+
+| Compared against | Short verdict |
+|---|---|
+| [Cursor `@codebase`](docs/comparisons/vs-cursor-codebase.md) | Works *only* in Cursor; NeuralMind works in any agent and adds tool-output compression |
+| [Aider repo-map](docs/comparisons/vs-aider-repomap.md) | Aider is syntactic only; NeuralMind adds semantic retrieval and compression |
+| [Sourcegraph Cody](docs/comparisons/vs-cody.md) | Cody is server-hosted and org-wide; NeuralMind is local and per-project |
+| [Continue / Cline](docs/comparisons/vs-continue-cline.md) | Those are agent runtimes; NeuralMind is the context/compression layer underneath |
+| [LangChain / LlamaIndex for code](docs/comparisons/vs-langchain-llamaindex.md) | Frameworks you assemble; NeuralMind is the assembled default for code agents |
+| [Long context windows (1M/2M)](docs/comparisons/vs-long-context.md) | Possible ≠ cheap — NeuralMind gives ~60× cost reduction on the same model |
+| [Generic RAG over a codebase](docs/comparisons/vs-rag.md) | Text chunking loses structure; NeuralMind keeps the call graph |
+| [Tree-sitter / ctags / grep](docs/comparisons/vs-treesitter-ctags.md) | Deterministic but syntactic; use alongside NeuralMind, not instead of |
+
+Full comparison index: [docs/comparisons/](docs/comparisons/README.md).
+
+---
+
 ## 🚀 Quick Start (humans)
 
 ```bash
@@ -895,6 +914,59 @@ For top-5 retrieval accuracy, run a project-specific relevance harness with the 
 
 ---
 
+## ❓ FAQ
+
+### How much does NeuralMind reduce Claude / GPT token costs?
+
+Measured on real repos: **40–70× reduction per query** (see [Benchmarks](#-benchmarks)). For a team running 100 queries/day on Claude Sonnet, that is roughly **$450/month → $7/month**. Exact savings depend on codebase size and model pricing.
+
+### Does NeuralMind work outside Claude Code?
+
+Yes. The CLI works anywhere Python runs; the MCP server works with Cursor, Cline, Continue, Claude Desktop, and any MCP-compatible agent. For non-MCP tools like ChatGPT or Gemini, `neuralmind wakeup . | pbcopy` pipes context into a regular chat window. Only the PostToolUse compression hooks are Claude-Code-specific.
+
+### Does my code leave my machine?
+
+No. NeuralMind is fully offline — no API calls, no cloud services. Embeddings run locally via ChromaDB, and the knowledge graph is stored in `graphify-out/` in your project. Query memory (optional, opt-in) is written to `.neuralmind/` on disk.
+
+### Is this RAG? How is it different from LangChain or LlamaIndex?
+
+It is a form of RAG, but specialized for code. Instead of chunking text, NeuralMind retrieves over a **knowledge graph of code entities** (functions, classes, clusters) with a fixed 4-layer structure. That keeps the call graph intact and produces a token-budgeted output instead of a flat list of chunks. See [vs. LangChain/LlamaIndex](docs/comparisons/vs-langchain-llamaindex.md).
+
+### I have a 1M context window now — do I still need this?
+
+Long context makes it *possible* to stuff a whole repo in; it does not make it *cheap*. You still pay per input token, so a 50K-token repo at Claude Sonnet rates costs ~$0.15 **every turn**. NeuralMind drops that to ~$0.002. See [vs. long context](docs/comparisons/vs-long-context.md).
+
+### Does it support my language?
+
+Any language [graphify](https://github.com/dfrostar/graphify) supports (Python, JavaScript/TypeScript, and others via tree-sitter). NeuralMind consumes `graphify-out/graph.json` — if graphify can index it, NeuralMind can query it.
+
+### What is the difference between `wakeup`, `query`, and `skeleton`?
+
+- **`wakeup`** — ~400 tokens of project orientation (L0 + L1). Run it at session start.
+- **`query`** — ~800–1,100 tokens for a specific natural-language question (L0–L3).
+- **`skeleton`** — compact view of a single file (functions + call graph + cross-file edges). Use before `Read`.
+
+### How does the PostToolUse compression work?
+
+When `neuralmind install-hooks .` has been run, Claude Code invokes NeuralMind **after** every `Read`/`Bash`/`Grep` tool call but **before** the agent sees the output. `Read` becomes a skeleton (~88% smaller), `Bash` keeps errors + last 3 lines (~91% smaller), `Grep` caps at 25 matches. Set `NEURALMIND_BYPASS=1` on any command to opt out.
+
+### Can I use NeuralMind without a knowledge graph?
+
+No — the knowledge graph (`graphify-out/graph.json`) is the source of truth. Run `graphify update .` first, then `neuralmind build .`.
+
+### Does it auto-update when I change code?
+
+Only if you install the git post-commit hook with `neuralmind init-hook .`. Otherwise run `neuralmind build .` manually; it is incremental and only re-embeds changed nodes.
+
+### What do I do if retrieval quality is poor on my repo?
+
+1. Check that `neuralmind stats .` reports all your nodes indexed.
+2. Run `neuralmind benchmark .` to see reduction ratios.
+3. Enable query memory (it prompts on first TTY run) and periodically run `neuralmind learn .` — cooccurrence-based reranking improves relevance on your actual queries.
+4. Open an issue with the query and expected result — retrieval quality is the thing we most want to improve.
+
+---
+
 ## 📚 Documentation
 
 | Resource | Contents |
@@ -907,6 +979,7 @@ For top-5 retrieval accuracy, run a project-specific relevance harness with the 
 | **[Integration Guide](https://github.com/dfrostar/neuralmind/wiki/Integration-Guide)** | MCP, CI/CD, VS Code, JetBrains |
 | **[Troubleshooting](https://github.com/dfrostar/neuralmind/wiki/Troubleshooting)** | Common issues and fixes |
 | **[Brain-like Learning](docs/brain_like_learning.md)** | Design rationale for the learning system |
+| **[Comparisons](docs/comparisons/README.md)** | NeuralMind vs. Cursor, Aider, Cody, LangChain, long context, RAG, tree-sitter |
 | **[USAGE.md](USAGE.md)** | Extended usage examples |
 
 ---

--- a/README.md
+++ b/README.md
@@ -247,6 +247,23 @@ You: "How does authentication work in my codebase?"
 
 ---
 
+## 👤 Who is NeuralMind for?
+
+| You are… | NeuralMind gives you… |
+|---|---|
+| A **Claude Code user** watching your token bill climb | PostToolUse compression on every Read/Bash/Grep + ~60× smaller query context |
+| A **Cursor user** who wants semantic retrieval outside Cursor too | CLI + MCP server that works in any agent with the same index |
+| A **Cline / Continue user** without a built-in codebase index | Drop-in MCP `neuralmind_query` and `neuralmind_skeleton` tools |
+| Running **OpenAI / Gemini / local models** | Model-agnostic context — pipe `wakeup` / `query` output into any chat |
+| A **solo developer** with a growing monorepo | Incremental rebuilds + learning that adapts to your query patterns |
+| A **team tech lead** worried about LLM spend | Measurable per-query token reduction with `neuralmind benchmark` |
+| A **security-conscious engineer** or in a **regulated industry** | 100% local, offline, no code leaves the machine |
+| A **researcher / hobbyist** exploring LLM cost optimization | Open-source reference implementation of two-phase token optimization |
+
+Not a fit if: you need cross-repo search across a whole organization (use [Sourcegraph Cody](docs/comparisons/vs-cody.md)), or you only want inline completions (use [Copilot](docs/comparisons/vs-github-copilot.md)).
+
+---
+
 ## 🤔 Why NeuralMind vs. Heuristic-Only
 
 Both approaches are valid; the tradeoff is retrieval quality vs. simplicity.
@@ -272,6 +289,10 @@ Short answers to "why not just use X?". Each row links to a deeper page.
 | [Aider repo-map](docs/comparisons/vs-aider-repomap.md) | Aider is syntactic only; NeuralMind adds semantic retrieval and compression |
 | [Sourcegraph Cody](docs/comparisons/vs-cody.md) | Cody is server-hosted and org-wide; NeuralMind is local and per-project |
 | [Continue / Cline](docs/comparisons/vs-continue-cline.md) | Those are agent runtimes; NeuralMind is the context/compression layer underneath |
+| [GitHub Copilot](docs/comparisons/vs-github-copilot.md) | Copilot is hosted completions; NeuralMind is local context for any agent |
+| [Windsurf / Codeium](docs/comparisons/vs-windsurf-codeium.md) | Vertically integrated IDE; NeuralMind is editor- and model-agnostic |
+| [Claude Projects](docs/comparisons/vs-claude-projects.md) | Projects reload all files every turn; NeuralMind retrieves only what the query needs |
+| [Prompt caching](docs/comparisons/vs-prompt-caching.md) | Caching amortizes a big prompt; NeuralMind makes the prompt small — combine both |
 | [LangChain / LlamaIndex for code](docs/comparisons/vs-langchain-llamaindex.md) | Frameworks you assemble; NeuralMind is the assembled default for code agents |
 | [Long context windows (1M/2M)](docs/comparisons/vs-long-context.md) | Possible ≠ cheap — NeuralMind gives ~60× cost reduction on the same model |
 | [Generic RAG over a codebase](docs/comparisons/vs-rag.md) | Text chunking loses structure; NeuralMind keeps the call graph |

--- a/docs/comparisons/README.md
+++ b/docs/comparisons/README.md
@@ -15,6 +15,10 @@ Each page follows the same structure:
 | [Aider repo-map](./vs-aider-repomap.md) | "Aider already builds a repo-map, isn't this the same?" |
 | [Sourcegraph Cody](./vs-cody.md) | "How is this different from Cody's code context?" |
 | [Continue / Cline](./vs-continue-cline.md) | "I already have an MCP-capable IDE agent" |
+| [GitHub Copilot](./vs-github-copilot.md) | "I pay for Copilot — does this overlap?" |
+| [Windsurf / Codeium](./vs-windsurf-codeium.md) | "How does this compare to the Windsurf IDE?" |
+| [Claude Projects](./vs-claude-projects.md) | "Can't I just attach files to a Claude Project?" |
+| [Prompt caching](./vs-prompt-caching.md) | "Doesn't prompt caching solve the cost problem?" |
 | [LangChain / LlamaIndex for code](./vs-langchain-llamaindex.md) | "Can I just wire up RAG myself?" |
 | [Long context windows](./vs-long-context.md) | "Claude has 1M context / Gemini has 2M — why compress?" |
 | [Generic RAG over a codebase](./vs-rag.md) | "Isn't this just RAG with extra steps?" |

--- a/docs/comparisons/README.md
+++ b/docs/comparisons/README.md
@@ -1,0 +1,30 @@
+# NeuralMind Comparisons
+
+Honest side-by-side comparisons between NeuralMind and the tools developers most often evaluate alongside it.
+
+Each page follows the same structure:
+
+1. **What it is** — one-paragraph description of the alternative
+2. **How it differs** — concrete mechanism and output differences
+3. **When to pick which** — decision guidance, not a sales pitch
+4. **Feature matrix** — side-by-side table
+
+| Compared against | Best when you are asking |
+|---|---|
+| [Cursor `@codebase`](./vs-cursor-codebase.md) | "I use Cursor — do I still need this?" |
+| [Aider repo-map](./vs-aider-repomap.md) | "Aider already builds a repo-map, isn't this the same?" |
+| [Sourcegraph Cody](./vs-cody.md) | "How is this different from Cody's code context?" |
+| [Continue / Cline](./vs-continue-cline.md) | "I already have an MCP-capable IDE agent" |
+| [LangChain / LlamaIndex for code](./vs-langchain-llamaindex.md) | "Can I just wire up RAG myself?" |
+| [Long context windows](./vs-long-context.md) | "Claude has 1M context / Gemini has 2M — why compress?" |
+| [Generic RAG over a codebase](./vs-rag.md) | "Isn't this just RAG with extra steps?" |
+| [Tree-sitter / ctags / grep](./vs-treesitter-ctags.md) | "Why do I need embeddings at all?" |
+
+## TL;DR
+
+NeuralMind is specifically a **two-phase token optimizer for AI coding agents**:
+
+- **Phase 1 (retrieval):** a 4-layer progressive disclosure index that surfaces ~800 tokens of structured context for a code question.
+- **Phase 2 (consumption):** PostToolUse hooks that compress `Read`, `Bash`, and `Grep` output *before the agent sees it*.
+
+Most alternatives cover one or the other, not both. The comparison pages walk through where each tool fits in that split.

--- a/docs/comparisons/vs-aider-repomap.md
+++ b/docs/comparisons/vs-aider-repomap.md
@@ -22,3 +22,7 @@ Aider builds a concise, tree-sitter-derived map of your repository — a ranked 
 - **Pick NeuralMind** if you want semantic (not just syntactic) retrieval, want it outside Aider, or want the consumption-side compression. Aider's map answers "what symbols exist"; NeuralMind's query answers "which 800 tokens best explain X".
 
 They compose: you can feed NeuralMind's `wakeup` output into an Aider session as additional context.
+
+---
+
+[← Back to comparison index](./README.md)

--- a/docs/comparisons/vs-aider-repomap.md
+++ b/docs/comparisons/vs-aider-repomap.md
@@ -1,0 +1,24 @@
+# NeuralMind vs. Aider repo-map
+
+## What Aider's repo-map is
+
+Aider builds a concise, tree-sitter-derived map of your repository — a ranked list of the most relevant symbols and their signatures — and injects it into the prompt every turn. It's a clever, zero-embedding, purely static approach.
+
+## How NeuralMind differs
+
+| Dimension | Aider repo-map | NeuralMind |
+|---|---|---|
+| Technique | Static tree-sitter + PageRank over symbol graph | Knowledge graph + vector embeddings (ChromaDB) |
+| Semantic retrieval | No — syntactic signal only | Yes — embedding similarity over all nodes |
+| Output | Ranked signatures injected every turn | On-demand progressive layers (wakeup / query / skeleton) |
+| Host | Aider CLI only | Any MCP agent + CLI + copy-paste to any LLM |
+| Tool-output compression | None | Read/Bash/Grep PostToolUse hooks |
+| Learns from usage | No | Yes — cooccurrence-based reranking |
+| Languages | Whatever tree-sitter supports | Same (via graphify) |
+
+## When to pick which
+
+- **Pick Aider repo-map** if you use Aider and want a zero-dependency, deterministic map.
+- **Pick NeuralMind** if you want semantic (not just syntactic) retrieval, want it outside Aider, or want the consumption-side compression. Aider's map answers "what symbols exist"; NeuralMind's query answers "which 800 tokens best explain X".
+
+They compose: you can feed NeuralMind's `wakeup` output into an Aider session as additional context.

--- a/docs/comparisons/vs-claude-projects.md
+++ b/docs/comparisons/vs-claude-projects.md
@@ -1,0 +1,30 @@
+# NeuralMind vs. Claude Projects
+
+## What Claude Projects is
+
+Claude Projects is Anthropic's feature for attaching a persistent set of files (docs, code, PDFs) to a Claude.ai conversation. The attached knowledge is loaded into the model context each turn, up to Claude's context window.
+
+## How NeuralMind differs
+
+| Dimension | Claude Projects | NeuralMind |
+|---|---|---|
+| Surface | Claude.ai web | CLI + MCP + Claude Code hooks |
+| Indexing | None — files are loaded verbatim | Knowledge graph + vector index |
+| Context shape | Raw file text | 4-layer progressive disclosure (L0–L3) |
+| Cost per turn | Pays for all attached content every turn | Pays only for the ~800 tokens actually retrieved |
+| File limit | Bounded by the attached-files quota | Bounded only by disk |
+| Works in IDE agents | No | Yes |
+| Tool-output compression | No | Yes |
+| Offline | No | Yes |
+| Model choice | Claude only | Any model |
+
+## When to pick which
+
+- **Pick Claude Projects** for doc-centric chats, onboarding material, or mixed knowledge bases you interact with through Claude.ai.
+- **Pick NeuralMind** when the content is source code, when you want retrieval that scales to larger codebases, or when you are working inside an IDE agent rather than Claude.ai.
+
+A common pattern: use Claude Projects for product specs and NeuralMind for the repo. Feed NeuralMind's `wakeup` or `query` output into a Projects conversation for the best of both.
+
+---
+
+[← Back to comparison index](./README.md)

--- a/docs/comparisons/vs-cody.md
+++ b/docs/comparisons/vs-cody.md
@@ -23,3 +23,7 @@ Sourcegraph Cody is a code AI assistant backed by Sourcegraph's server-side code
 - **Pick NeuralMind** if you want a zero-infrastructure, local, per-project tool that integrates into any agent and compresses not just retrieval but also tool output.
 
 They address different scales: Cody for "find something across 500 repos", NeuralMind for "answer this question about this repo using the fewest tokens possible".
+
+---
+
+[← Back to comparison index](./README.md)

--- a/docs/comparisons/vs-cody.md
+++ b/docs/comparisons/vs-cody.md
@@ -1,0 +1,25 @@
+# NeuralMind vs. Sourcegraph Cody
+
+## What Cody is
+
+Sourcegraph Cody is a code AI assistant backed by Sourcegraph's server-side code graph. It uses Sourcegraph's semantic search and cross-repo indexing to inject relevant code into prompts, with both cloud and self-hosted enterprise deployments.
+
+## How NeuralMind differs
+
+| Dimension | Cody | NeuralMind |
+|---|---|---|
+| Deployment | SaaS or self-hosted Sourcegraph server | Local CLI/MCP, no server |
+| Index scope | Cross-repo, organization-wide | Single repo, per-project |
+| Hosting | Requires Sourcegraph infra | Pure local, offline |
+| Data flow | Code may be sent to Sourcegraph or your Sourcegraph instance | Nothing leaves the machine |
+| Agent coverage | Cody clients (VS Code/JetBrains) | Any MCP-compatible agent or plain CLI |
+| Tool-output compression | No | Yes (PostToolUse hooks) |
+| License | Proprietary (open-core) | MIT |
+| Best fit | Large orgs with many repos | Individual developers + single-repo teams |
+
+## When to pick which
+
+- **Pick Cody** if you need cross-repo awareness, already run Sourcegraph, or have enterprise compliance requirements that favor a managed deployment.
+- **Pick NeuralMind** if you want a zero-infrastructure, local, per-project tool that integrates into any agent and compresses not just retrieval but also tool output.
+
+They address different scales: Cody for "find something across 500 repos", NeuralMind for "answer this question about this repo using the fewest tokens possible".

--- a/docs/comparisons/vs-continue-cline.md
+++ b/docs/comparisons/vs-continue-cline.md
@@ -1,0 +1,26 @@
+# NeuralMind vs. Continue / Cline (MCP-capable IDE agents)
+
+## What Continue and Cline are
+
+Continue and Cline are open-source coding agents that run inside VS Code (and elsewhere) and support the Model Context Protocol (MCP). They provide the *agent runtime*: chat UI, tool execution, model routing.
+
+## How NeuralMind differs
+
+NeuralMind is not an agent — it's a **context provider** that agents call. It plugs into Continue, Cline, Claude Code, Claude Desktop, Cursor, or any MCP client.
+
+| Dimension | Continue / Cline | NeuralMind |
+|---|---|---|
+| Role | Agent runtime (chat + tools + model) | Context provider (MCP server + CLI) |
+| What it produces | LLM responses, file edits | Token-budgeted context strings, skeletons, search results |
+| Codebase retrieval built-in | Basic (file reads, grep, optional embeddings) | Dedicated 4-layer progressive disclosure system |
+| Tool-output compression | No | Yes (Claude Code hook format; portable to others) |
+| Replaces the other? | No | No — they compose |
+
+## When to pick which
+
+Use both. NeuralMind makes Continue/Cline cheaper and more accurate by:
+
+1. Providing the `neuralmind_query` MCP tool for any code question.
+2. (In Claude Code) compressing every `Read`/`Bash`/`Grep` result via PostToolUse hooks.
+
+If you only use Continue or Cline without NeuralMind, you rely on their built-in file-read/grep flow — which loads raw content and pays for every line the model sees. NeuralMind is the compression layer underneath.

--- a/docs/comparisons/vs-continue-cline.md
+++ b/docs/comparisons/vs-continue-cline.md
@@ -24,3 +24,7 @@ Use both. NeuralMind makes Continue/Cline cheaper and more accurate by:
 2. (In Claude Code) compressing every `Read`/`Bash`/`Grep` result via PostToolUse hooks.
 
 If you only use Continue or Cline without NeuralMind, you rely on their built-in file-read/grep flow — which loads raw content and pays for every line the model sees. NeuralMind is the compression layer underneath.
+
+---
+
+[← Back to comparison index](./README.md)

--- a/docs/comparisons/vs-cursor-codebase.md
+++ b/docs/comparisons/vs-cursor-codebase.md
@@ -23,3 +23,7 @@ Cursor's `@codebase` feature indexes your repository and injects relevant chunks
 - **Pick NeuralMind** if you want the same quality of retrieval outside Cursor, measurable token savings, offline operation, or tool-output compression that cuts cost across *every* `Read`/`Bash`/`Grep` call — not just explicit `@codebase` invocations.
 
 They are not mutually exclusive: run NeuralMind's MCP server inside Cursor and you get compression on top of Cursor's own indexing.
+
+---
+
+[← Back to comparison index](./README.md)

--- a/docs/comparisons/vs-cursor-codebase.md
+++ b/docs/comparisons/vs-cursor-codebase.md
@@ -1,0 +1,25 @@
+# NeuralMind vs. Cursor `@codebase`
+
+## What Cursor `@codebase` is
+
+Cursor's `@codebase` feature indexes your repository and injects relevant chunks into the model prompt when you reference it in a chat. Indexing is automatic and tied to the Cursor IDE.
+
+## How NeuralMind differs
+
+| Dimension | Cursor `@codebase` | NeuralMind |
+|---|---|---|
+| Host | Cursor IDE only | Any agent (Claude Code, Cursor, Cline, Continue, Claude Desktop, CLI) via MCP |
+| Index unit | File chunks | Graph nodes (functions, classes) + communities + rationales |
+| Retrieval | Chunk similarity | 4-layer progressive disclosure (identity → summary → clusters → search) |
+| Output | Raw chunks into prompt | Structured, token-budgeted context with reduction metrics |
+| Tool-output compression | None | PostToolUse hooks compress Read/Bash/Grep results |
+| Offline | No (Cursor cloud) | Yes — nothing leaves your machine |
+| Cost | Bundled in Cursor subscription | Free, local |
+| Adapts to you | No | Yes — `neuralmind learn` discovers cooccurrence patterns |
+
+## When to pick which
+
+- **Pick Cursor `@codebase`** if you only use Cursor and are happy with the built-in behavior.
+- **Pick NeuralMind** if you want the same quality of retrieval outside Cursor, measurable token savings, offline operation, or tool-output compression that cuts cost across *every* `Read`/`Bash`/`Grep` call — not just explicit `@codebase` invocations.
+
+They are not mutually exclusive: run NeuralMind's MCP server inside Cursor and you get compression on top of Cursor's own indexing.

--- a/docs/comparisons/vs-github-copilot.md
+++ b/docs/comparisons/vs-github-copilot.md
@@ -1,0 +1,30 @@
+# NeuralMind vs. GitHub Copilot
+
+## What GitHub Copilot is
+
+GitHub Copilot is Microsoft/GitHub's AI pair programmer: inline completions in your editor and a chat panel that can reference open files, workspace context, and (with Copilot Chat/Enterprise) indexed repositories. The index and retrieval are managed on GitHub's infrastructure.
+
+## How NeuralMind differs
+
+| Dimension | GitHub Copilot | NeuralMind |
+|---|---|---|
+| Core product | Code completion + chat | Context provider / token optimizer |
+| Hosted | GitHub cloud | Fully local |
+| Indexing | Server-side, GitHub-managed | Local knowledge graph + ChromaDB |
+| Works outside GitHub's editors | Limited | Yes — any MCP agent, any CLI, any LLM |
+| Model choice | GitHub-provided models | Model-agnostic (Claude, GPT, Gemini, local) |
+| Tool-output compression | No | Yes (PostToolUse hooks) |
+| License | Proprietary, per-seat | MIT, free |
+| Data flow | Code snippets sent to GitHub/OpenAI | Nothing leaves your machine |
+| Cost scaling | Flat subscription | Flat local cost; API costs drop 40–70× |
+
+## When to pick which
+
+- **Pick Copilot** if you want a fully hosted, zero-config pair programmer tied to VS Code / JetBrains and your GitHub account.
+- **Pick NeuralMind** if you run your own agent (Claude Code, Cursor, Cline, Continue), want local-only indexing, or want to *reduce* the token bill of the agent you already use.
+
+They are complementary: Copilot handles inline suggestions, NeuralMind handles the "explain / plan / refactor" conversations in whatever agent you prefer. If you are paying per-token for a non-Copilot agent, NeuralMind's savings compound with every query.
+
+---
+
+[← Back to comparison index](./README.md)

--- a/docs/comparisons/vs-langchain-llamaindex.md
+++ b/docs/comparisons/vs-langchain-llamaindex.md
@@ -1,0 +1,24 @@
+# NeuralMind vs. LangChain / LlamaIndex for code
+
+## What LangChain and LlamaIndex are
+
+General-purpose frameworks for building RAG pipelines. You choose a loader, splitter, embedder, vector store, and retriever, then wire them into a prompt template. For code, a common recipe is: `DirectoryLoader` → `RecursiveCharacterTextSplitter` → OpenAI/local embeddings → Chroma/FAISS → retriever.
+
+## How NeuralMind differs
+
+| Dimension | LangChain / LlamaIndex for code | NeuralMind |
+|---|---|---|
+| Primitives | Document/Node, Splitter, Embedder, Retriever | Code graph (functions, classes, communities) |
+| Chunking | Text-level (line/token windows) | Symbol-level from the knowledge graph |
+| Context shape | Flat top-k chunks | 4 layers (identity, summary, clusters, search) with token budget |
+| Setup | You assemble the pipeline | `pip install neuralmind && neuralmind build .` |
+| Agent integration | You write the glue | MCP server + CLI + PostToolUse hooks ready to use |
+| Tool-output compression | Not its concern | First-class feature |
+| Flexibility | Very high | Opinionated for code |
+
+## When to pick which
+
+- **Pick LangChain / LlamaIndex** if you are building a custom RAG product (e.g., a domain-specific code assistant, a web app, a multi-source retriever mixing code + docs + tickets).
+- **Pick NeuralMind** if you want the "best default" code context for an AI coding agent with zero glue code and measurable per-query token savings.
+
+Roughly: LangChain/LlamaIndex give you the Lego bricks; NeuralMind is the assembled model optimized specifically for "AI agent answers questions about a repo".

--- a/docs/comparisons/vs-langchain-llamaindex.md
+++ b/docs/comparisons/vs-langchain-llamaindex.md
@@ -22,3 +22,7 @@ General-purpose frameworks for building RAG pipelines. You choose a loader, spli
 - **Pick NeuralMind** if you want the "best default" code context for an AI coding agent with zero glue code and measurable per-query token savings.
 
 Roughly: LangChain/LlamaIndex give you the Lego bricks; NeuralMind is the assembled model optimized specifically for "AI agent answers questions about a repo".
+
+---
+
+[← Back to comparison index](./README.md)

--- a/docs/comparisons/vs-long-context.md
+++ b/docs/comparisons/vs-long-context.md
@@ -1,0 +1,36 @@
+# NeuralMind vs. Long context windows (Claude 1M, Gemini 2M, Projects)
+
+## The premise
+
+"Why not just stuff the whole codebase into a 1M or 2M context window?"
+
+It works — for a while. Then the bill arrives.
+
+## The numbers
+
+Consider a 50,000-token codebase and 100 queries/day.
+
+| Approach | Tokens per query | Monthly input cost (Claude Sonnet) |
+|---|---|---|
+| Full codebase every turn | 50,000 | ~$450 |
+| NeuralMind query | ~800 | ~$7 |
+
+Long context windows make it *possible* to stuff everything in. They do not make it *cheap*. Input tokens are billed per token — a 1M context at $3/MTok is $3 per message.
+
+## Other dimensions
+
+| Dimension | Long context | NeuralMind |
+|---|---|---|
+| Cost scaling | Linear in codebase size | Roughly flat (~800 tokens/query) |
+| Recall quality | Strong on small repos, degrades on large ones (needle-in-haystack effects) | Stable — retrieval focuses the window |
+| Latency | Increases with context size | Roughly flat |
+| Provider lock-in | Ties you to 1M+ models | Model-agnostic |
+| Works offline | No | Yes |
+| Prompt caching savings | Possible, but full repo still loaded | Context is small enough that caching is secondary |
+
+## When to pick which
+
+- **Use raw long context** for one-off exploration on small repos where you don't mind the bill.
+- **Use NeuralMind** for sustained coding work — the per-query savings compound daily, and retrieval quality actually *improves* as the repo grows (more signal for clustering), where raw long context gets worse.
+
+The two also compose: feed NeuralMind's output into a long-context model and you get both focus and headroom.

--- a/docs/comparisons/vs-long-context.md
+++ b/docs/comparisons/vs-long-context.md
@@ -34,3 +34,7 @@ Long context windows make it *possible* to stuff everything in. They do not make
 - **Use NeuralMind** for sustained coding work — the per-query savings compound daily, and retrieval quality actually *improves* as the repo grows (more signal for clustering), where raw long context gets worse.
 
 The two also compose: feed NeuralMind's output into a long-context model and you get both focus and headroom.
+
+---
+
+[← Back to comparison index](./README.md)

--- a/docs/comparisons/vs-prompt-caching.md
+++ b/docs/comparisons/vs-prompt-caching.md
@@ -1,0 +1,43 @@
+# NeuralMind vs. Prompt caching (Anthropic / OpenAI)
+
+## What prompt caching is
+
+Anthropic and OpenAI both offer *prompt caching*: when you resend the same prefix on many requests, the provider caches the computed KV state and charges a discounted rate (Anthropic: ~10% of the normal input price) for the cached portion. It is a **pricing** optimization, not a **context** optimization.
+
+## How NeuralMind differs
+
+Prompt caching makes resending a large context cheaper. NeuralMind makes the context **smaller in the first place**. They solve different halves of the problem.
+
+| Dimension | Prompt caching | NeuralMind |
+|---|---|---|
+| What it optimizes | Repeat cost of the same prefix | Size of the prefix itself |
+| Discount mechanism | Provider-side cache hit | Client-side retrieval + compression |
+| Requires identical prefix | Yes | No |
+| First-turn savings | 0% | 40–70× |
+| Nth-turn savings (cached) | ~90% of cached portion | 40–70× (plus cache on top) |
+| Works offline | No | Yes |
+| Tool-output savings | No | Yes |
+| Vendor lock-in | Yes (per-provider) | No |
+
+## Worked example
+
+50,000-token codebase, 100 queries/day, Claude Sonnet input at $3/MTok:
+
+| Strategy | First query | Subsequent queries | Monthly |
+|---|---|---|---|
+| Raw repo, no cache | 50K × $3/MTok = $0.15 | $0.15 | ~$450 |
+| Raw repo + prompt caching | $0.15 + cache write | ~$0.015 (cache hit) | ~$50 |
+| NeuralMind | ~$0.0024 (800 tokens) | ~$0.0024 | ~$7 |
+| NeuralMind + prompt caching | ~$0.0024 + cache write | ~$0.00024 | ~$1 |
+
+Caching on top of NeuralMind is not zero cost, but it is essentially free at this scale.
+
+## When to pick which
+
+- **Pick prompt caching alone** when your prompt is already small and mostly static (system prompts, short tool definitions).
+- **Pick NeuralMind alone** when you don't want vendor-specific plumbing.
+- **Combine them** for the cheapest possible sustained coding workload: NeuralMind compresses the code context, and prompt caching amortizes the repeated project instructions.
+
+---
+
+[← Back to comparison index](./README.md)

--- a/docs/comparisons/vs-rag.md
+++ b/docs/comparisons/vs-rag.md
@@ -24,3 +24,7 @@ Code is not prose. It has structure (call graphs, imports, class hierarchies) th
 - **Pick NeuralMind** for code. The graph-aware layers and skeleton output capture the structural context that generic chunking throws away — and you don't pay for the throwaway tokens.
 
 If you already have a generic RAG pipeline and only want the compression half, NeuralMind's PostToolUse hooks can run standalone without the retrieval layer.
+
+---
+
+[← Back to comparison index](./README.md)

--- a/docs/comparisons/vs-rag.md
+++ b/docs/comparisons/vs-rag.md
@@ -1,0 +1,26 @@
+# NeuralMind vs. Generic RAG over a codebase
+
+## What "generic RAG" means here
+
+The standard recipe: chunk files by lines or tokens, embed them, store in a vector DB, retrieve top-k by cosine similarity, concatenate into the prompt. Works fine for documentation and long-form text.
+
+## Why code needs more
+
+Code is not prose. It has structure (call graphs, imports, class hierarchies) that text chunking destroys. NeuralMind keeps that structure and uses it.
+
+| Dimension | Generic RAG | NeuralMind |
+|---|---|---|
+| Unit of retrieval | Text chunk (e.g. 500 chars) | Graph node (function, class) with metadata |
+| Context | Flat list of chunks | Progressive: identity → summary → clusters → hits |
+| Call graph | Lost at chunking | Preserved, used in skeletons |
+| Community/cluster awareness | None | First-class (top clusters by relevance in L2) |
+| Cross-file edges | Not encoded | Explicit (`imports_from`, `shares_data_with`) |
+| Token budget | You enforce it | Built-in, reported per query |
+| Consumption-side savings | None | Read/Bash/Grep PostToolUse compression |
+
+## When to pick which
+
+- **Pick generic RAG** if you are indexing docs, tickets, or mixed content where structure doesn't matter.
+- **Pick NeuralMind** for code. The graph-aware layers and skeleton output capture the structural context that generic chunking throws away — and you don't pay for the throwaway tokens.
+
+If you already have a generic RAG pipeline and only want the compression half, NeuralMind's PostToolUse hooks can run standalone without the retrieval layer.

--- a/docs/comparisons/vs-treesitter-ctags.md
+++ b/docs/comparisons/vs-treesitter-ctags.md
@@ -1,0 +1,28 @@
+# NeuralMind vs. Tree-sitter / ctags / grep
+
+## What these tools are
+
+Purely syntactic: tree-sitter parses source into AST, ctags builds a symbol index, grep matches regex across files. They are fast, deterministic, and answer "where is this symbol?" — not "what answers this question?".
+
+## How NeuralMind differs
+
+| Dimension | Tree-sitter / ctags / grep | NeuralMind |
+|---|---|---|
+| Query type | Exact / regex / symbol name | Natural language ("how does auth work") |
+| Underlying signal | Syntax | Syntax (via graphify) **+** semantic embeddings |
+| Output | List of matches | Structured, token-budgeted context for an LLM |
+| Agent integration | You parse results yourself | MCP server + PostToolUse hooks |
+| Handles synonyms / paraphrase | No | Yes (embedding similarity) |
+| Dependencies | Minimal | ChromaDB |
+| Offline | Yes | Yes |
+
+## When to pick which
+
+- **Pick grep/ctags/tree-sitter** when you know the exact symbol or pattern and want a 5ms deterministic answer.
+- **Pick NeuralMind** when the question is natural language, spans multiple files, or is the kind of thing an LLM agent needs to orient itself.
+
+They are complementary. NeuralMind's `search` command gives you ranked semantic results; `grep` gives you every literal hit. Most real agent loops benefit from both — which is why NeuralMind's PostToolUse hooks leave `Grep` output intact (just capped at 25 matches) rather than replacing it.
+
+## The heuristic-only alternative
+
+If you want NeuralMind's output *shape* (skeletons, clusters) without embeddings, the [graphify](https://github.com/dfrostar/graphify) knowledge graph alone already provides ~33x token reduction with zero ML dependencies. NeuralMind adds semantic retrieval on top, trading a ChromaDB dependency for stronger recall on paraphrased queries.

--- a/docs/comparisons/vs-treesitter-ctags.md
+++ b/docs/comparisons/vs-treesitter-ctags.md
@@ -26,3 +26,7 @@ They are complementary. NeuralMind's `search` command gives you ranked semantic 
 ## The heuristic-only alternative
 
 If you want NeuralMind's output *shape* (skeletons, clusters) without embeddings, the [graphify](https://github.com/dfrostar/graphify) knowledge graph alone already provides ~33x token reduction with zero ML dependencies. NeuralMind adds semantic retrieval on top, trading a ChromaDB dependency for stronger recall on paraphrased queries.
+
+---
+
+[← Back to comparison index](./README.md)

--- a/docs/comparisons/vs-windsurf-codeium.md
+++ b/docs/comparisons/vs-windsurf-codeium.md
@@ -1,0 +1,29 @@
+# NeuralMind vs. Windsurf / Codeium
+
+## What Windsurf and Codeium are
+
+Codeium (now evolving into the Windsurf IDE) is a full AI coding environment with its own editor, proprietary indexing, and agent runtime. It indexes your repository on Codeium's infrastructure and injects context into completions and chat.
+
+## How NeuralMind differs
+
+| Dimension | Windsurf / Codeium | NeuralMind |
+|---|---|---|
+| Product type | IDE + agent + indexer, vertically integrated | Context provider / optimizer |
+| Editor | Windsurf (VS Code fork) | Editor-agnostic |
+| Indexing | Server-side, proprietary | Local knowledge graph + ChromaDB |
+| Agent runtime | Built-in | Use your own (Claude Code, Cursor, Cline, Continue) |
+| Model choice | Codeium-curated set | Any — NeuralMind is just context |
+| Data flow | Code sent to Codeium infrastructure | Fully local |
+| Tool-output compression | No | Yes (in Claude Code) |
+| License | Proprietary | MIT |
+
+## When to pick which
+
+- **Pick Windsurf/Codeium** if you want a turn-key AI IDE and you are comfortable with server-side indexing.
+- **Pick NeuralMind** if you already have an editor and agent you like, want local-only indexing, or want model-agnostic context that works across Claude, GPT, and Gemini.
+
+You can also use NeuralMind *inside* Windsurf as a CLI: generate `wakeup` / `query` context and paste it into the chat panel. You don't get PostToolUse compression there (that's Claude-Code-specific), but you still get the retrieval-side savings.
+
+---
+
+[← Back to comparison index](./README.md)

--- a/docs/use-cases/README.md
+++ b/docs/use-cases/README.md
@@ -1,0 +1,13 @@
+# NeuralMind Use Cases
+
+Walkthroughs for the most common "what do I actually do?" questions, organized by who you are and what you're trying to solve. Each page is command-driven — copy, run, done.
+
+| Use case | Best for | Primary goal |
+|---|---|---|
+| [Claude Code user](./claude-code.md) | You use Claude Code daily and want full two-phase optimization | Cheapest + smartest agent sessions |
+| [Cost optimization](./cost-optimization.md) | Teams or solos watching LLM spend climb | Measure, reduce, and report savings |
+| [Any LLM (ChatGPT / Gemini / local)](./any-llm.md) | You use non-MCP chats or a model-agnostic workflow | Get NeuralMind context into any chat window |
+| [Offline / regulated work](./offline-regulated.md) | Regulated industries, air-gapped machines | 100% local retrieval with zero telemetry |
+| [Growing monorepo](./growing-monorepo.md) | Codebase where old context goes stale fast | Keep the index fresh with minimal effort |
+
+Not sure which applies? Start with the [symptom / goal table in the main README](../../README.md#-when-do-i-reach-for-neuralmind).

--- a/docs/use-cases/any-llm.md
+++ b/docs/use-cases/any-llm.md
@@ -1,0 +1,101 @@
+# Use Case: Any LLM (ChatGPT / Gemini / Local Models)
+
+## What you're solving for
+
+You want NeuralMind-quality context but you're not using Claude Code, Cursor, or any MCP-compatible agent. You're in ChatGPT, Gemini, a Perplexity thread, an Ollama session, or just a custom script. You need **portable context** that fits any chat window.
+
+## The pattern
+
+NeuralMind's CLI output is plain text. Pipe it into any clipboard, file, or request body — the model doesn't care how it got there.
+
+## Setup
+
+```bash
+pip install neuralmind graphifyy
+cd your-project
+graphify update .
+neuralmind build .
+```
+
+## Patterns
+
+### 1. Copy-paste into a web chat
+
+**macOS:**
+```bash
+neuralmind wakeup . | pbcopy
+# paste into ChatGPT / Gemini / Claude.ai
+```
+
+**Linux:**
+```bash
+neuralmind wakeup . | xclip -selection clipboard
+```
+
+**Windows (PowerShell):**
+```powershell
+neuralmind wakeup . | Set-Clipboard
+```
+
+Then start your chat with: "Here is the project context: `<paste>`. My question is …"
+
+### 2. Piped into a one-shot script
+
+```bash
+CONTEXT=$(neuralmind query . "How does auth work?")
+curl https://api.openai.com/v1/chat/completions \
+  -H "Authorization: Bearer $OPENAI_API_KEY" \
+  -d "$(jq -n --arg c "$CONTEXT" --arg q "explain the flow" '{
+    model: "gpt-4o",
+    messages: [
+      {role: "system", content: $c},
+      {role: "user", content: $q}
+    ]
+  }')"
+```
+
+### 3. Saved as a file the model reads
+
+```bash
+neuralmind wakeup . > CONTEXT.md
+neuralmind query . "How does billing work?" > BILLING_CONTEXT.md
+```
+
+Attach those files to a Gemini Project, Claude Project, or Ollama system prompt. You get NeuralMind retrieval without needing the MCP server running.
+
+### 4. Per-question context
+
+Don't load the whole repo — load just what the question needs:
+
+```bash
+neuralmind query . "How does the payment webhook validate signatures?" | pbcopy
+```
+
+Paste, ask, done. Usually ~800–1,100 tokens instead of tens of thousands.
+
+## What you lose vs. Claude Code
+
+- **No PostToolUse compression** — that's Claude-Code-specific. You still get the retrieval-side savings (40–70×), just not the additional Read/Bash/Grep compression layer.
+- **No MCP tool calls** — the model can't invoke `neuralmind_query` itself; you invoke it and paste.
+
+## What you still get
+
+- The same 4-layer progressive disclosure
+- The same skeleton views (`neuralmind skeleton <file>`)
+- The same semantic search (`neuralmind search . "term"`)
+- Fully local, no data leaves your machine
+- Works with any model — OpenAI, Google, Anthropic, Ollama, vLLM, anything
+
+## Pro tip: system prompt pattern
+
+Generate context once at the start of a long session:
+
+```bash
+neuralmind wakeup . > /tmp/sys.md
+```
+
+Set the contents of `/tmp/sys.md` as your system prompt. For specific questions during the session, append `neuralmind query . "..."` output to the user message.
+
+---
+
+[← Back to use-case index](./README.md) · [Main README](../../README.md)

--- a/docs/use-cases/claude-code.md
+++ b/docs/use-cases/claude-code.md
@@ -1,0 +1,72 @@
+# Use Case: Claude Code User
+
+## What you're solving for
+
+You use Claude Code daily. Your context fills up fast, `Read` pulls in too much source, long `Bash` outputs blow your budget, and the bill is adding up. You want both **retrieval-side** and **consumption-side** optimization.
+
+## Setup (one time)
+
+```bash
+pip install neuralmind graphifyy
+cd your-project
+graphify update .              # builds the knowledge graph
+neuralmind build .             # builds the vector index
+neuralmind install-hooks .     # PostToolUse compression (Read/Bash/Grep)
+neuralmind init-hook .         # auto-rebuild on every git commit
+```
+
+## Daily workflow
+
+**At session start**, have Claude Code call:
+
+```
+neuralmind_wakeup(project_path=".")
+```
+
+That gives the agent ~400 tokens of architecture/cluster context instead of 50K tokens of file reads.
+
+**When asking a code question**, prefer `neuralmind_query` over raw exploration:
+
+```
+neuralmind_query(project_path=".", question="How does authentication flow through the middleware?")
+```
+
+Returns ~800–1,100 tokens with the right clusters and search hits.
+
+**Before opening a file**, use `neuralmind_skeleton`:
+
+```
+neuralmind_skeleton(project_path=".", file_path="src/auth/handlers.py")
+```
+
+Returns the function list, rationales, call graph, and cross-file edges — ~88% cheaper than `Read`.
+
+**Everything else** (Read, Bash, Grep you don't route through NeuralMind) is **automatically compressed** by the hooks. You don't have to think about it.
+
+## What changes for you
+
+| Before | After |
+|---|---|
+| Session starts with "let me explore the repo" + 20 file reads | `wakeup` loads orientation in one call |
+| Asking about a flow = reading 5 files end-to-end | `query` returns the relevant slice |
+| `npm test` dumps 800 lines into the agent | Hook keeps errors + last 3 lines (~91% smaller) |
+| `grep -r "foo"` floods with 200 matches | Capped at 25 with "N more hidden" pointer |
+| Every commit drifts the index | `post-commit` hook rebuilds incrementally |
+
+## Escape hatches
+
+Need the raw file body for a specific command?
+
+```bash
+NEURALMIND_BYPASS=1 <your command>
+```
+
+Tune hook thresholds via env vars — see [PostToolUse Compression](../../README.md#-posttooluse-compression).
+
+## Expected savings
+
+Combined retrieval + consumption reduction is typically **5–10×** vs vanilla Claude Code on the same tasks. Run `neuralmind benchmark . --json` on your repo for a concrete number.
+
+---
+
+[← Back to use-case index](./README.md) · [Main README](../../README.md)

--- a/docs/use-cases/cost-optimization.md
+++ b/docs/use-cases/cost-optimization.md
@@ -1,0 +1,85 @@
+# Use Case: LLM Cost Optimization
+
+## What you're solving for
+
+Your team or product spends measurable money on LLM API calls for code questions. You need to reduce spend **without** moving to a cheaper model or cutting features, and report the savings to a stakeholder.
+
+## Step 1 — Baseline the current spend
+
+Before installing NeuralMind, capture what you're spending. Pick a representative workday:
+
+```bash
+# Count tokens per query today by logging your agent's input/output
+# (most agents have a debug mode or you can estimate with tiktoken)
+```
+
+Compute: `avg_tokens_per_query × queries_per_day × 30 × $_per_MTok`. That's your monthly floor.
+
+## Step 2 — Install NeuralMind
+
+```bash
+pip install neuralmind graphifyy
+graphify update .
+neuralmind build .
+neuralmind install-hooks .     # Claude Code users only
+```
+
+## Step 3 — Measure the new baseline
+
+```bash
+neuralmind benchmark . --json
+```
+
+Returns:
+
+```json
+{
+  "wakeup_tokens": 341,
+  "avg_query_tokens": 739,
+  "avg_reduction_ratio": 65.6,
+  "results": [...]
+}
+```
+
+Compare `avg_query_tokens` to your pre-install baseline. This is the **retrieval-side** savings.
+
+## Step 4 — Measure consumption-side savings (Claude Code)
+
+PostToolUse hooks compress Read/Bash/Grep output. Rough numbers:
+
+| Tool | Typical reduction |
+|---|---|
+| Read | ~88% (file → skeleton) |
+| Bash | ~91% (errors + tail) |
+| Grep | Capped at 25 matches |
+
+Combined retrieval + consumption is typically **5–10× total reduction** vs baseline.
+
+## Step 5 — Report to stakeholders
+
+A one-page summary template:
+
+> **NeuralMind rollout — token cost impact**
+>
+> - Baseline: `{avg_tokens} × {queries/day} × 30 × ${price}/MTok = ${monthly}`
+> - After NeuralMind: `{new_tokens} × {queries/day} × 30 × ${price}/MTok = ${new_monthly}`
+> - Reduction: **{ratio}×** on retrieval, **{total_ratio}×** combined with PostToolUse hooks
+> - Setup cost: one-time `graphify update && neuralmind build` (~minutes)
+> - Ongoing cost: incremental rebuild on git commit (seconds)
+> - Risk: fully local, no new SaaS dependency, MIT-licensed
+
+## Ongoing hygiene
+
+- **Index freshness:** `neuralmind init-hook .` auto-rebuilds on every commit.
+- **Adapt to workflow:** enable memory (TTY prompt) + periodically `neuralmind learn .` to rerank by actual query patterns.
+- **Model changes:** run `neuralmind benchmark` again when you switch models — absolute dollar savings scale with input price.
+
+## What this doesn't fix
+
+- **Output tokens** — NeuralMind reduces input context, not model output length. Pair with prompt instructions to keep responses concise.
+- **Non-code LLM usage** — docs QA, ticket triage, etc. NeuralMind is code-specific.
+- **One-off experiments** — savings compound with repeated queries; single questions show less benefit.
+
+---
+
+[← Back to use-case index](./README.md) · [Main README](../../README.md)

--- a/docs/use-cases/growing-monorepo.md
+++ b/docs/use-cases/growing-monorepo.md
@@ -1,0 +1,98 @@
+# Use Case: Growing Monorepo
+
+## What you're solving for
+
+Your codebase is growing fast. Every week there are new services, new modules, refactors. Agent context goes stale quickly. You need retrieval that **stays accurate without manual effort** as the repo evolves.
+
+## The freshness problem
+
+The NeuralMind index is built from `graphify-out/graph.json`. If the graph isn't up to date, retrieval will reference entities that have moved, renamed, or been deleted. You'll notice:
+
+- Agent cites functions that no longer exist.
+- New code doesn't appear in search results.
+- Cluster summaries describe an older architecture.
+
+## Three ways to keep it fresh
+
+### 1. Git post-commit hook (recommended)
+
+```bash
+neuralmind init-hook .
+```
+
+After every `git commit`, the hook runs `neuralmind build .` in the background. Incremental — only re-embeds changed nodes — so it's seconds, not minutes.
+
+Coexists with existing hooks (husky, pre-commit, lint-staged) — appends safely rather than overwriting.
+
+### 2. CI pipeline
+
+```yaml
+# .github/workflows/neuralmind.yml
+on:
+  push:
+    branches: [main]
+jobs:
+  reindex:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: pip install neuralmind graphifyy
+      - run: graphify update . && neuralmind build .
+      - run: neuralmind wakeup . > AI_CONTEXT.md
+      - uses: actions/upload-artifact@v4
+        with: { name: ai-context, path: AI_CONTEXT.md }
+```
+
+Everyone on the team can download the latest `AI_CONTEXT.md` artifact — useful for PR reviews, onboarding, and pasting into non-MCP chats.
+
+### 3. Scheduled cron
+
+```cron
+0 6 * * * cd /path/to/repo && graphify update . && neuralmind build .
+```
+
+Good for slower-moving repos or shared machines.
+
+## Large-repo tuning
+
+**Incremental-only builds:**
+
+```bash
+neuralmind build .              # default: incremental
+```
+
+Only re-embeds nodes whose source changed. Run time scales with the churn, not the repo size.
+
+**Force full rebuild (rare — after graphify upgrades, schema changes):**
+
+```bash
+neuralmind build . --force
+```
+
+**Check what the index sees:**
+
+```bash
+neuralmind stats . --json
+```
+
+Watch `total_nodes` and `communities` — sudden drops mean something went wrong with `graphify update`.
+
+## Query patterns for large repos
+
+- **Start every session with `wakeup`** — with hundreds of clusters, orientation matters more, not less.
+- **Use `search` before `query`** when you know the entity name: `neuralmind search . "PaymentController"` is faster and cheaper than an LLM round-trip.
+- **Use `skeleton` aggressively** — for multi-thousand-line files, skeleton is the only sane entry point.
+
+## Enable learning
+
+Query patterns in a large repo often cluster around hot paths (auth, billing, search). Enable memory (TTY prompt) and run weekly:
+
+```bash
+neuralmind learn .
+```
+
+Future queries get a `+0.3` rerank boost on modules that historically cooccur with your team's queries. Over a few weeks, retrieval starts to anticipate what you mean.
+
+---
+
+[← Back to use-case index](./README.md) · [Main README](../../README.md)

--- a/docs/use-cases/offline-regulated.md
+++ b/docs/use-cases/offline-regulated.md
@@ -1,0 +1,82 @@
+# Use Case: Offline / Regulated Work
+
+## What you're solving for
+
+You work in a regulated industry (healthcare, finance, defense, legal), on an air-gapped machine, or under a policy that forbids sending source code to third-party services. You still want AI-assisted code understanding — without the code leaving the building.
+
+## Why NeuralMind fits
+
+- **No API calls.** Indexing, embeddings, retrieval — all local.
+- **No cloud account required.** No sign-up, no telemetry, no outbound network.
+- **No code uploaded anywhere.** ChromaDB runs in-process.
+- **Pairs with local LLMs.** Use with Ollama, llama.cpp, vLLM for an end-to-end local stack.
+
+## Fully local stack
+
+```bash
+pip install neuralmind graphifyy
+graphify update .
+neuralmind build .              # local embeddings, local vector store
+```
+
+Pair with a local model:
+
+```bash
+# Example: Ollama + NeuralMind
+ollama pull llama3.1:70b
+CONTEXT=$(neuralmind query . "how does auth work?")
+echo "$CONTEXT" | ollama run llama3.1:70b "Explain the auth flow"
+```
+
+Nothing here touches the public internet.
+
+## Compliance-friendly properties
+
+| Property | NeuralMind |
+|---|---|
+| Source code transmitted externally | Never |
+| Telemetry | None |
+| SaaS dependency | None |
+| Account / login | None |
+| Network required for install | Only to fetch the Python package — mirror it internally if needed |
+| License | MIT (auditable) |
+| Data at rest | `graphify-out/` and `.neuralmind/` inside your project |
+| Data in transit | N/A (no outbound calls) |
+
+## Air-gapped install
+
+1. On a connected machine:
+   ```bash
+   pip download neuralmind graphifyy -d ./offline-bundle
+   ```
+2. Copy `./offline-bundle/` to the air-gapped machine.
+3. Install:
+   ```bash
+   pip install --no-index --find-links ./offline-bundle neuralmind graphifyy
+   ```
+
+ChromaDB pulls its embedding model on first use — download it in advance or point `HF_HOME` at a pre-populated directory.
+
+## Turning off query memory (if your policy forbids local logs)
+
+```bash
+export NEURALMIND_MEMORY=0
+export NEURALMIND_LEARNING=0
+```
+
+Or decline the TTY consent prompt the first time `neuralmind query` runs. No events are logged.
+
+## Audit trail
+
+Every action is a local file operation — easy to log via existing endpoint monitoring:
+
+- Knowledge graph: `graphify-out/graph.json`
+- Vector store: `graphify-out/neuralmind_db/`
+- Query events (only if opted in): `.neuralmind/memory/query_events.jsonl`
+- Learned patterns (only after `neuralmind learn`): `.neuralmind/learned_patterns.json`
+
+Delete any of these at any time — nothing persists outside your project.
+
+---
+
+[← Back to use-case index](./README.md) · [Main README](../../README.md)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "neuralmind"
 version = "0.3.4"
-description = "Adaptive Neural Knowledge System + PostToolUse compression hooks. Two-phase token optimization (retrieval + consumption) for Claude Code."
+description = "Reduce Claude, GPT, and Gemini token costs on code questions by 40-70x. Semantic codebase indexing, MCP server, and PostToolUse compression hooks for Claude Code, Cursor, Cline, and Continue."
 readme = "README.md"
 license = "MIT"
 authors = [
@@ -17,19 +17,54 @@ maintainers = [
 keywords = [
     "ai",
     "llm",
+    "llm-tools",
+    "rag",
+    "code-rag",
     "code-understanding",
+    "code-search",
+    "codebase-indexing",
+    "codebase-search",
+    "repo-map",
     "knowledge-graph",
     "token-reduction",
-    "semantic-search",
-    "mcp",
-    "chromadb",
-    "embeddings",
+    "token-optimization",
+    "reduce-tokens",
+    "claude-token-cost",
+    "llm-cost-optimization",
+    "context-engineering",
     "context-window",
+    "long-context",
+    "semantic-search",
+    "semantic-code-search",
+    "embeddings",
+    "vector-database",
+    "chromadb",
+    "mcp",
+    "mcp-server",
+    "model-context-protocol",
     "ai-coding-assistant",
+    "ai-coding-agent",
+    "ai-agent",
+    "agent-tools",
+    "claude",
     "claude-code",
+    "claude-desktop",
+    "anthropic",
+    "cursor",
+    "cursor-alternative",
+    "cline",
+    "continue-dev",
+    "aider",
+    "copilot-alternative",
+    "sourcegraph-cody-alternative",
+    "openai",
+    "gpt-4",
+    "gemini",
     "posttooluse-hook",
     "skeleton-view",
-    "output-compression"
+    "output-compression",
+    "developer-tools",
+    "developer-productivity"
 ]
 classifiers = [
     "Development Status :: 4 - Beta",


### PR DESCRIPTION
## Summary

Three linked additions that answer the two questions first-time visitors actually have — "when do I use this?" and "how is this different from X?" — and broaden SEO so those visitors can find the repo in the first place.

### 1. Comparison pages (`docs/comparisons/`)

12 honest side-by-side pages against the tools developers evaluate alongside NeuralMind. Each follows the same structure: what the alternative is → how NeuralMind differs → when to pick which → feature matrix.

- `vs-cursor-codebase.md`
- `vs-aider-repomap.md`
- `vs-cody.md` (Sourcegraph)
- `vs-continue-cline.md`
- `vs-github-copilot.md`
- `vs-windsurf-codeium.md`
- `vs-claude-projects.md`
- `vs-prompt-caching.md` (with worked cost-per-turn example)
- `vs-langchain-llamaindex.md`
- `vs-long-context.md`
- `vs-rag.md`
- `vs-treesitter-ctags.md`

Linked from a new **NeuralMind vs. Alternatives** matrix in the main README.

### 2. Use-case walkthroughs (`docs/use-cases/`)

Command-driven, persona-matched step-by-step guides:

- `claude-code.md` — full two-phase setup + daily workflow + before/after table
- `cost-optimization.md` — baseline → measure → stakeholder report template
- `any-llm.md` — ChatGPT / Gemini / Ollama via copy-paste and CLI piping
- `offline-regulated.md` — air-gapped install + compliance properties + audit trail
- `growing-monorepo.md` — three freshness strategies + large-repo tuning

### 3. README additions

- **🚨 When do I reach for NeuralMind?** — paired tables: symptom-driven ("this is happening to me") and goal-driven ("what am I solving for"), each mapping to the exact command to run.
- **👤 Who is NeuralMind for?** — 8-archetype persona table with honest "not a fit if…" callout.
- **⚖️ NeuralMind vs. Alternatives** — 12-row matrix linking to the comparison pages.
- **❓ FAQ** — 10 Q&As targeting natural-language search intent (cost, RAG vs. this, long context, PostToolUse compression, etc.).

### 4. SEO — `pyproject.toml`

- Description rewritten to lead with the value prop ("reduce Claude, GPT, Gemini token costs by 40-70×") and name the agents it works with.
- Keywords expanded from 15 → 49, covering RAG, code-search, cost-optimization, MCP, and competitor-alternative queries (cursor-alternative, copilot-alternative, sourcegraph-cody-alternative, aider, cline, continue-dev, etc.).

## Test plan

- [ ] All internal links resolve (README → comparisons, README → use-cases, back-links on every comparison page)
- [ ] No broken Markdown tables or fenced blocks (`mkdocs build` / GitHub render preview)
- [ ] `pyproject.toml` still parses and builds (`pip install -e .`)
- [ ] No functional code changes — docs and package metadata only

## Not in this PR (separate follow-ups)

These require GitHub UI access, not code:

- Add repo **topics** (sidebar tags) to match the new keywords
- Upload a **social preview image** (Settings → Social preview) for LinkedIn/Twitter/HN unfurls
- Update the **short repo description** to match the new `pyproject.toml` description

https://claude.ai/code/session_013FYQFpJAVj1M4Ueos1dP5i