### PR TITLE
ci: add workflow_dispatch to release.yml so v0.5.3 (and future skips) can be replayed

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,21 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Existing tag to release (e.g., v0.5.3). The tag MUST already exist in the repo.'
+        required: true
+        type: string
+
+# RELEASE_TAG is the canonical "what are we releasing" value for every job
+# below. On a tag push (github.ref_name == 'v0.5.3') it derives from the
+# ref; on manual workflow_dispatch it comes from the user-supplied input.
+# This lets us recover when release-please cuts a tag with GITHUB_TOKEN
+# (which doesn't fire push:tags workflows) by re-running this workflow
+# manually against the existing tag — see issue #98.
+env:
+  RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
 
 jobs:
   validate-version:
@@ -11,11 +26,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ env.RELEASE_TAG }}
 
       - name: Check tag matches pyproject.toml version
         run: |
           set -euo pipefail
-          TAG_VERSION="${GITHUB_REF#refs/tags/v}"
+          TAG_VERSION="${RELEASE_TAG#v}"
           PKG_VERSION="$(python - <<'EOF'
           import re, sys
           content = open("pyproject.toml").read()
@@ -41,6 +58,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ env.RELEASE_TAG }}
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -61,6 +80,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ env.RELEASE_TAG }}
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -116,7 +137,7 @@ jobs:
       - name: Smoke test published package from PyPI
         run: |
           set -euo pipefail
-          VERSION="${GITHUB_REF#refs/tags/v}"
+          VERSION="${RELEASE_TAG#v}"
           echo "Testing neuralmind==${VERSION}"
           sleep 30
           python -m venv .venv
@@ -169,6 +190,8 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ env.RELEASE_TAG }}
 
       - name: Download build artifacts
         uses: actions/download-artifact@v8
@@ -181,7 +204,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          TAG="${GITHUB_REF#refs/tags/}"
+          TAG="${RELEASE_TAG}"
           echo "Tag: ${TAG}"
 
           if gh release view "${TAG}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary

Adds `workflow_dispatch` to `release.yml` so a maintainer can manually replay the release pipeline for any already-tagged version. This is the workaround for #98 — release-please uses the default `GITHUB_TOKEN`, which GitHub deliberately blocks from triggering `push:tags` workflows. v0.5.3 already tripped over this: the tag exists, the GitHub Release exists, but `release.yml` never ran and `v0.5.3` isn't on PyPI.

## What changed

- New `workflow_dispatch` trigger with a single required `tag` input (e.g. `v0.5.3`).
- New workflow-level `env: RELEASE_TAG` that resolves to `inputs.tag` on dispatch or `github.ref_name` on tag push — a single source of truth for every downstream job.
- Every `actions/checkout@v6` now pins `ref: ${{ env.RELEASE_TAG }}` so a dispatched run builds the tagged tree, not whatever `main` looks like at dispatch time.
- `validate-version`, `smoke-test-pypi`, and `github-release` shell blocks now read `${RELEASE_TAG}` instead of `${GITHUB_REF#refs/tags/v}` — same value, works under both triggers.

The `github-release` job already handles "Release exists, attach artifacts" cleanly (or warns if the Release is immutable), so re-running for v0.5.3 will at minimum attach the missing wheel/sdist and PyPI gets the canonical install.

## Why a workaround instead of a permanent fix

The permanent fix is a PAT or a GitHub App token for `release-please-action` so tag pushes trigger downstream workflows automatically — that's tracked in #98 and needs maintainer action (provision secret, install App). This PR is the **smaller, contained, no-secret-needed** change that unblocks v0.5.3 immediately and gives every future release a manual escape hatch.

## Test plan

- [ ] CI on this PR passes (Lint / Test 3.10–3.12 / Type Check / Build Package / benchmark / CodeQL).
- [ ] After merge, dispatch the workflow via Actions → Release → Run workflow → input `v0.5.3`. Expect: `validate-version` ✅ (pyproject.toml at v0.5.3 tag = 0.5.3), `test` ✅, `build` ✅, `publish-pypi` ✅ (OIDC trusted publish), `smoke-test-pypi` ✅ (installs from PyPI in fresh venv), `publish-testpypi` ✅ (or skipped/continue-on-error), `github-release` ✅ (attaches dist/* to existing v0.5.3 Release).
- [ ] Confirm `pip install neuralmind==0.5.3` works from PyPI.
- [ ] Future releases: leave the existing tag-push trigger as the happy path; only dispatch manually when release-please skips downstream.

## Out of scope

- Provisioning the PAT or GitHub App for the permanent fix — #98.
- Adding branch protection or CI-on-release-PR gating — separate concern, file when the bigger release flow is settled.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RaaU2ekh8LxVWxgciscTU7)_