### PR TITLE
fix(security): bump mcp, black, pytest to clear 6 Dependabot alerts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,14 +88,14 @@ dependencies = [
 
 [project.optional-dependencies]
 mcp = [
-    "mcp>=0.1.0"
+    "mcp>=1.23.0"
 ]
 dev = [
-    "pytest>=7.0",
+    "pytest>=9.0.3",
     "pytest-asyncio>=0.21.0",
     "pytest-cov>=4.0",
     "pytest-mock>=3.10",
-    "black>=23.0",
+    "black>=26.3.1",
     "ruff>=0.1.0",
     "mypy>=1.0",
     "pre-commit>=3.0"

--- a/requirements-pinned.txt
+++ b/requirements-pinned.txt
@@ -9,8 +9,8 @@ pyyaml==6.0.1
 toml==0.10.2
 
 # Optional: MCP Server
-# Bumped from 0.1.0 to 1.23.0 to resolve GHSA-3 alerts on the MCP SDK
-# (FastMCP DoS, Streamable HTTP DoS, DNS-rebinding default).
+# Bumped from 0.1.0 to 1.23.0 to resolve three GHSA alerts on the MCP SDK:
+#   FastMCP validation DoS, Streamable HTTP DoS, DNS-rebinding default.
 mcp==1.23.0
 
 # Optional: Development & Testing

--- a/requirements-pinned.txt
+++ b/requirements-pinned.txt
@@ -9,12 +9,17 @@ pyyaml==6.0.1
 toml==0.10.2
 
 # Optional: MCP Server
-mcp==0.1.0
+# Bumped from 0.1.0 to 1.23.0 to resolve GHSA-3 alerts on the MCP SDK
+# (FastMCP DoS, Streamable HTTP DoS, DNS-rebinding default).
+mcp==1.23.0
 
 # Optional: Development & Testing
-pytest==7.4.3
+# pytest bumped from 7.4.3 to 9.0.3 to fix tmpdir handling vuln (CVE-2025-71176).
+# black bumped from 23.12.1 to 26.3.1 to fix ReDoS (CVE-2024-21503) and the
+# arbitrary-file-write cache vuln (GHSA-3936-cmfr-pm3m).
+pytest==9.0.3
 pytest-asyncio==0.21.1
-black==23.12.1
+black==26.3.1
 ruff==0.1.11
 mypy==1.8.0
 


### PR DESCRIPTION
## Summary

Clears all 6 Dependabot security alerts on `main`'s default branch by bumping three vulnerable dependencies. Scope is intentionally narrow — only `pyproject.toml` and `requirements-pinned.txt` change. The `0.3.6` version bump and the docs disambiguation are tracked separately on `claude/fix-workflow-issues-HuLp0`.

## Alerts cleared

| # | Severity | Package | Old | New | Advisory |
|---|---|---|---|---|---|
| #1 | Moderate | black | 23.12.1 | 26.3.1 | ReDoS, CVE-2024-21503 (fixed in 24.3.0; we bump higher to also clear #5) |
| #2 | High | mcp | 0.1.0 | 1.23.0 | Streamable HTTP DoS |
| #3 | High | mcp | 0.1.0 | 1.23.0 | FastMCP validation DoS |
| #4 | High | mcp | 0.1.0 | 1.23.0 | DNS rebinding off by default |
| #5 | High | black | 23.12.1 | 26.3.1 | Cache file-write, GHSA-3936-cmfr-pm3m (fix only in 26.3.1) |
| #6 | Moderate | pytest | 7.4.3 | 9.0.3 | tmpdir, CVE-2025-71176 |

## Changes

- `pyproject.toml`:
  - `[project.optional-dependencies] mcp`: `mcp>=0.1.0` → `mcp>=1.23.0`
  - `[project.optional-dependencies] dev`: `pytest>=7.0` → `pytest>=9.0.3`, `black>=23.0` → `black>=26.3.1`
- `requirements-pinned.txt`: exact pins bumped to the same target versions, with comments noting which advisory each fixes.

## Test plan

Verified locally before push:
- [x] `ruff check .` — passes
- [x] `black --check .` — 57 files unchanged on 26.3.1 (no reformatting fallout from the 23 → 26 jump)
- [x] `pytest tests/` on 9.0.3 — 292 passed, 7 expected skips (no pytest 7 → 9 deprecation breakage)
- [x] `import mcp` — 1.23.0+ resolves and imports
- [ ] CI confirms on this PR
- [ ] Dependabot alert count goes 6 → 0 once merged to `main`

## Why bump black to 26.3.1 and not 24.3.0

The ReDoS fix landed in 24.3.0, but the cache-file-write vulnerability (#5, GHSA-3936-cmfr-pm3m) is only patched in 26.3.1 per the advisory's "Patched versions" field. One bump clears both alerts; verified locally that 26 doesn't reformat any of the existing 57 files.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NGV9NwnwfzTk5UmHDtbUG8)_