### PR TITLE
docs(readme): add Hermes-Agent and OpenClaw MCP integration sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -785,6 +785,39 @@ are supported — see the upstream
 for the full schema (`command`, `args`, `env`, `url`, `headers`, `enabled`,
 per-server `tools` filtering).
 
+### OpenClaw
+
+[OpenClaw](https://github.com/openclaw/openclaw) is a personal AI assistant
+that registers MCP servers via the `openclaw mcp set` CLI command. Add
+NeuralMind:
+
+```bash
+openclaw mcp set neuralmind '{"command":"neuralmind-mcp","args":["/absolute/path/to/project"]}'
+```
+
+Then verify and inspect:
+
+```bash
+openclaw mcp list
+openclaw mcp show neuralmind
+```
+
+Remove with `openclaw mcp unset neuralmind`. Definitions are stored under
+the `mcp.servers` key in OpenClaw's config (`~/.openclaw/openclaw.json`).
+
+If you haven't installed OpenClaw yet:
+
+```bash
+npm install -g openclaw@latest   # or: pnpm add -g openclaw@latest
+openclaw onboard --install-daemon
+```
+
+OpenClaw's MCP support covers stdio (shown above), SSE, HTTP, and
+`streamable-http` transports — see the upstream
+[MCP CLI reference](https://docs.openclaw.ai/cli/mcp) for details on
+`url`/`transport` config and the inverse direction (`openclaw mcp serve`,
+which exposes OpenClaw's own channels as an MCP server to other clients).
+
 ### MCP tool schemas
 
 #### `neuralmind_wakeup`

--- a/README.md
+++ b/README.md
@@ -758,6 +758,33 @@ Drop a `.mcp.json` at your project root:
 }
 ```
 
+### Hermes-Agent (Nous Research)
+
+[Hermes-Agent](https://github.com/nousresearch/hermes-agent) is a self-improving
+agent framework that supports MCP servers via its YAML config. Add NeuralMind
+under the `mcp_servers` key of `~/.hermes/config.yaml`:
+
+```yaml
+mcp_servers:
+  neuralmind:
+    command: "neuralmind-mcp"
+    args: ["/absolute/path/to/project"]
+```
+
+If you haven't installed Hermes-Agent yet, the upstream installer is:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash
+source ~/.bashrc
+```
+
+After editing the config, run `/reload-mcp` from the `hermes` CLI to pick up
+the new server without restarting. Both stdio (shown above) and HTTP transports
+are supported — see the upstream
+[MCP integration docs](https://hermes-agent.nousresearch.com/docs/user-guide/features/mcp)
+for the full schema (`command`, `args`, `env`, `url`, `headers`, `enabled`,
+per-server `tools` filtering).
+
 ### MCP tool schemas
 
 #### `neuralmind_wakeup`


### PR DESCRIPTION
## Summary

Adds two new integration sections to `README.md` under "🔌 MCP Server",
following the same pattern as the existing Claude Desktop and Claude
Code / Cursor sections:

- **Hermes-Agent (Nous Research)** — `~/.hermes/config.yaml` YAML config under `mcp_servers`, with the upstream installer one-liner and the `/reload-mcp` step.
- **OpenClaw** — the `openclaw mcp set <name> <json>` CLI command, plus `mcp list` / `mcp show` / `mcp unset` for management. Definitions are stored under `mcp.servers` in `~/.openclaw/openclaw.json`.

## Sources (verbatim, no fabrication)

| Section | Schema source | Schema verified |
|---|---|---|
| Hermes-Agent | [github.com/nousresearch/hermes-agent](https://github.com/nousresearch/hermes-agent) README + [hermes-agent.nousresearch.com/docs/user-guide/features/mcp](https://hermes-agent.nousresearch.com/docs/user-guide/features/mcp) | YAML config path `~/.hermes/config.yaml`, `mcp_servers` top-level key, `command`/`args`/`env`/`url`/`headers`/`enabled`/`tools` schema, `/reload-mcp` reload command, stdio + HTTP transports |
| OpenClaw | [github.com/openclaw/openclaw](https://github.com/openclaw/openclaw) README + [docs.openclaw.ai/cli/mcp](https://docs.openclaw.ai/cli/mcp) | `openclaw mcp set/list/show/unset` CLI, `mcp.servers` config key, `~/.openclaw/openclaw.json` config path, stdio/SSE/HTTP/streamable-http transports |

Each section links to the upstream docs for the full schema rather than
duplicating every key, so the README stays accurate as those tools evolve.

## What this PR does *not* do

- **Doesn't claim untested behavior.** OpenClaw's reload mechanism isn't
  documented on the upstream MCP page, so the OpenClaw section deliberately
  omits a "reload after edit" step rather than guess. Hermes's `/reload-mcp`
  is documented and is included.
- **Doesn't change any code.** README only. No version bump, no new
  features, no test changes.
- **Doesn't reconcile the pre-existing "5–10× vs 40–70×" copy
  inconsistency** between `docs/index.html`/`docs/about.html` and the
  README — that's a separate doc-audit task.

## Test plan

- [ ] CI runs (lint, type-check, tests on Python 3.10/3.11/3.12, build) — README-only change should pass trivially.
- [ ] Visual: confirm rendered Hermes and OpenClaw sections appear under "🔌 MCP Server" → after the Claude Code / Cursor `.mcp.json` block, before "MCP tool schemas".
- [ ] Optional: a Hermes user follows the instructions; a `~/.hermes/config.yaml` with the YAML snippet plus `/reload-mcp` exposes `neuralmind-mcp` to the agent.
- [ ] Optional: an OpenClaw user runs `openclaw mcp set neuralmind '{"command":"neuralmind-mcp","args":["."]}'` and the server shows up in `openclaw mcp list`.

## Note on prior research

I initially attempted to research "openclaw" via web search and got back
SEO-spam-style results with contradictory facts (different star counts,
multiple "canonical" domains). I refused to write fabricated config from
those results. Once @dfrostar provided the canonical repo URL
(`github.com/openclaw/openclaw`), I verified it directly via raw README
fetch and the upstream `/cli/mcp` docs page before writing this section.

https://claude.ai/code/session_01Py3fjmPd4v73UyCCv9FaUj

---
_Generated by [Claude Code](https://claude.ai/code/session_01Py3fjmPd4v73UyCCv9FaUj)_