### PR TITLE
docs(readme): harden Hermes/OpenClaw sections after end-to-end verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -761,14 +761,41 @@ Drop a `.mcp.json` at your project root:
 ### Hermes-Agent (Nous Research)
 
 [Hermes-Agent](https://github.com/nousresearch/hermes-agent) is a self-improving
-agent framework that supports MCP servers via its YAML config. Add NeuralMind
-under the `mcp_servers` key of `~/.hermes/config.yaml`:
+agent framework that supports MCP servers. NeuralMind has been verified
+end-to-end against **Hermes-Agent v0.12.0 (build 2026.4.30)** — the agent
+discovered all 11 NeuralMind tools (4-second handshake) when registered as
+shown below.
+
+**Prerequisite:** install NeuralMind with the MCP extra. The MCP SDK is
+not part of the default install:
+
+```bash
+pip install "neuralmind[mcp]"      # not just "neuralmind"
+```
+
+**Two ways to register the server.** Both end up in `~/.hermes/config.yaml`:
+
+*Option A — CLI (recommended for first-time setup):*
+
+```bash
+hermes mcp add
+```
+
+*Option B — edit the config directly* (`~/.hermes/config.yaml`, add under
+the `mcp_servers` top-level key):
 
 ```yaml
 mcp_servers:
   neuralmind:
     command: "neuralmind-mcp"
     args: ["/absolute/path/to/project"]
+```
+
+**Verify** the server is registered and reachable:
+
+```bash
+hermes mcp list                     # neuralmind should appear, status ✓
+hermes mcp test neuralmind          # ✓ Connected, ✓ Tools discovered: 11
 ```
 
 If you haven't installed Hermes-Agent yet, the upstream installer is:
@@ -778,32 +805,43 @@ curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scri
 source ~/.bashrc
 ```
 
-After editing the config, run `/reload-mcp` from the `hermes` CLI to pick up
-the new server without restarting. Both stdio (shown above) and HTTP transports
-are supported — see the upstream
+After editing the YAML directly, run `/reload-mcp` from the running `hermes`
+CLI to pick up the change without restarting (the `hermes mcp add` flow does
+this automatically). Both stdio (shown above) and HTTP transports are
+supported — see the upstream
 [MCP integration docs](https://hermes-agent.nousresearch.com/docs/user-guide/features/mcp)
 for the full schema (`command`, `args`, `env`, `url`, `headers`, `enabled`,
-per-server `tools` filtering).
+per-server `tools` filtering, `timeout`, `connect_timeout`).
 
 ### OpenClaw
 
 [OpenClaw](https://github.com/openclaw/openclaw) is a personal AI assistant
-that registers MCP servers via the `openclaw mcp set` CLI command. Add
-NeuralMind:
+that registers MCP servers via its CLI. Verified against **OpenClaw 2026.5.2** —
+`mcp set` / `mcp list` / `mcp show` round-trip the documented JSON schema
+into `~/.openclaw/openclaw.json` exactly as expected.
+
+**Prerequisite:** install NeuralMind with the MCP extra (the MCP SDK is
+not part of the default install):
+
+```bash
+pip install "neuralmind[mcp]"      # not just "neuralmind"
+```
+
+**Register** NeuralMind:
 
 ```bash
 openclaw mcp set neuralmind '{"command":"neuralmind-mcp","args":["/absolute/path/to/project"]}'
 ```
 
-Then verify and inspect:
+**Verify** it landed:
 
 ```bash
-openclaw mcp list
-openclaw mcp show neuralmind
+openclaw mcp list                  # neuralmind should appear
+openclaw mcp show neuralmind       # echoes the JSON you stored
 ```
 
 Remove with `openclaw mcp unset neuralmind`. Definitions are stored under
-the `mcp.servers` key in OpenClaw's config (`~/.openclaw/openclaw.json`).
+the `mcp.servers` key in `~/.openclaw/openclaw.json`.
 
 If you haven't installed OpenClaw yet:
 
@@ -817,6 +855,30 @@ OpenClaw's MCP support covers stdio (shown above), SSE, HTTP, and
 [MCP CLI reference](https://docs.openclaw.ai/cli/mcp) for details on
 `url`/`transport` config and the inverse direction (`openclaw mcp serve`,
 which exposes OpenClaw's own channels as an MCP server to other clients).
+
+### Troubleshooting
+
+**"Connection closed" / "Connection failed" right after register.** Almost
+always means NeuralMind was installed without the `[mcp]` extra and
+`neuralmind-mcp` is exiting because the MCP SDK is missing. Fix:
+
+```bash
+pip install --upgrade "neuralmind[mcp]"
+```
+
+Then re-run the host's verify step (`hermes mcp test neuralmind` or
+`openclaw mcp list`).
+
+**`neuralmind-mcp: command not found`.** The package installed but the
+console script wasn't put on PATH — usually because pip installed into a
+user site-packages dir that isn't on PATH. Add `~/.local/bin` to PATH or
+reinstall in a venv where the entry point is on PATH.
+
+**The host shows neuralmind in `mcp list` but no tools when you query.**
+Run `neuralmind build /path/to/project` first — the index has to exist
+before the MCP tools can answer queries. The hooks (`SessionStart`,
+`UserPromptSubmit`, `PreCompact` from `neuralmind install-hooks`) need a
+built index too.
 
 ### MCP tool schemas
 


### PR DESCRIPTION
## Summary

Followup to #75 — verified the Hermes-Agent and OpenClaw integration sections by **actually installing both tools and registering NeuralMind through them**, then folded the findings back into the README.

## Verification results

| Integration | Version tested | Result |
|---|---|---|
| **Hermes-Agent** | v0.12.0 (build 2026.4.30) | ✓ `hermes mcp test neuralmind` reports **Connected (4081ms), 11 tools discovered** — all 4 v0.4.0 synapse tools included. |
| **OpenClaw** | 2026.5.2 (8b2a6e5) | ✓ `mcp set` / `mcp list` / `mcp show` round-trip the documented JSON schema verbatim into `~/.openclaw/openclaw.json`. (OpenClaw has no `mcp test` analogue, so end-to-end tool calls aren't independently verifiable from its CLI.) |

## Critical doc bug caught

`pip install neuralmind` does NOT include the MCP SDK by default — it's an `[mcp]` optional extra in `pyproject.toml`. Without it, `neuralmind-mcp` exits with stderr `"MCP SDK not installed. Install with: pip install mcp"` and exit code 1, which the host (Hermes, in my test) surfaces as a confusing **"Connection closed"** with no usable diagnostic.

This is the failure mode every first-time user would hit. **Both integration sections now lead with `pip install "neuralmind[mcp]"`** as a prerequisite, and the new Troubleshooting block calls it out by name.

## Other improvements (from hands-on use, not from upstream docs)

- **Hermes:** the README now recommends `hermes mcp add` (interactive CLI) as Option A, with direct YAML editing as Option B. The Hermes CLI already does the right thing (writes to `~/.hermes/config.yaml` + auto-reloads).
- **Hermes verify:** added `hermes mcp test <name>` to the verify step — this is the command I used to actually catch the missing-SDK bug.
- **OpenClaw verify:** `mcp list` + `mcp show` confirm the config landed; no upstream `mcp test` to add.
- **Pinned versions:** each section now states the exact upstream version verified, so readers know this isn't aspirational copy.
- **Troubleshooting block:** three most likely first-run failures — missing `[mcp]` extra, console script off PATH, querying before `neuralmind build`.

## Why now (not part of #75)

I didn't run the integrations myself before opening #75; I wrote those sections from upstream docs. After the merge, I verified end-to-end and immediately found the `[mcp]` issue, which is a real blocker for any user copying the README. This PR fixes that without rewriting the integration sections — it adds the missing prerequisite and tightens the surrounding language.

## What this PR is *not*

- **Not a code change.** README only. No version bump, no test changes, no behavior change.
- **Not a fix to `pyproject.toml`.** Whether `mcp` should be a hard dependency vs an optional extra is a separate decision (it has its own dependency tree and forces an opinionated install). For now, the README correctly reflects what the package actually does today.
- **Not an OpenClaw end-to-end verify.** OpenClaw's CLI doesn't expose a `mcp test`-equivalent; configuration round-trip is what we can verify from the CLI alone. I'm being explicit about that limit in the version-pin row above.

## Test plan

- [ ] CI: lint, type-check, all 3 Test versions, build — README-only change should pass trivially.
- [ ] Visual: confirm the rendered Hermes and OpenClaw sections show the new prerequisite, the verify steps, the version pins, and the new Troubleshooting block.
- [ ] Optional: a Hermes user follows the new instructions, sees `✓ Connected, ✓ Tools discovered: 11` in `hermes mcp test`.
- [ ] Optional: an OpenClaw user sees `neuralmind` listed in `openclaw mcp list` after `mcp set`.

https://claude.ai/code/session_01Py3fjmPd4v73UyCCv9FaUj

---
_Generated by [Claude Code](https://claude.ai/code/session_01Py3fjmPd4v73UyCCv9FaUj)_