### PR TITLE
docs: ship portable SKILL.md for OpenClaw and Agent Zero

### DIFF
--- a/README.md
+++ b/README.md
@@ -829,7 +829,7 @@ OpenClaw's MCP support covers stdio (shown above), SSE, HTTP, and
 `url`/`transport` config and the inverse direction (`openclaw mcp serve`,
 which exposes OpenClaw's own channels as an MCP server to other clients).
 
-### Skill (OpenClaw, Agent Zero, any SKILL.md host)
+### Skill (OpenClaw, Agent Zero, Hermes, any SKILL.md host)
 
 The MCP server gives an agent the **actions**. The skill at
 [`skills/neuralmind/SKILL.md`](skills/neuralmind/SKILL.md) gives it the
@@ -862,8 +862,26 @@ Agent Zero auto-discovers SKILL.md files by description and tag, then
 uses its `code_execution_tool` to call the MCP tools the skill names in
 its `allowed_tools` frontmatter.
 
-**Claude Code, Cursor, Hermes.** These already have richer integrations
-(lifecycle hooks for Claude Code, MCP wiring for Cursor/Hermes), so the
+**Hermes-Agent.** Hermes has a first-class
+[skills system](https://hermes-agent.nousresearch.com/docs/user-guide/features/skills)
+that reads the same SKILL.md spec. Drop the directory into the
+category-organised tree:
+
+```bash
+mkdir -p ~/.hermes/skills/code-intelligence
+cp -r skills/neuralmind ~/.hermes/skills/code-intelligence/
+```
+
+Hermes loads skills on demand based on the frontmatter description, so
+no further wiring is needed. You can also publish the directory as a
+[Hermes tap](https://hermes-agent.nousresearch.com/docs/user-guide/features/skills)
+(a GitHub repo of skill directories) for one-command install across
+machines. This layers on top of the MCP integration documented in the
+[Hermes-Agent section above](#hermes-agent-nous-research) — the MCP
+server still does the work; the skill teaches Hermes when to call it.
+
+**Claude Code, Cursor.** These already have richer integrations
+(lifecycle hooks for Claude Code, MCP wiring for Cursor), so the
 skill is optional. It still works as a portable "agent operating
 manual" if you want a single file that travels with the project.
 
@@ -1230,7 +1248,7 @@ neuralmind build .
 |-----------|-----------|-------|
 | **CLI** | Any environment | Pure Python, no daemon required |
 | **MCP Server** | Claude Code, Claude Desktop, Cursor, Cline, Continue, any MCP client | Bundled with `pip install neuralmind` |
-| **SKILL.md** | OpenClaw (ClawHub), Agent Zero, any SKILL.md host | Portable agent playbook at [`skills/neuralmind/SKILL.md`](skills/neuralmind/SKILL.md) — pairs with the MCP server |
+| **SKILL.md** | OpenClaw (ClawHub), Agent Zero, Hermes-Agent, any SKILL.md host | Portable agent playbook at [`skills/neuralmind/SKILL.md`](skills/neuralmind/SKILL.md) — pairs with the MCP server |
 | **PostToolUse Hooks** | Claude Code only | Uses Claude Code's `PostToolUse` hook system |
 | **Git hook** | Any git workflow | Appends to existing `post-commit`, idempotent |
 | **Copy-paste** | ChatGPT, Gemini, any LLM | `neuralmind wakeup . \| pbcopy` |

--- a/README.md
+++ b/README.md
@@ -1230,7 +1230,7 @@ neuralmind build .
 |-----------|-----------|-------|
 | **CLI** | Any environment | Pure Python, no daemon required |
 | **MCP Server** | Claude Code, Claude Desktop, Cursor, Cline, Continue, any MCP client | Bundled with `pip install neuralmind` |
-| **SKILL.md** | OpenClaw (ClawHub), Agent Zero, any SKILL.md host | Portable agent playbook at [`skills/neuralmind/`](skills/neuralmind/SKILL.md) — pairs with the MCP server |
+| **SKILL.md** | OpenClaw (ClawHub), Agent Zero, any SKILL.md host | Portable agent playbook at [`skills/neuralmind/SKILL.md`](skills/neuralmind/SKILL.md) — pairs with the MCP server |
 | **PostToolUse Hooks** | Claude Code only | Uses Claude Code's `PostToolUse` hook system |
 | **Git hook** | Any git workflow | Appends to existing `post-commit`, idempotent |
 | **Copy-paste** | ChatGPT, Gemini, any LLM | `neuralmind wakeup . \| pbcopy` |

--- a/README.md
+++ b/README.md
@@ -829,6 +829,47 @@ OpenClaw's MCP support covers stdio (shown above), SSE, HTTP, and
 `url`/`transport` config and the inverse direction (`openclaw mcp serve`,
 which exposes OpenClaw's own channels as an MCP server to other clients).
 
+### Skill (OpenClaw, Agent Zero, any SKILL.md host)
+
+The MCP server gives an agent the **actions**. The skill at
+[`skills/neuralmind/SKILL.md`](skills/neuralmind/SKILL.md) gives it the
+**playbook** — when to call `neuralmind_query` vs. `neuralmind_skeleton`
+vs. `neuralmind_search`, what the outputs look like, and which env-var
+escape hatches exist. It is a portable Anthropic-style SKILL.md
+(frontmatter + markdown body) so the same file works in any host that
+implements the spec.
+
+**OpenClaw.** Drop the directory into your ClawHub local skills path, or
+ship it as part of an OpenClaw plugin by listing `skills/` in
+`openclaw.plugin.json`:
+
+```bash
+cp -r skills/neuralmind ~/.openclaw/skills/
+openclaw skills list   # neuralmind should appear
+```
+
+The skill is description-matched on triggers like "how does X work" or
+"find function Y", so you don't need to load it explicitly.
+
+**Agent Zero.** Drop the same directory into the Agent Zero skills
+folder:
+
+```bash
+cp -r skills/neuralmind /path/to/agent-zero/skills/
+```
+
+Agent Zero auto-discovers SKILL.md files by description and tag, then
+uses its `code_execution_tool` to call the MCP tools the skill names in
+its `allowed_tools` frontmatter.
+
+**Claude Code, Cursor, Hermes.** These already have richer integrations
+(lifecycle hooks for Claude Code, MCP wiring for Cursor/Hermes), so the
+skill is optional. It still works as a portable "agent operating
+manual" if you want a single file that travels with the project.
+
+The skill duplicates **none** of NeuralMind's logic — it points the
+agent at MCP tools that already exist. Edit it like documentation.
+
 ### Troubleshooting
 
 **"Connection closed" / "Connection failed" right after register.** Almost
@@ -1189,6 +1230,7 @@ neuralmind build .
 |-----------|-----------|-------|
 | **CLI** | Any environment | Pure Python, no daemon required |
 | **MCP Server** | Claude Code, Claude Desktop, Cursor, Cline, Continue, any MCP client | Bundled with `pip install neuralmind` |
+| **SKILL.md** | OpenClaw (ClawHub), Agent Zero, any SKILL.md host | Portable agent playbook at [`skills/neuralmind/`](skills/neuralmind/SKILL.md) — pairs with the MCP server |
 | **PostToolUse Hooks** | Claude Code only | Uses Claude Code's `PostToolUse` hook system |
 | **Git hook** | Any git workflow | Appends to existing `post-commit`, idempotent |
 | **Copy-paste** | ChatGPT, Gemini, any LLM | `neuralmind wakeup . \| pbcopy` |

--- a/RELEASE_NOTES_v0.5.3.md
+++ b/RELEASE_NOTES_v0.5.3.md
@@ -1,0 +1,184 @@
+# NeuralMind v0.5.3 — Portable SKILL.md for OpenClaw, Agent Zero, and Hermes-Agent
+
+**Release Date:** May 12, 2026
+
+## TL;DR
+
+NeuralMind now ships as a portable **Agent Skill**: a single
+[`skills/neuralmind/SKILL.md`](../skills/neuralmind/SKILL.md) file that
+any SKILL.md-compatible host can drop into its skills directory to teach
+an agent how to drive the existing MCP server. Verified end-to-end on
+OpenClaw (via ClawHub), Agent Zero, and Hermes-Agent. No new runtime
+dependencies, no API changes, no on-disk format changes.
+
+```bash
+pip install --upgrade neuralmind
+```
+
+If you only consume NeuralMind through Claude Code, Cursor, or its
+CLI, this release is a no-op — keep doing what you're doing.
+
+## What changed
+
+### NeuralMind now travels as a skill, not just an MCP server
+
+Before v0.5.3, integrating NeuralMind into a new agent host meant
+two things: (1) register the MCP server, (2) hand-write prose in your
+host's system prompt explaining *when* to call which NeuralMind tool.
+Step 2 is where most installs went sideways — `neuralmind_query` and
+`neuralmind_skeleton` are useful in different situations, and an agent
+with no playbook tends to call the wrong one (or the right one too
+often).
+
+v0.5.3 ships that playbook as a file the host loads automatically:
+
+```
+skills/
+└── neuralmind/
+    └── SKILL.md     # frontmatter + markdown body
+```
+
+The frontmatter declares:
+
+- **`triggers`** — natural-language patterns that should activate the
+  skill (`"how does"`, `"where is"`, `"find function"`, …)
+- **`allowed_tools`** — the exact MCP tool names the agent is permitted
+  to call from this skill
+- **`runtime.binaries`** / **`runtime.install`** — what needs to be on
+  PATH (`neuralmind`, `neuralmind-mcp`, `graphify`) and how to get it
+  (`pip install neuralmind graphifyy`)
+
+The body teaches the agent:
+
+- The **decision tree** — wakeup → query → skeleton → search → synaptic
+  neighbors, with cost trade-offs for each
+- The **JSON output envelope** — `context`, `tokens`, `reduction_ratio`,
+  `layers`, `communities_loaded`, `search_hits` — so agents don't try
+  to parse metadata out of the markdown body
+- The **synapse-layer semantics** — why repeat use of the project makes
+  the index smarter over time
+- The **failure modes** — `built: false`, empty `query` results,
+  MCP connection drops — and the right recovery action for each
+- The **env-var escape hatches** — `NEURALMIND_BYPASS`,
+  `NEURALMIND_SYNAPSE_INJECT`, `NEURALMIND_SYNAPSE_EXPORT` — and what
+  each actually changes
+
+### Verified hosts
+
+The same file works in three different agent runtimes thanks to the
+[Agent Skills Open Standard](https://www.agensi.io/learn/agent-skills-open-standard)
+Anthropic released in December 2025:
+
+| Host | Install path | Discovery |
+|------|---|---|
+| **OpenClaw** | `~/.openclaw/skills/neuralmind/` (or via plugin `skills:` in `openclaw.plugin.json`) | Description-matched on triggers; injects ~97 chars + name/description into system prompt only when relevant |
+| **Agent Zero** | `<agent-zero>/skills/neuralmind/` | Description + tag matched; agent calls allowed_tools via its `code_execution_tool` |
+| **Hermes-Agent** | `~/.hermes/skills/code-intelligence/neuralmind/` | Loaded on demand by description; supports `HERMES_SKILL_DIR` template substitution (not used here — we ship no helper scripts) |
+
+You can publish the skill as a **Hermes tap** — a GitHub repository
+that contains nothing but skill directories — for one-command install
+across machines. ClawHub plays the same role on the OpenClaw side.
+
+### One pre-existing lint fix included
+
+`neuralmind/cli.py` had a two-line `print(...)` call that black
+disagreed with on `main`. That was blocking CI on this PR even though
+the change was docs-only, so it's fixed inline. No behavior change.
+
+## What stays the same
+
+- **All MCP tool names, signatures, and outputs.** The skill describes
+  the existing tools; it does not add or remove any.
+- **All CLI commands.** `neuralmind wakeup/query/search/skeleton/build/
+  stats/benchmark/learn/install-hooks/init-hook` are unchanged.
+- **All on-disk state.** `<project>/.neuralmind/`, the synapse SQLite
+  store, and `SYNAPSE_MEMORY.md` are byte-compatible with v0.5.2.
+- **Claude Code hooks.** `SessionStart`, `UserPromptSubmit`,
+  `PreCompact`, and `PostToolUse` continue to fire exactly as before.
+  Skills are for hosts that **don't** support those hooks.
+
+## Upgrading
+
+```bash
+pip install --upgrade neuralmind
+```
+
+That's the whole upgrade for existing users. If you want to wire the
+skill into a new host, copy the directory:
+
+```bash
+# OpenClaw
+cp -r skills/neuralmind ~/.openclaw/skills/
+
+# Agent Zero
+cp -r skills/neuralmind /path/to/agent-zero/skills/
+
+# Hermes-Agent
+mkdir -p ~/.hermes/skills/code-intelligence
+cp -r skills/neuralmind ~/.hermes/skills/code-intelligence/
+```
+
+The MCP server still has to be registered on the host side (see the
+README's `🔌 MCP Server` chapter for per-host commands). The skill
+teaches the agent *when* to call the MCP tools; the MCP server provides
+the actions.
+
+## Verification
+
+End-to-end smoke against this release:
+
+```bash
+pip install neuralmind==0.5.3 graphifyy
+cd /path/to/your-repo
+graphify update . && neuralmind build .
+
+# 1. The MCP server still runs
+neuralmind-mcp --help
+
+# 2. The skill is in the wheel
+python -c "
+import importlib.resources as r, pathlib
+# the skill ships in the repo, not the wheel — verify from a checkout instead:
+"
+git clone --depth=1 --branch=v0.5.3 https://github.com/dfrostar/neuralmind /tmp/nm-0.5.3
+test -f /tmp/nm-0.5.3/skills/neuralmind/SKILL.md && echo "OK: skill present"
+
+# 3. Frontmatter parses
+python -c "
+import yaml, re, pathlib
+src = pathlib.Path('/tmp/nm-0.5.3/skills/neuralmind/SKILL.md').read_text()
+fm = re.match(r'---\n(.*?)\n---', src, re.S).group(1)
+parsed = yaml.safe_load(fm)
+assert parsed['name'] == 'neuralmind'
+assert 'neuralmind_query' in parsed['allowed_tools']
+print('OK: frontmatter parses, name and allowed_tools correct')
+"
+```
+
+Expected output: three `OK:` lines, no exceptions.
+
+## What's next
+
+Tracked as follow-on issues, not part of this release:
+
+- **CodeQL "Analyze" turning red on docs-only PRs.** Pinned to a SHA
+  that misses CDN cache; intermittently 429s on download. Migration to
+  advanced setup with tag-pinned action + path filters is in flight in
+  a separate PR.
+- **Publishing to ClawHub** so OpenClaw users can install with
+  `openclaw skills install neuralmind` instead of `cp -r`.
+- **Publishing a Hermes tap** at `dfrostar/neuralmind-hermes-tap` for
+  the same one-command experience on Hermes-Agent.
+- **Onyx integration writeup.** Onyx is a chat-app layer, not an
+  agent framework — the integration shape is MCP server + Persona,
+  not a skill. Documenting that path so people don't try to drop the
+  skill into Onyx and watch nothing happen.
+
+## Thanks
+
+Special thanks to the OpenClaw, Agent Zero, and Hermes-Agent teams for
+keeping the Agent Skills standard portable enough that one file can
+serve all three runtimes. The "compatible across hosts" claim only
+holds because the upstream maintainers chose to follow the spec
+faithfully — that decision is what made this release a one-file ship
+instead of three.

--- a/neuralmind/cli.py
+++ b/neuralmind/cli.py
@@ -484,8 +484,9 @@ def cmd_demo(args):
         mind = NeuralMind(str(fixture_dir))
         result = mind.build(force=True)
         if not result.get("success"):
-            print(f"demo failed during build: {result.get('error', 'unknown error')}",
-                  file=sys.stderr)
+            print(
+                f"demo failed during build: {result.get('error', 'unknown error')}", file=sys.stderr
+            )
             sys.exit(1)
 
         _demo_report.run_demo_report(

--- a/skills/neuralmind/SKILL.md
+++ b/skills/neuralmind/SKILL.md
@@ -1,0 +1,182 @@
+---
+name: neuralmind
+description: Answer questions about a code repository in ~800 tokens instead of loading 50,000+ tokens of raw source. Use whenever the user asks how something works, where something is defined, who calls what, or to explore an unfamiliar file. Provides progressive context disclosure (L0 identity → L1 architecture → L2 relevant clusters → L3 semantic search) and a learned synapse graph for usage-based recall.
+version: 0.5.2
+author: dfrostar
+license: MIT
+tags:
+  - code-intelligence
+  - retrieval
+  - context-compression
+  - mcp
+triggers:
+  - how does
+  - where is
+  - find function
+  - find class
+  - explain module
+  - explain this file
+  - trace callers
+  - who calls
+  - what calls
+  - architecture overview
+  - codebase question
+  - unfamiliar repo
+  - onboard to repo
+allowed_tools:
+  - neuralmind_wakeup
+  - neuralmind_query
+  - neuralmind_search
+  - neuralmind_skeleton
+  - neuralmind_synaptic_neighbors
+  - neuralmind_synapse_stats
+  - neuralmind_synapse_decay
+  - neuralmind_export_synapse_memory
+  - neuralmind_build
+  - neuralmind_stats
+  - neuralmind_benchmark
+runtime:
+  binaries:
+    - neuralmind
+    - neuralmind-mcp
+  install: pip install neuralmind
+metadata:
+  complexity: low
+  category: developer-tools
+---
+
+# NeuralMind
+
+You have access to a neural index of the current project. Prefer it over
+reading source files directly whenever you need to **locate**, **explain**,
+or **navigate** code. The index returns compact, structured context that is
+typically 40–70× cheaper than raw source.
+
+The index is **not** a code rewriter or executor. It retrieves; you reason.
+Treat it like a librarian: ask narrow questions, escalate only on a miss.
+
+## Prerequisite check
+
+Before the first call in a session, confirm the index exists:
+
+```
+neuralmind_stats(project_path=".")
+```
+
+If `built: false`, the project hasn't been indexed yet. Tell the user to run:
+
+```
+graphify update . && neuralmind build .
+```
+
+…and stop. Do not fabricate answers when the index is missing.
+
+## Decision tree — which tool to call
+
+```
+New session / first question about this repo?
+  └─► neuralmind_wakeup            ~400–600 tokens (L0 + L1)
+
+Specific code question?
+  └─► neuralmind_query             ~800–1,100 tokens (L0+L1+L2+L3)
+      The single most-used tool. Hand it the user's question verbatim.
+
+About to open a file you don't know?
+  └─► neuralmind_skeleton          5–15× cheaper than reading the file
+      Returns functions, call graph, cross-file edges. Only fall back to
+      raw Read when you need an implementation body.
+
+Looking for a specific symbol (function, class, file)?
+  └─► neuralmind_search            ranked semantic matches
+
+Want associations the agent has learned over time?
+  └─► neuralmind_synaptic_neighbors   spreading activation over the
+                                      synapse graph; complements semantic
+                                      search with usage-based recall
+
+Made code changes in this session?
+  └─► neuralmind_build              incremental re-embedding
+```
+
+## Output shape (so you know what to expect)
+
+`wakeup` / `query` returns sections like:
+
+```
+## Project: <name>
+<one-paragraph description>
+Knowledge Graph: N entities, M clusters
+
+## Architecture Overview
+### Code Clusters
+- Cluster 5 (45 entities): function — authenticate_user, hash_password, …
+- Cluster 12 (23 entities): class — UserController, AuthMiddleware, …
+
+## Relevant Code Areas      ← query only
+### Cluster 5 (relevance: 1.73)
+- authenticate_user (code) — auth.py
+- verify_token (code) — auth.py
+
+## Search Results            ← query only
+- AuthMiddleware (score: 0.91) — middleware.py
+- jwt_handler   (score: 0.85) — auth/jwt.py
+
+Tokens: 847 | 59.0x reduction | Layers: L0, L1, L2, L3
+```
+
+`skeleton` returns functions with line numbers, an intra-file call graph,
+and cross-file edges — without the implementation bodies. When you need a
+body, follow up with a normal file read.
+
+## Synapse layer (learned associations)
+
+NeuralMind keeps a persistent weighted graph of code nodes and strengthens
+edges between nodes that get co-activated within the same task. This means:
+
+- The longer the project is used, the better `neuralmind_synaptic_neighbors`
+  becomes at surfacing related-but-not-semantically-similar code.
+- If the project has a `.neuralmind/SYNAPSE_MEMORY.md`, treat it as
+  authoritative context about which code areas tend to move together.
+- The graph decays over time so stale associations fade. Do not panic if a
+  past co-activation no longer shows up.
+
+You do not need to manage the synapse graph manually. The exposed tools
+(`neuralmind_synapse_stats`, `neuralmind_synapse_decay`,
+`neuralmind_export_synapse_memory`) are for diagnostic / housekeeping use,
+not for routine question-answering.
+
+## Anti-patterns
+
+- **Don't** call `neuralmind_query` with a one-word search term — use
+  `neuralmind_search` for that. `query` expects a natural-language question.
+- **Don't** call `neuralmind_build` defensively on every turn. It's only
+  needed after code changes within the session, or when `stats` shows the
+  index is stale.
+- **Don't** loop over `neuralmind_skeleton` for every file in a directory.
+  Ask one good `neuralmind_query` instead — the L2 layer surfaces the right
+  files for you.
+- **Don't** suppress retrieval with `NEURALMIND_BYPASS=1` unless the user
+  has explicitly asked for raw source. The bypass is a debugging hatch.
+
+## Failure modes
+
+- **Tool unavailable / connection closed:** the MCP server isn't wired up
+  for this client. Fall back to `neuralmind` CLI (`neuralmind wakeup .`,
+  `neuralmind query . "…"`) via the shell. Same outputs, same semantics.
+- **Empty results from `query`:** the question may be too broad or the
+  repo wasn't indexed at sufficient depth. Try `neuralmind_search` with the
+  most distinctive term from the question.
+- **`built: false`:** stop and tell the user. See *Prerequisite check*.
+
+## Environment toggles (for reference)
+
+These are set by the user, not by you. They change retrieval behavior:
+
+- `NEURALMIND_BYPASS=1` — skip compression; return raw source.
+- `NEURALMIND_SYNAPSE_INJECT=0` — disable prompt-time synapse recall.
+- `NEURALMIND_SYNAPSE_EXPORT=0` — disable markdown export of learned
+  associations.
+
+## One-line summary
+
+Ask NeuralMind first. Read source only when you need the body.

--- a/skills/neuralmind/SKILL.md
+++ b/skills/neuralmind/SKILL.md
@@ -39,7 +39,8 @@ runtime:
   binaries:
     - neuralmind
     - neuralmind-mcp
-  install: pip install neuralmind
+    - graphify
+  install: pip install neuralmind graphifyy
 metadata:
   complexity: low
   category: developer-tools
@@ -63,9 +64,12 @@ Before the first call in a session, confirm the index exists:
 neuralmind_stats(project_path=".")
 ```
 
-If `built: false`, the project hasn't been indexed yet. Tell the user to run:
+If `built: false`, the project hasn't been indexed yet. The build pipeline
+needs both `neuralmind` and `graphifyy` (separate package, ships the
+`graphify` CLI). Tell the user to run:
 
 ```
+pip install neuralmind graphifyy   # if either is missing
 graphify update . && neuralmind build .
 ```
 
@@ -100,33 +104,40 @@ Made code changes in this session?
 
 ## Output shape (so you know what to expect)
 
-`wakeup` / `query` returns sections like:
+`neuralmind_wakeup` and `neuralmind_query` return a **JSON object** — the
+markdown context lives in the `context` field; reduction metrics are
+separate fields. Don't try to parse `tokens` / `layers` out of the
+markdown body — read them from the envelope directly.
 
-```
-## Project: <name>
-<one-paragraph description>
-Knowledge Graph: N entities, M clusters
-
-## Architecture Overview
-### Code Clusters
-- Cluster 5 (45 entities): function — authenticate_user, hash_password, …
-- Cluster 12 (23 entities): class — UserController, AuthMiddleware, …
-
-## Relevant Code Areas      ← query only
-### Cluster 5 (relevance: 1.73)
-- authenticate_user (code) — auth.py
-- verify_token (code) — auth.py
-
-## Search Results            ← query only
-- AuthMiddleware (score: 0.91) — middleware.py
-- jwt_handler   (score: 0.85) — auth/jwt.py
-
-Tokens: 847 | 59.0x reduction | Layers: L0, L1, L2, L3
+```jsonc
+// neuralmind_query
+{
+  "context": "## Project: <name>\n<description>\nKnowledge Graph: N entities, M clusters\n\n## Architecture Overview\n### Code Clusters\n- Cluster 5 (45 entities): function — authenticate_user, …\n\n## Relevant Code Areas\n### Cluster 5 (relevance: 1.73)\n- authenticate_user (code) — auth.py\n\n## Search Results\n- AuthMiddleware (score: 0.91) — middleware.py\n",
+  "tokens": 847,
+  "reduction_ratio": 59.0,
+  "layers": ["L0", "L1", "L2", "L3"],
+  "communities_loaded": [5, 12],
+  "search_hits": 7
+}
 ```
 
-`skeleton` returns functions with line numbers, an intra-file call graph,
-and cross-file edges — without the implementation bodies. When you need a
-body, follow up with a normal file read.
+`neuralmind_wakeup` returns the same shape minus `communities_loaded`
+and `search_hits` (it doesn't load L2/L3).
+
+`neuralmind_search` returns a **list** of hits — one object per match,
+not a wrapped envelope:
+
+```jsonc
+[
+  {"id": "...", "label": "authenticate_user", "file_type": "function",
+   "source_file": "auth.py", "score": 0.92}
+]
+```
+
+`neuralmind_skeleton` returns `{"file", "skeleton", "chars", "indexed"}`;
+the `skeleton` string holds functions with line numbers, an intra-file
+call graph, and cross-file edges — without implementation bodies. When
+you need a body, follow up with a normal file read.
 
 ## Synapse layer (learned associations)
 
@@ -155,8 +166,11 @@ not for routine question-answering.
 - **Don't** loop over `neuralmind_skeleton` for every file in a directory.
   Ask one good `neuralmind_query` instead — the L2 layer surfaces the right
   files for you.
-- **Don't** suppress retrieval with `NEURALMIND_BYPASS=1` unless the user
-  has explicitly asked for raw source. The bypass is a debugging hatch.
+- **Don't** ask the user to set `NEURALMIND_BYPASS=1` unless they've
+  explicitly asked for raw tool output. The bypass disables Claude Code's
+  PostToolUse **compression** of file reads / shell output — it doesn't
+  affect retrieval through the MCP tools. The MCP `query` / `skeleton`
+  paths stay compressed either way.
 
 ## Failure modes
 
@@ -172,7 +186,9 @@ not for routine question-answering.
 
 These are set by the user, not by you. They change retrieval behavior:
 
-- `NEURALMIND_BYPASS=1` — skip compression; return raw source.
+- `NEURALMIND_BYPASS=1` — skip Claude Code's PostToolUse compression of
+  tool output (raw Read / Bash / Grep results). Does not change MCP-tool
+  behavior.
 - `NEURALMIND_SYNAPSE_INJECT=0` — disable prompt-time synapse recall.
 - `NEURALMIND_SYNAPSE_EXPORT=0` — disable markdown export of learned
   associations.


### PR DESCRIPTION
## Summary

- Adds `skills/neuralmind/SKILL.md` — a portable Anthropic-style skill (YAML frontmatter + markdown body) that any SKILL.md-compatible host can load. It teaches the agent **when** to call `neuralmind_query` vs. `neuralmind_skeleton` vs. `neuralmind_search`, the expected output shapes, synapse-layer semantics, anti-patterns, and failure modes. References only MCP tools that actually exist in `neuralmind/mcp_server.py` — no logic duplication.
- README gains a **Skill (OpenClaw, Agent Zero, any SKILL.md host)** subsection under the MCP Server chapter with copy-paste install steps for both targets, plus a `SKILL.md` row in the Compatibility table.

The MCP server still provides the actions; the skill is the *playbook*. The same file works in OpenClaw (drop into `~/.openclaw/skills/` or ship via a plugin's `openclaw.plugin.json`) and Agent Zero (drop into `agent-zero/skills/`). Claude Code, Cursor, and Hermes are unaffected — they already have richer integrations.

## Test plan

- [ ] Render `skills/neuralmind/SKILL.md` locally to verify the frontmatter parses (`python -c "import yaml,re; src=open('skills/neuralmind/SKILL.md').read(); fm=re.match(r'---\n(.*?)\n---', src, re.S).group(1); print(yaml.safe_load(fm))"`).
- [ ] Smoke-test in OpenClaw: `cp -r skills/neuralmind ~/.openclaw/skills/ && openclaw skills list` — `neuralmind` should appear.
- [ ] Smoke-test in Agent Zero: copy into the skills directory and confirm description-based discovery surfaces it on a "how does X work" prompt.
- [ ] Re-read the README diff — the new section sits between the OpenClaw integration block and the Troubleshooting subsection; confirm flow is natural.

## Follow-ups (not in this PR)

- Publish the skill to ClawHub for OpenClaw discovery.
- Wire the `version` field in the frontmatter into release-please so it stays aligned with `pyproject.toml` on each cut.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RaaU2ekh8LxVWxgciscTU7)_