### PR TITLE
fix(ci): resolve ruff lint failures breaking CI

### DIFF
--- a/neuralmind/core.py
+++ b/neuralmind/core.py
@@ -80,15 +80,16 @@ class NeuralMind:
         self._built = False
         self._build_stats: dict = {}
 
-    @property
-    def backend_name(self) -> str:
-        return self.backend_manager.backend_name
         self._emit_audit(
             category="backend",
             action="initialize",
             target=self.project_path.name,
             details={"backend": self.backend_manager.backend_name},
         )
+
+    @property
+    def backend_name(self) -> str:
+        return self.backend_manager.backend_name
 
     def _emit_audit(
         self,
@@ -165,7 +166,6 @@ class NeuralMind:
             "db_path": final_stats.get("db_path", ""),
             "duration_seconds": round(duration, 2),
             "built_at": datetime.now().isoformat(),
-            "backend": self.backend_name,
         }
 
         self._built = True

--- a/neuralmind/mcp_server.py
+++ b/neuralmind/mcp_server.py
@@ -41,11 +41,11 @@ except ImportError:
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from neuralmind.core import NeuralMind
-from neuralmind.mcp_security import MCPSecurityManager, get_security_manager
+from neuralmind.mcp_security import _SECURITY_MANAGERS, get_security_manager
 
 # Cache for NeuralMind instances per project
 _mind_cache: dict[str, NeuralMind] = {}
-_security_cache: dict[str, MCPSecurityManager] = {}
+_security_cache = _SECURITY_MANAGERS
 
 
 def get_mind(project_path: str, auto_build: bool = True) -> NeuralMind:
@@ -56,14 +56,6 @@ def get_mind(project_path: str, auto_build: bool = True) -> NeuralMind:
         if auto_build:
             _mind_cache[abs_path].build()
     return _mind_cache[abs_path]
-
-
-def get_security_manager(project_path: str) -> MCPSecurityManager:
-    """Get or create security manager for project."""
-    abs_path = str(Path(project_path).resolve())
-    if abs_path not in _security_cache:
-        _security_cache[abs_path] = MCPSecurityManager(abs_path)
-    return _security_cache[abs_path]
 
 
 def tool_wakeup(project_path: str) -> dict[str, Any]:


### PR DESCRIPTION
## Summary

The `Lint` job in `ci.yml` has been failing on `main` since commit `536518b` (a merge-conflict resolution) introduced three ruff errors. This PR fixes them so CI goes green and `release-please` can cut a clean `0.3.5`.

### What was broken

- **`neuralmind/core.py:83`** (RET503) — the `backend_name` property had a dead `_emit_audit("initialize", ...)` call sitting after its `return` statement.
- **`neuralmind/core.py:168`** (F601) — `_build_stats` dict had the key `"backend"` twice.
- **`neuralmind/mcp_server.py:61`** (F811) — `get_security_manager` was both imported from `mcp_security` and redefined locally, shadowing the fuller version that loads role/rate-limit config.

### Fixes

- Restore `backend_name` to a plain getter; move the init-time audit emit to the end of `__init__` where it was clearly meant to run.
- Drop the duplicate `"backend"` key from `_build_stats` (the earlier entry already sets the same value).
- Remove the local `get_security_manager` stub in `mcp_server.py`; re-export `_SECURITY_MANAGERS` as `_security_cache` so `tests/test_mcp_server.py`'s cache-clearing fixture keeps working.

## Test plan

- [x] `ruff check .` — passes
- [x] `black --check .` — passes
- [x] `pytest tests/` — 292 passed, 7 skipped (expected: missing fixture graph / firewalled S3)
- [x] Fresh-venv install (`pip install .` + imports + `neuralmind --help`) — passes
- [x] `python -m build` + `twine check` — passes
- [ ] CI confirms the above on the PR

## Release

The commit follows Conventional Commits (`fix(ci): ...`), so after merge `release-please` should automatically open a `0.3.4 → 0.3.5` bump PR. The existing `smoke-test-pypi` job in `release.yml` already gates the GitHub Release on a clean-install test from PyPI.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NGV9NwnwfzTk5UmHDtbUG8)_