### PR TITLE
Self-improvement engine: plans + D1 logging substrate + D2 selector auto-tuning

### DIFF
--- a/evals/faithfulness/PLAN.md
+++ b/evals/faithfulness/PLAN.md
@@ -1,0 +1,87 @@
+# Faithfulness study — plan
+
+Status: proposed (not started). 3–5 day scope.
+
+## Question being answered
+
+When NeuralMind hands an agent a compressed L0/L1/L2/L3 context for a code
+question, does the agent reach the *same answer* it would with full source?
+If not, where does it break?
+
+## Scope
+
+In: code Q&A on a fixed corpus, single-turn, single-file and cross-file
+questions.
+
+Out: multi-turn editing, agentic loops, latency, throughput. Those belong
+in the end-to-end workload benchmark, not here.
+
+## Setup
+
+- **Corpus:** the bundled `neuralmind/demo_data/sample_project/` plus 1–2
+  real OSS repos pinned to a SHA (candidates: `requests`, `flask`).
+  Read-only.
+- **Question set:** ~60 questions across 4 buckets — *definition lookup*,
+  *call-site / usage*, *cross-file behavior*, *invariant / "why"*.
+  Hand-written, with ground-truth: a free-text reference answer plus a
+  citation set (file paths + line ranges that must appear in any correct
+  answer).
+- **Models:** one cheap (Haiku 4.5), one strong (Sonnet 4.6). Two runs
+  each at temperature 0 to measure the non-determinism floor.
+
+## Conditions (per question)
+
+1. **Full-source baseline** — entire relevant file(s) in context.
+2. **NeuralMind L0 only** — one-line summaries.
+3. **NeuralMind L0+L1** — + signatures.
+4. **NeuralMind L0+L1+L2** — + docstrings / key bodies.
+5. **NeuralMind L0–L3** — full progressive disclosure, synapse recall on.
+6. **L0–L3, synapse recall off** — isolates whether learned associations
+   actually help.
+7. **Naive top-k embedding retrieval** at matched token budget — controls
+   for "is graph structure doing work, or just retrieval?"
+
+## Metrics
+
+- **Citation recall / precision** vs. ground-truth file:line ranges.
+  Deterministic. **Primary metric.**
+- **Answer correctness** — LLM-judge (Sonnet) with rubric. Human spot-check
+  20% for calibration. Secondary.
+- **Token cost** per condition (already instrumented).
+- **Faithfulness / cost frontier** — correctness vs. tokens. Headline chart.
+
+## Deliverables
+
+- `evals/faithfulness/` runner: questions YAML, condition matrix, judge
+  prompt, results JSONL.
+- One results table + frontier plot.
+- Short internal writeup of which question buckets degrade earliest —
+  that's the actionable signal for tuning the context selector.
+
+## Day plan
+
+- **D1:** author ~20 questions + ground-truth citations on sample fixture.
+- **D2:** runner, condition matrix, judge harness; smoke-run all 7
+  conditions on the sample corpus.
+- **D3:** extend corpus to one OSS repo, author ~40 more questions.
+- **D4:** full run (2 models × 7 conditions × ~60 q ≈ 840 calls,
+  cacheable), score, plot.
+- **D5:** writeup. Decide whether the end-to-end workload benchmark is
+  worth running given results.
+
+## Risks / open decisions
+
+- LLM-judge bias toward verbose answers — mitigated by using citation
+  recall as the primary metric and the judge as secondary.
+- 60 questions is small. The frontier shape should still be visible, but
+  powering a per-bucket significance test would need ~150.
+- Synapse recall needs warm-up traffic to be fair to condition 5. Plan a
+  synthetic warm-up pass over the corpus before scoring.
+
+## Explicitly not in this plan
+
+- README or marketing changes.
+- Regenerating `demo_data/.../graph.json` — graphify output is
+  non-deterministic enough that re-running it would churn wheel contents.
+- Merging `tests/fixtures/sample_project/` and
+  `neuralmind/demo_data/sample_project/` — different lifecycles.

--- a/evals/self_improvement/PLAN.md
+++ b/evals/self_improvement/PLAN.md
@@ -56,49 +56,83 @@ Derived signals:
 
 ## Architecture
 
-One new SQLite table next to the existing synapse store, one new
-module per subsystem, no changes to the public MCP surface.
+We do **not** need a new SQLite table — `neuralmind/memory.py` already
+exists and handles per-project + global JSONL event logging behind an
+opt-in consent sentinel. `core.NeuralMind.query()` already calls
+`log_query_event()` at `core.py:283`. D1 extends that substrate
+rather than duplicating it.
 
-### Storage: `query_events` table
+### Existing substrate (already in tree)
 
-Lives in the existing synapse DB at `<project>/.neuralmind/synapses.db`
-to share the connection / WAL setup. Schema (added via
-`CREATE TABLE IF NOT EXISTS`, no migration framework needed yet):
+`neuralmind/memory.py` provides:
 
-```sql
-CREATE TABLE IF NOT EXISTS query_events (
-  id           INTEGER PRIMARY KEY AUTOINCREMENT,
-  ts           REAL NOT NULL,             -- unix timestamp
-  session_id   TEXT NOT NULL,             -- Claude Code session id
-  tool         TEXT NOT NULL,             -- 'wakeup' | 'query'
-  query_hash   TEXT,                      -- sha1(query text), null for wakeup
-  query_text   TEXT,                      -- truncated to 512 chars, null for wakeup
-  layers_used  TEXT,                      -- JSON array, e.g. '["L0","L1","L2"]'
-  recall_nodes TEXT,                      -- JSON array of node ids
-  community_id TEXT,                      -- primary community touched, if any
-  escalated_l3 INTEGER NOT NULL DEFAULT 0 -- 1 if L3 was used
-);
-CREATE INDEX IF NOT EXISTS idx_query_events_session ON query_events(session_id, ts);
-CREATE INDEX IF NOT EXISTS idx_query_events_community ON query_events(community_id);
-```
+- `is_memory_logging_enabled()` — gates everything on the consent
+  sentinel at `~/.neuralmind/memory_consent.json`.
+- `log_query_event(project_path, question, result)` — appends a JSON
+  line per query to both `<project>/.neuralmind/memory/query_events.jsonl`
+  and `~/.neuralmind/memory/query_events.jsonl`. Captures
+  `layers_used`, `communities_loaded`, `search_hits`, `tokens`,
+  `reduction_ratio`, `timestamp`, `query`.
+- `read_query_events(path)` — reads back the JSONL.
 
-Retention: cap at 50k rows per project, prune oldest on insert past
-threshold (cheap, no separate cron).
+This satisfies most of subsystem A and B's data needs. The privacy
+story (opt-in consent, local-first, JSONL on disk) is also already
+designed and tested.
 
-Writer: `neuralmind/query_log.py` (new). Single function
-`record_query_event(...)` — opens the existing synapse DB, inserts,
-commits. Stdlib-only, parallels `synapses.py` style.
+### What D1 adds
 
-### Hook point
+Four small gaps:
 
-`hooks.py` already registers PostToolUse hooks. Add one for
-`neuralmind_query` and `neuralmind_wakeup` that calls
-`record_query_event`. The tool's response already contains
-`layers_used` and the node ids — no change to the tool body required.
+1. **Wakeup logging.** `core.NeuralMind.wakeup()` does not currently
+   log. Add `log_wakeup_event(project_path, result, session_id)` and
+   call it from `wakeup()`. Critical for the "L0/L1 was sufficient"
+   positive signal — without wakeup events, we can't tell whether
+   the agent woke up and stopped (good) or woke up and immediately
+   queried (under-disclosure).
 
-This keeps query logging entirely in the hook layer, so users who
-disable hooks (`NEURALMIND_QUERY_LOG=0`) lose self-improvement but
-retain core behavior.
+2. **`session_id` on events.** Both `query` and `wakeup` events need
+   a session id so we can compute *intra-session* signals (re-query
+   rate, wakeup-without-followup). Source order:
+   - `CLAUDE_SESSION_ID` env var if set,
+   - else a process-lifetime uuid generated lazily (one per
+     `NeuralMind` instance).
+
+3. **Derived `escalated_l3` flag.** Trivially `"L3" in layers_used`,
+   but surface as a helper so subsystem A reads through one
+   function rather than re-implementing the predicate.
+
+4. **Aggregation helpers in `memory.py`.** Subsystem A's tuning rule
+   needs:
+   - `recent_events(path, *, since=None, window=None) -> list[dict]`
+   - `escalation_rate(events) -> float`
+   - `re_query_rate(events) -> float`
+   - `wakeup_only_rate(events) -> float`
+
+   Each is short (a few lines). They're the read-side primitives;
+   subsystem A is the only consumer. Keeping them in `memory.py`
+   (not a new module) so future readers find aggregation logic next
+   to the storage that produces it.
+
+### Tunables storage (subsystem A, later)
+
+`l2_recall_k` and `l3_escalation_threshold` will live in the
+existing `meta` table of `synapses.db` — that's already a
+key-value scratchpad and avoids introducing a third storage
+location. Subsystem C, when it lands, writes there too. (D1 does
+not touch the meta table.)
+
+### Why not hooks
+
+The plan's earlier draft proposed PostToolUse hooks on
+`neuralmind_query` / `neuralmind_wakeup`. In-process logging from
+`core.py` is strictly better:
+- The data is already structured (`ContextResult` object), no JSON
+  re-parsing.
+- `core.query()` already calls `log_query_event` — the substrate is
+  in-process.
+- Hooks would only fire when the user has Claude Code's hooks
+  installed; in-process logging works for any caller (CLI, MCP,
+  programmatic).
 
 ## Subsystem A: selector auto-tuning
 
@@ -271,28 +305,48 @@ moves scalars in the expected direction.
 
 ## D1 deliverable (detailed)
 
-In one branch, `claude/self-improvement-d1` (forked from
-`claude/plan-next-task-nwJak` once we start coding):
+Developed on `claude/plan-next-task-nwJak`. Extends the existing
+`memory.py` substrate; no new modules, no new storage backend.
 
-1. **`neuralmind/query_log.py`** — `init_schema(conn)`,
-   `record_query_event(...)`, `recent_events(window)`,
-   `prune_to(retention)`. Reuses `synapses.default_db_path()` and
-   the same connection-open helper.
-2. **Schema bootstrap** — call `init_schema` from
-   `synapses.SynapseStore.__init__` so a single open creates both
-   sets of tables. No separate migration.
-3. **Hook integration** — extend `hooks.py` PostToolUse handlers to
-   record an event after `neuralmind_query` and `neuralmind_wakeup`.
-   Read `tool_response.layers_used`, recall node ids, and escalation
-   flag. Gate behind `NEURALMIND_QUERY_LOG`.
-4. **Tests** — `tests/test_query_log.py` covering insert, JSON
-   columns, retention trim, idempotent schema creation.
-5. **No behavior change** for users with the env var unset
-   (default is on, but the table is just inert append).
+1. **Add `log_wakeup_event` to `memory.py`.** Same JSONL file as
+   query events, `event_type: "wakeup"`. Captures
+   `layers_used`, `tokens`, `timestamp`, `session_id`,
+   `project_path`. No `query` field.
 
-D1 ships nothing user-visible — purely the data layer that A, B, C
-all depend on. This is intentional: gives us a logging substrate to
-start collecting signal *while* we build A and B.
+2. **Add `session_id` to `log_query_event` and `log_wakeup_event`.**
+   Resolution: `CLAUDE_SESSION_ID` env var, else a lazy
+   process-lifetime uuid via `_current_session_id()`. Add the field
+   to events emitted by both functions.
+
+3. **Wire `core.NeuralMind.wakeup()` to call `log_wakeup_event`.**
+   One line, mirrors the existing `log_query_event` call in
+   `query()`.
+
+4. **Aggregation helpers** in `memory.py`:
+   - `recent_events(events, *, since_ts=None, last_n=None)`
+   - `escalation_rate(events)` — fraction with `"L3"` in
+     `layers_used` (query events only).
+   - `re_query_rate(events)` — fraction of query events with ≥50%
+     `communities_loaded` overlap with the previous query in the
+     same session.
+   - `wakeup_only_rate(events)` — fraction of sessions whose only
+     events are wakeups (no queries).
+
+5. **Tests** in `tests/test_memory.py` (or a sibling
+   `tests/test_memory_aggregations.py` to keep file size sane):
+   - `log_wakeup_event` writes to both project and global JSONL.
+   - `session_id` is included on both event types.
+   - `session_id` honors `CLAUDE_SESSION_ID` when set, falls back
+     to a stable process-lifetime uuid otherwise.
+   - Each aggregation helper on hand-built event streams.
+   - Existing `test_memory.py` cases still pass (no regression on
+     `log_query_event` shape — just additive field).
+
+6. **No behavior change** for users without consent. All logging
+   already gated by `is_memory_logging_enabled()`.
+
+D1 ships nothing user-visible — purely fills gaps in the data layer
+that subsystems A and B will read.
 
 ## D2 / D3 (sketch only)
 

--- a/evals/self_improvement/PLAN.md
+++ b/evals/self_improvement/PLAN.md
@@ -1,0 +1,319 @@
+# Self-improvement engine — plan
+
+Status: proposed. Sequencing: subsystems A and B first (~2–3 days),
+then closed-loop tuning (subsystem C) once `evals/faithfulness/` lands.
+
+## Goal
+
+NeuralMind already learns associations via the Hebbian synapse layer
+(`neuralmind/synapses.py`). That tunes *which nodes are co-active*. It
+does **not** tune:
+
+- **what gets surfaced at query time** — the L2 recall set size, the
+  L3 escalation threshold, the synapse spread-activation params.
+- **the quality of stored summaries** — the L2 community summaries in
+  ChromaDB, which are the only LLM-generated text in the index and
+  the only thing where regeneration is meaningful.
+
+This document specifies an outer loop that uses observed agent behavior
+to tune both, plus the closed-loop variant that uses the faithfulness
+eval as a fitness function.
+
+## What we are NOT doing
+
+- Regenerating L0 / L1. They are computed on-the-fly from project
+  metadata (CLAUDE.md, README.md, mempalace.yaml) and graph stats —
+  there's nothing stored to refine. (See `context_selector.py:230-308`.)
+- Replacing the Hebbian synapse store. This sits on top.
+- Anything that requires the agent to give explicit feedback. The
+  signal must be implicit (which tools were used, did the agent
+  re-query, did escalation happen).
+- Touching the README or producing marketing material.
+
+## Available signals
+
+From the existing MCP tools (`mcp_server.py`):
+
+- `neuralmind_wakeup` was called with project hash H at time T.
+- `neuralmind_query` was called with query Q, returned `layers_used`
+  (e.g. `["L0", "L1", "L2"]` or `["L0", "L1", "L2", "L3"]`), recall
+  set R (the node IDs surfaced), session S.
+- Within a session, queries Q1, Q2, … and which nodes overlapped.
+- PostToolUse hook fires on these — we can log without changing tool
+  behavior.
+
+Derived signals:
+
+- **L3 escalation rate per query type.** If a class of queries always
+  escalates to L3, L2 is under-recalling for that class.
+- **Re-query rate.** Two queries in the same session whose recall sets
+  overlap by ≥50% suggests the first query under-disclosed.
+- **Wakeup-only sessions.** If `neuralmind_wakeup` is called and no
+  `neuralmind_query` follows within the session, L0/L1 was
+  sufficient — this is the *positive* signal.
+- **Per-community escalation rate.** Queries that touch community C
+  and escalate to L3 → C's summary is inadequate for that query type.
+
+## Architecture
+
+One new SQLite table next to the existing synapse store, one new
+module per subsystem, no changes to the public MCP surface.
+
+### Storage: `query_events` table
+
+Lives in the existing synapse DB at `<project>/.neuralmind/synapses.db`
+to share the connection / WAL setup. Schema (added via
+`CREATE TABLE IF NOT EXISTS`, no migration framework needed yet):
+
+```sql
+CREATE TABLE IF NOT EXISTS query_events (
+  id           INTEGER PRIMARY KEY AUTOINCREMENT,
+  ts           REAL NOT NULL,             -- unix timestamp
+  session_id   TEXT NOT NULL,             -- Claude Code session id
+  tool         TEXT NOT NULL,             -- 'wakeup' | 'query'
+  query_hash   TEXT,                      -- sha1(query text), null for wakeup
+  query_text   TEXT,                      -- truncated to 512 chars, null for wakeup
+  layers_used  TEXT,                      -- JSON array, e.g. '["L0","L1","L2"]'
+  recall_nodes TEXT,                      -- JSON array of node ids
+  community_id TEXT,                      -- primary community touched, if any
+  escalated_l3 INTEGER NOT NULL DEFAULT 0 -- 1 if L3 was used
+);
+CREATE INDEX IF NOT EXISTS idx_query_events_session ON query_events(session_id, ts);
+CREATE INDEX IF NOT EXISTS idx_query_events_community ON query_events(community_id);
+```
+
+Retention: cap at 50k rows per project, prune oldest on insert past
+threshold (cheap, no separate cron).
+
+Writer: `neuralmind/query_log.py` (new). Single function
+`record_query_event(...)` — opens the existing synapse DB, inserts,
+commits. Stdlib-only, parallels `synapses.py` style.
+
+### Hook point
+
+`hooks.py` already registers PostToolUse hooks. Add one for
+`neuralmind_query` and `neuralmind_wakeup` that calls
+`record_query_event`. The tool's response already contains
+`layers_used` and the node ids — no change to the tool body required.
+
+This keeps query logging entirely in the hook layer, so users who
+disable hooks (`NEURALMIND_QUERY_LOG=0`) lose self-improvement but
+retain core behavior.
+
+## Subsystem A: selector auto-tuning
+
+Module: `neuralmind/selector_tuning.py` (new). Read-side; no LLM calls.
+
+### What it tunes
+
+Two scalars per project, persisted in the existing `meta` table of
+the synapse DB:
+
+- `l2_recall_k` — how many community summaries to include in L2
+  (currently a hard-coded constant in `context_selector.py`).
+- `l3_escalation_threshold` — score below which we escalate to L3
+  deep search.
+
+### Tuning rule (deliberately simple)
+
+Run once per session-end (hook into SessionEnd or recompute at
+SessionStart from accumulated `query_events`):
+
+```
+window = last 200 query_events
+if rate(escalated_l3) > 0.4:
+    l3_escalation_threshold *= 0.95   # escalate more eagerly
+    l2_recall_k = min(l2_recall_k + 1, 12)
+elif rate(escalated_l3) < 0.1 and rate(re_query) < 0.05:
+    l3_escalation_threshold *= 1.05   # tighten
+    l2_recall_k = max(l2_recall_k - 1, 3)
+```
+
+Bounded, hysteretic, cheap. Nothing fancy until subsystem C exists to
+score it.
+
+### Warm-up
+
+Tuner refuses to act until `query_events` has ≥50 rows. Until then,
+hard-coded defaults stand.
+
+### Toggle
+
+`NEURALMIND_SELECTOR_AUTOTUNE=1` (default off until we've observed it
+on real traffic for a week).
+
+### Read path integration
+
+`context_selector.py` reads `l2_recall_k` and `l3_escalation_threshold`
+from the meta table at construction time. One read per `get_context`
+call is fine; the values change at most once per session.
+
+## Subsystem B: L2 summary refinement
+
+Module: `neuralmind/summary_refiner.py` (new). Write-side; LLM cost.
+
+### Trigger
+
+A community C is enqueued for refinement when, over the last 200
+`query_events` touching C:
+
+- escalation-to-L3 rate ≥ 0.5, AND
+- ≥ 10 events touched C (avoid refining on tiny samples).
+
+### Refinement
+
+1. Pull the current community summary from ChromaDB (via
+   `embedder.get_community_summary()` at `embedder.py:360-408`).
+2. Pull the top-N node bodies that recent L3 escalations actually
+   surfaced for queries touching C — these are what the agent
+   *needed* but didn't get from the summary.
+3. Prompt: re-summarize C such that the surfaced bodies' key
+   properties are recoverable from the summary. Same model used for
+   the original summarization pass (so cost/format match).
+4. **A/B promote, don't replace.** Write the new summary as
+   `summary_candidate` in ChromaDB metadata alongside the existing
+   `summary`. Tag with `candidate_since_ts`.
+5. After 50 more events touching C, compare L3 escalation rate when
+   the candidate was used vs. baseline. If candidate's rate is
+   lower, promote (overwrite `summary`, drop candidate). If not,
+   discard the candidate and add a cool-down on C to avoid
+   thrashing.
+
+### Where it runs
+
+Refinement is *not* on the hot path. Two options:
+
+- **Watcher hook** — `FileActivityWatcher` already has a debounce
+  loop (`watcher.py:88-100`). Piggyback: after the file activity
+  flush, drain a small refinement queue (≤1 community per flush).
+  Pro: no new process. Con: refinement only happens when there's
+  also file activity.
+- **CLI subcommand** — `neuralmind refine` runs a bounded pass;
+  user or cron triggers it. Pro: deterministic. Con: needs scheduling.
+
+D2 builds the watcher hook variant first; CLI subcommand is a small
+addition on top.
+
+### Toggle
+
+`NEURALMIND_REFINE_SUMMARIES=0` by default. Refinement does an LLM
+call per community; users should opt in explicitly.
+
+### Failure modes
+
+- LLM call fails → log, leave existing summary, retry next eligible
+  trigger. Don't block the watcher.
+- ChromaDB upsert fails → roll back the candidate write, keep the
+  existing summary intact.
+- A/B verdict noisy on low-traffic communities → require ≥50
+  candidate-served events before deciding; until then, both stay.
+
+## Subsystem C: closed-loop eval-driven tuning (later)
+
+Depends on `evals/faithfulness/` shipping (see
+`evals/faithfulness/PLAN.md`).
+
+A nightly job:
+
+1. Snapshot current `(l2_recall_k, l3_escalation_threshold,
+   synapse decay rate, recall threshold)` as the baseline.
+2. Sweep small perturbations (one or two params at a time, 3-point
+   grid).
+3. Re-run the faithfulness eval against the cached question set.
+4. Promote the perturbation that improves the
+   correctness-vs-tokens frontier; otherwise revert.
+
+Out of scope for this plan beyond noting the integration points.
+Subsystems A and B are designed to read their tunables from the meta
+table, so subsystem C can write to the same place without touching
+A or B's code.
+
+## Configuration surface
+
+| Env var                          | Default | What it controls                    |
+| -------------------------------- | ------- | ----------------------------------- |
+| `NEURALMIND_QUERY_LOG`           | `1`     | Record `query_events` at all       |
+| `NEURALMIND_SELECTOR_AUTOTUNE`   | `0`     | Subsystem A active                  |
+| `NEURALMIND_REFINE_SUMMARIES`    | `0`     | Subsystem B active                  |
+| `NEURALMIND_QUERY_LOG_RETENTION` | `50000` | Max rows in `query_events`          |
+
+Goal: ship the logging on by default, tuning behaviors gated.
+
+## Observability
+
+A small `neuralmind self-improve status` CLI subcommand prints:
+
+- query_events row count, oldest / newest timestamps
+- current `l2_recall_k`, `l3_escalation_threshold`
+- recent L3 escalation rate, re-query rate
+- pending refinement candidates and their A/B status
+
+Read-only. Useful for debugging and for the eventual subsystem C
+diagnosis.
+
+## Test strategy
+
+Tests are stdlib-only, like `tests/synapse_*` — don't drag in the
+full dep set.
+
+- `tests/test_query_log.py` — schema creation, insert, retention
+  trim, JSON round-trip.
+- `tests/test_selector_tuning.py` — synthetic event streams,
+  assert tuning rule produces expected scalar movement.
+- `tests/test_summary_refiner_logic.py` — mock the LLM call and
+  ChromaDB; assert candidate is written, A/B promotion logic
+  fires correctly, cool-down respected.
+
+Integration test on the bundled sample fixture
+(`neuralmind/demo_data/sample_project/`): run a synthetic session of
+queries, verify a `query_events` row count of N, verify autotune
+moves scalars in the expected direction.
+
+## D1 deliverable (detailed)
+
+In one branch, `claude/self-improvement-d1` (forked from
+`claude/plan-next-task-nwJak` once we start coding):
+
+1. **`neuralmind/query_log.py`** — `init_schema(conn)`,
+   `record_query_event(...)`, `recent_events(window)`,
+   `prune_to(retention)`. Reuses `synapses.default_db_path()` and
+   the same connection-open helper.
+2. **Schema bootstrap** — call `init_schema` from
+   `synapses.SynapseStore.__init__` so a single open creates both
+   sets of tables. No separate migration.
+3. **Hook integration** — extend `hooks.py` PostToolUse handlers to
+   record an event after `neuralmind_query` and `neuralmind_wakeup`.
+   Read `tool_response.layers_used`, recall node ids, and escalation
+   flag. Gate behind `NEURALMIND_QUERY_LOG`.
+4. **Tests** — `tests/test_query_log.py` covering insert, JSON
+   columns, retention trim, idempotent schema creation.
+5. **No behavior change** for users with the env var unset
+   (default is on, but the table is just inert append).
+
+D1 ships nothing user-visible — purely the data layer that A, B, C
+all depend on. This is intentional: gives us a logging substrate to
+start collecting signal *while* we build A and B.
+
+## D2 / D3 (sketch only)
+
+- **D2:** subsystem A — `selector_tuning.py`, meta-table reads from
+  `context_selector.py`, tests, `neuralmind self-improve status`
+  subcommand stub.
+- **D3:** subsystem B — `summary_refiner.py`, watcher hook,
+  candidate/A-B logic, mocked LLM tests. Refinement disabled by
+  default.
+
+## Risks / open decisions
+
+- **Privacy.** `query_text` is stored truncated; do we even need it?
+  D1 stores it; we can drop the column in a follow-up if we decide
+  `query_hash` is sufficient. Decision deferred to D2 when we see
+  what tuning actually needs.
+- **DB contention.** Synapse store already takes the lock for
+  Hebbian writes; query event writes are short and append-only, so
+  contention should be negligible, but worth measuring on D1.
+- **Project relocation.** The DB lives under `<project>/.neuralmind/`
+  — moving the project moves the history. Acceptable for now.
+- **Multi-machine sync.** Out of scope. Self-improvement is
+  per-checkout. If we want shared learning across a team later,
+  that's a separate design.

--- a/evals/self_improvement/PLAN.md
+++ b/evals/self_improvement/PLAN.md
@@ -1,7 +1,8 @@
 # Self-improvement engine — plan
 
-Status: proposed. Sequencing: subsystems A and B first (~2–3 days),
-then closed-loop tuning (subsystem C) once `evals/faithfulness/` lands.
+Status: D1 landed (memory substrate), D2 landed (subsystem A, scoped to
+`l2_recall_k`). Next: D3 (subsystem B, L2 summary refinement), then
+closed-loop tuning (subsystem C) once `evals/faithfulness/` lands.
 
 ## Goal
 
@@ -97,9 +98,12 @@ Four small gaps:
    - else a process-lifetime uuid generated lazily (one per
      `NeuralMind` instance).
 
-3. **Derived `escalated_l3` flag.** Trivially `"L3" in layers_used`,
-   but surface as a helper so subsystem A reads through one
-   function rather than re-implementing the predicate.
+3. **Derived `escalated_l3` flag.** Surfaced as the `escalation_rate`
+   helper so subsystem A reads through one function rather than
+   re-implementing the predicate. (D1 implemented the predicate as a
+   bare `"L3" in layers_used` membership check; that never matched —
+   real `layers_used` elements are decorated, e.g.
+   `"L3:Search(4 results)"`. D2 fixed it to match by `"L3"` prefix.)
 
 4. **Aggregation helpers in `memory.py`.** Subsystem A's tuning rule
    needs:
@@ -113,13 +117,14 @@ Four small gaps:
    (not a new module) so future readers find aggregation logic next
    to the storage that produces it.
 
-### Tunables storage (subsystem A, later)
+### Tunables storage (subsystem A)
 
-`l2_recall_k` and `l3_escalation_threshold` will live in the
-existing `meta` table of `synapses.db` — that's already a
-key-value scratchpad and avoids introducing a third storage
-location. Subsystem C, when it lands, writes there too. (D1 does
-not touch the meta table.)
+Tunables live in the existing `meta` table of `synapses.db` — already
+a key-value scratchpad, avoids a third storage location. D2 added
+`get_meta`/`set_meta` helpers and stores `l2_recall_k` +
+`l2_recall_k_tuned_at` there. An `l3_escalation_threshold` would live
+here too if/when the L3 gate is built. Subsystem C, when it lands,
+writes here as well. (D1 does not touch the meta table.)
 
 ### Why not hooks
 
@@ -134,53 +139,93 @@ The plan's earlier draft proposed PostToolUse hooks on
   installed; in-process logging works for any caller (CLI, MCP,
   programmatic).
 
-## Subsystem A: selector auto-tuning
+## Subsystem A: selector auto-tuning  (D2 — landed)
 
-Module: `neuralmind/selector_tuning.py` (new). Read-side; no LLM calls.
+Module: `neuralmind/self_improve.py`. Read-side; no LLM calls.
+
+### Scope: `l2_recall_k` only
+
+The original draft tuned **two** scalars — `l2_recall_k` and an
+`l3_escalation_threshold`. D2 ships only `l2_recall_k`.
+
+`l3_escalation_threshold` was dropped because **it does not exist**:
+L3 deep search runs unconditionally whenever there's a query
+(`context_selector.py`). Introducing a threshold below which L3 is
+*skipped* is net-new behavior, not the tuning of an existing knob —
+and skipping L3 risks correctness. That gate is **deferred** until
+`evals/faithfulness/` can validate it's safe. Until then there is no
+L3 escalation threshold to tune.
+
+A knock-on consequence: `escalation_rate` is useless as a tuning
+signal while L3 is ungated (it fires on ~every query). So D2's rule
+is driven by `re_query_rate` instead.
 
 ### What it tunes
 
-Two scalars per project, persisted in the existing `meta` table of
+One scalar per project, persisted in the existing `meta` table of
 the synapse DB:
 
-- `l2_recall_k` — how many community summaries to include in L2
-  (currently a hard-coded constant in `context_selector.py`).
-- `l3_escalation_threshold` — score below which we escalate to L3
-  deep search.
+- `l2_recall_k` — how many community summaries L2 surfaces per query
+  (was a hard-coded `3` in `context_selector.py`).
+
+`l2_recall_k_tuned_at` is also stored — an ISO timestamp of the last
+change, used both as a diagnostic and to window the tuning signal.
 
 ### Tuning rule (deliberately simple)
 
-Run once per session-end (hook into SessionEnd or recompute at
-SessionStart from accumulated `query_events`):
+Runs once per session at SessionStart, recomputed from accumulated
+`query_events`:
 
 ```
-window = last 200 query_events
-if rate(escalated_l3) > 0.4:
-    l3_escalation_threshold *= 0.95   # escalate more eagerly
-    l2_recall_k = min(l2_recall_k + 1, 12)
-elif rate(escalated_l3) < 0.1 and rate(re_query) < 0.05:
-    l3_escalation_threshold *= 1.05   # tighten
-    l2_recall_k = max(l2_recall_k - 1, 3)
+events  = project query_events
+if len(events) < 50:            hold        # warm-up gate
+window  = events since l2_recall_k_tuned_at  (else last 200)
+if len(window) < 20:            hold        # insufficient recent signal
+rate    = re_query_rate(window)
+if   rate > 0.40:  l2_recall_k = min(l2_recall_k + 1, 6)   # under-disclosing
+elif rate < 0.15:  l2_recall_k = max(l2_recall_k - 1, 2)   # over-disclosing
+else:              hold                                    # dead band
 ```
 
-Bounded, hysteretic, cheap. Nothing fancy until subsystem C exists to
-score it.
+Bounded `[2, 6]`, default `3`, single-step moves, hysteretic dead
+band. The `0.15` / `0.40` thresholds are provisional guesses —
+`re_query_rate` is a weak, noisy signal, which is exactly why the
+tuner is off by default. Subsystem C replaces the hand-tuned rule
+with an eval-driven one.
+
+`tune_selector()` never raises (fail-open — safe for the hook path).
+
+### Why window the signal
+
+The window is keyed off `l2_recall_k_tuned_at` so the tuner doesn't
+chase a distribution it just perturbed: raising `l2_recall_k` changes
+`communities_loaded`, which feeds `re_query_rate` — a self-referential
+loop. Windowing + dead band + single-step + once-per-session cadence
+dampen it. The `< 20` window guard handles the common post-tune case
+where the window is empty (no fresh events yet) — an empty window
+means "no signal, hold", not "rate is 0.0, lower it".
 
 ### Warm-up
 
-Tuner refuses to act until `query_events` has ≥50 rows. Until then,
-hard-coded defaults stand.
+Tuner refuses to act until `query_events` has ≥50 rows, and until the
+windowed slice has ≥20. Until then, the default (`3`) stands.
 
 ### Toggle
 
-`NEURALMIND_SELECTOR_AUTOTUNE=1` (default off until we've observed it
-on real traffic for a week).
+`NEURALMIND_SELECTOR_AUTOTUNE=1` (default off). Opt-in `== "1"` rather
+than the `!= "0"` pattern used elsewhere, because this is net behavior
+change. Wired into the SessionStart hook after the synapse decay tick;
+tuner failures are swallowed so the hook always exits 0.
 
 ### Read path integration
 
-`context_selector.py` reads `l2_recall_k` and `l3_escalation_threshold`
-from the meta table at construction time. One read per `get_context`
-call is fine; the values change at most once per session.
+`core.NeuralMind.build()` reads `l2_recall_k` from the synapse meta
+table (via the existing lazy `self.synapses` property) and passes it
+to the `ContextSelector` constructor, which clamps it defensively.
+Read once at construction, not per `get_context` call: the value
+changes at most once per session (in the SessionStart tuner tick), so
+a per-call DB read would be pure overhead. The read path is fully
+guarded — a missing DB falls back to the default.
 
 ## Subsystem B: L2 summary refinement
 
@@ -275,28 +320,32 @@ Goal: ship the logging on by default, tuning behaviors gated.
 
 ## Observability
 
-A small `neuralmind self-improve status` CLI subcommand prints:
+`neuralmind self-improve status [project]` (landed in D2, read-only,
+`--json` supported) prints:
 
-- query_events row count, oldest / newest timestamps
-- current `l2_recall_k`, `l3_escalation_threshold`
-- recent L3 escalation rate, re-query rate
-- pending refinement candidates and their A/B status
+- current `l2_recall_k` and when it was last tuned
+- total query_events count + whether the warm-up gate is cleared
+- events in the current tuning window
+- windowed `re_query_rate`
+- whether `NEURALMIND_SELECTOR_AUTOTUNE` is enabled
 
-Read-only. Useful for debugging and for the eventual subsystem C
-diagnosis.
+Nested under a `self-improve` parser so D3 / subsystem C can attach
+their own sub-actions. D3 will extend `status` with pending refinement
+candidates and their A/B state.
 
 ## Test strategy
 
 Tests are stdlib-only, like `tests/synapse_*` — don't drag in the
 full dep set.
 
-- `tests/test_query_log.py` — schema creation, insert, retention
-  trim, JSON round-trip.
-- `tests/test_selector_tuning.py` — synthetic event streams,
-  assert tuning rule produces expected scalar movement.
+- `tests/test_memory.py` — event schema, insert, JSON round-trip,
+  aggregation helpers (D1).
+- `tests/test_self_improve.py` — synthetic event streams; assert the
+  `_decide` rule and `tune_selector` produce expected `l2_recall_k`
+  movement, warm-up / window guards hold, fail-open on bad input (D2).
 - `tests/test_summary_refiner_logic.py` — mock the LLM call and
   ChromaDB; assert candidate is written, A/B promotion logic
-  fires correctly, cool-down respected.
+  fires correctly, cool-down respected (D3).
 
 Integration test on the bundled sample fixture
 (`neuralmind/demo_data/sample_project/`): run a synthetic session of
@@ -348,11 +397,14 @@ Developed on `claude/plan-next-task-nwJak`. Extends the existing
 D1 ships nothing user-visible — purely fills gaps in the data layer
 that subsystems A and B will read.
 
-## D2 / D3 (sketch only)
+## D2 (landed) / D3 (sketch only)
 
-- **D2:** subsystem A — `selector_tuning.py`, meta-table reads from
-  `context_selector.py`, tests, `neuralmind self-improve status`
-  subcommand stub.
+- **D2 (landed):** subsystem A — `self_improve.py` (`tune_selector`,
+  `selector_report`), `get_meta`/`set_meta` on `SynapseStore`,
+  `l2_recall_k` threaded through `core.py` → `ContextSelector`,
+  SessionStart hook integration, `neuralmind self-improve status`
+  CLI subcommand, and the D1 `escalation_rate` bug fix. Scoped to
+  `l2_recall_k`; the L3 gate is deferred (see Subsystem A).
 - **D3:** subsystem B — `summary_refiner.py`, watcher hook,
   candidate/A-B logic, mocked LLM tests. Refinement disabled by
   default.

--- a/neuralmind/cli.py
+++ b/neuralmind/cli.py
@@ -325,6 +325,30 @@ def cmd_learn(args):
             print(f"  {pair}: {count} times")
 
 
+def cmd_self_improve_status(args):
+    """Show the self-improvement engine's current selector tuning state."""
+    import os
+
+    from .self_improve import selector_report
+
+    project_path = Path(args.project_path).resolve()
+    report = selector_report(project_path)
+    autotune_on = os.environ.get("NEURALMIND_SELECTOR_AUTOTUNE") == "1"
+
+    if args.json:
+        report["autotune_enabled"] = autotune_on
+        print(json.dumps(report, indent=2))
+        return
+
+    print(f"Project: {project_path.name}")
+    print(f"Autotune enabled: {autotune_on} (NEURALMIND_SELECTOR_AUTOTUNE)")
+    print(f"l2_recall_k: {report['l2_recall_k']}")
+    print(f"Last tuned at: {report['l2_recall_k_tuned_at'] or 'never'}")
+    print(f"Events logged: {report['total_events']} (warmed up: {report['warmed_up']})")
+    print(f"Events in tuning window: {report['windowed_events']}")
+    print(f"re_query_rate: {report['re_query_rate']:.3f}")
+
+
 def cmd_skeleton(args):
     """Return a graph-backed compact view of a file."""
     from .core import create_mind
@@ -739,6 +763,19 @@ def main():
     )
     learn_p.add_argument("project_path")
     learn_p.set_defaults(func=cmd_learn)
+
+    # Self-improvement engine — nested so future subsystems can attach here.
+    self_improve_p = subparsers.add_parser(
+        "self-improve", help="Inspect the self-improvement engine"
+    )
+    self_improve_sub = self_improve_p.add_subparsers(dest="self_improve_command")
+    self_improve_p.set_defaults(func=lambda _a: self_improve_p.print_help())
+    si_status_p = self_improve_sub.add_parser(
+        "status", help="Show selector auto-tuning state"
+    )
+    si_status_p.add_argument("project_path", nargs="?", default=".")
+    si_status_p.add_argument("--json", "-j", action="store_true")
+    si_status_p.set_defaults(func=cmd_self_improve_status)
 
     # Init-hook command
     init_parser = subparsers.add_parser(

--- a/neuralmind/cli.py
+++ b/neuralmind/cli.py
@@ -344,8 +344,8 @@ def cmd_self_improve_status(args):
     print(f"Autotune enabled: {autotune_on} (NEURALMIND_SELECTOR_AUTOTUNE)")
     print(f"l2_recall_k: {report['l2_recall_k']}")
     print(f"Last tuned at: {report['l2_recall_k_tuned_at'] or 'never'}")
-    print(f"Events logged: {report['total_events']} (warmed up: {report['warmed_up']})")
-    print(f"Events in tuning window: {report['windowed_events']}")
+    print(f"Query events logged: {report['total_events']} (warmed up: {report['warmed_up']})")
+    print(f"Query events in tuning window: {report['windowed_events']}")
     print(f"re_query_rate: {report['re_query_rate']:.3f}")
 
 

--- a/neuralmind/cli.py
+++ b/neuralmind/cli.py
@@ -770,9 +770,7 @@ def main():
     )
     self_improve_sub = self_improve_p.add_subparsers(dest="self_improve_command")
     self_improve_p.set_defaults(func=lambda _a: self_improve_p.print_help())
-    si_status_p = self_improve_sub.add_parser(
-        "status", help="Show selector auto-tuning state"
-    )
+    si_status_p = self_improve_sub.add_parser("status", help="Show selector auto-tuning state")
     si_status_p.add_argument("project_path", nargs="?", default=".")
     si_status_p.add_argument("--json", "-j", action="store_true")
     si_status_p.set_defaults(func=cmd_self_improve_status)

--- a/neuralmind/context_selector.py
+++ b/neuralmind/context_selector.py
@@ -90,7 +90,17 @@ class ContextSelector:
     # Chars per token estimate
     CHARS_PER_TOKEN = 4
 
-    def __init__(self, embedder, project_path: str = None, enable_reranking: bool = True):
+    # L2 community recall count. Default; overridden per-project by the
+    # self-improvement tuner via the constructor.
+    L2_RECALL_K_DEFAULT = 3
+
+    def __init__(
+        self,
+        embedder,
+        project_path: str = None,
+        enable_reranking: bool = True,
+        l2_recall_k: int = L2_RECALL_K_DEFAULT,
+    ):
         """
         Initialize context selector.
 
@@ -98,6 +108,8 @@ class ContextSelector:
             embedder: GraphEmbedder instance with loaded embeddings
             project_path: Path to project root (for reading metadata files)
             enable_reranking: If True, apply learned patterns to rerank L3 search results
+            l2_recall_k: Number of L2 community summaries to surface per query.
+                Tuned per-project by the self-improvement engine; clamped here.
         """
         self.embedder = embedder
         # Handle project_path - can be string, Path, or get from embedder
@@ -113,6 +125,12 @@ class ContextSelector:
             )
         else:
             self.project_path = Path.cwd()
+
+        # L2 recall count, defensively clamped against bad persisted values.
+        try:
+            self.l2_recall_k = max(1, min(int(l2_recall_k), 10))
+        except (TypeError, ValueError):
+            self.l2_recall_k = self.L2_RECALL_K_DEFAULT
 
         # Reranking configuration
         self.enable_reranking = enable_reranking
@@ -464,7 +482,7 @@ class ContextSelector:
 
         # L2: On-demand (requires query)
         if include_l2 and query:
-            l2, comms = self.get_l2_context(query)
+            l2, comms = self.get_l2_context(query, max_communities=self.l2_recall_k)
             if l2:
                 budget.l2_ondemand = self._estimate_tokens(l2)
                 context_parts.append(l2)

--- a/neuralmind/core.py
+++ b/neuralmind/core.py
@@ -199,9 +199,24 @@ class NeuralMind:
         # Embed nodes
         embed_stats = self.embedder.embed_nodes(force=force)
 
-        # Initialize selector with reranking
+        # Initialize selector with reranking. l2_recall_k is tuned per-project
+        # by the self-improvement engine and persisted in the synapse meta
+        # table; fall back to the selector default if it's absent or unreadable.
+        l2_recall_k = ContextSelector.L2_RECALL_K_DEFAULT
+        try:
+            store = self.synapses
+            if store is not None:
+                persisted = store.get_meta("l2_recall_k")
+                if persisted is not None:
+                    l2_recall_k = int(persisted)
+        except Exception:
+            l2_recall_k = ContextSelector.L2_RECALL_K_DEFAULT
+
         self.selector = ContextSelector(
-            self.embedder, str(self.project_path), enable_reranking=self.enable_reranking
+            self.embedder,
+            str(self.project_path),
+            enable_reranking=self.enable_reranking,
+            l2_recall_k=l2_recall_k,
         )
 
         # Get final stats

--- a/neuralmind/core.py
+++ b/neuralmind/core.py
@@ -29,7 +29,7 @@ from pathlib import Path
 from .audit import get_audit_trail
 from .backend_manager import BackendManager
 from .context_selector import ContextResult, ContextSelector
-from .memory import is_memory_logging_enabled, log_query_event
+from .memory import is_memory_logging_enabled, log_query_event, log_wakeup_event
 from .synapses import SynapseStore, default_db_path
 
 DEFAULT_HYBRID_HIGHLIGHT_COUNT = 3
@@ -253,6 +253,7 @@ class NeuralMind:
         """
         self._ensure_built()
         result = self.selector.get_wakeup_context()
+        log_wakeup_event(self.project_path, result)
         self._emit_audit(
             category="audit",
             action="wakeup",

--- a/neuralmind/hooks.py
+++ b/neuralmind/hooks.py
@@ -265,6 +265,15 @@ def run_hook(action: str) -> int:
             store.decay()
         except Exception:
             pass
+        # Self-improvement engine: tune the selector from logged usage.
+        # Opt-in (not the != "0" pattern) because it is net behavior change.
+        if os.environ.get("NEURALMIND_SELECTOR_AUTOTUNE") == "1":
+            try:
+                from .self_improve import tune_selector
+
+                tune_selector(cwd)
+            except Exception:
+                pass
         if os.environ.get("NEURALMIND_SYNAPSE_EXPORT") != "0":
             try:
                 from .synapse_memory import export_synapse_memory

--- a/neuralmind/memory.py
+++ b/neuralmind/memory.py
@@ -281,7 +281,7 @@ def escalation_rate(events: list[dict[str, Any]]) -> float:
         1
         for e in queries
         if any(
-            str(layer).startswith("L3")
+            str(layer) == "L3" or str(layer).startswith("L3:")
             for layer in (e.get("retrieval_summary") or {}).get("layers_used", [])
         )
     )
@@ -300,19 +300,27 @@ def re_query_rate(events: list[dict[str, Any]]) -> float:
     for e in events:
         if e.get("event_type") != "query":
             continue
-        sid = e.get("session_id") or ""
+        sid = e.get("session_id")
+        if not sid:
+            # Pre-D1 events have no session_id. Without one we can't tell
+            # which queries were truly consecutive, so skip them rather
+            # than lumping unrelated history under a shared empty-string key.
+            continue
         queries_by_session.setdefault(sid, []).append(e)
 
     re_query_count = 0
     pairs = 0
     for qs in queries_by_session.values():
         for i in range(1, len(qs)):
-            pairs += 1
             prev = set((qs[i - 1].get("retrieval_summary") or {}).get("communities_loaded", []))
             cur = set((qs[i].get("retrieval_summary") or {}).get("communities_loaded", []))
             denom = min(len(prev), len(cur))
             if denom == 0:
+                # A pair where either query loaded no communities carries
+                # no overlap signal either way — it must not count toward
+                # the denominator, or it would deflate the rate.
                 continue
+            pairs += 1
             if len(prev & cur) / denom >= 0.5:
                 re_query_count += 1
     return (re_query_count / pairs) if pairs else 0.0

--- a/neuralmind/memory.py
+++ b/neuralmind/memory.py
@@ -308,12 +308,8 @@ def re_query_rate(events: list[dict[str, Any]]) -> float:
     for qs in queries_by_session.values():
         for i in range(1, len(qs)):
             pairs += 1
-            prev = set(
-                (qs[i - 1].get("retrieval_summary") or {}).get("communities_loaded", [])
-            )
-            cur = set(
-                (qs[i].get("retrieval_summary") or {}).get("communities_loaded", [])
-            )
+            prev = set((qs[i - 1].get("retrieval_summary") or {}).get("communities_loaded", []))
+            cur = set((qs[i].get("retrieval_summary") or {}).get("communities_loaded", []))
             denom = min(len(prev), len(cur))
             if denom == 0:
                 continue

--- a/neuralmind/memory.py
+++ b/neuralmind/memory.py
@@ -4,12 +4,31 @@ from __future__ import annotations
 
 import json
 import os
+import uuid
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
 CONSENT_FILE_NAME = "memory_consent.json"
 QUERY_EVENTS_FILE_NAME = "query_events.jsonl"
+
+_PROCESS_SESSION_ID: str | None = None
+
+
+def _current_session_id() -> str:
+    """Resolve a session id for event logging.
+
+    Honors CLAUDE_SESSION_ID when set so events from one Claude Code
+    session group together. Otherwise generates a stable per-process
+    uuid so programmatic / CLI callers still get session grouping.
+    """
+    env = os.environ.get("CLAUDE_SESSION_ID")
+    if env:
+        return env
+    global _PROCESS_SESSION_ID
+    if _PROCESS_SESSION_ID is None:
+        _PROCESS_SESSION_ID = str(uuid.uuid4())
+    return _PROCESS_SESSION_ID
 
 
 def _is_disabled(env_name: str) -> bool:
@@ -107,7 +126,12 @@ def count_events(path: Path) -> int:
         return sum(1 for line in file if line.strip())
 
 
-def log_query_event(project_path: str | Path, question: str, result: Any) -> bool:
+def log_query_event(
+    project_path: str | Path,
+    question: str,
+    result: Any,
+    session_id: str | None = None,
+) -> bool:
     if not is_memory_logging_enabled():
         return False
 
@@ -115,6 +139,7 @@ def log_query_event(project_path: str | Path, question: str, result: Any) -> boo
         "event_type": "query",
         "timestamp": datetime.now(timezone.utc).isoformat(),
         "project_path": str(Path(project_path).resolve()),
+        "session_id": session_id or _current_session_id(),
         "query": question,
         "retrieval_summary": {
             "layers_used": list(getattr(result, "layers_used", [])),
@@ -122,6 +147,40 @@ def log_query_event(project_path: str | Path, question: str, result: Any) -> boo
             "search_hits": int(getattr(result, "search_hits", 0)),
             "tokens": int(getattr(getattr(result, "budget", None), "total", 0)),
             "reduction_ratio": float(getattr(result, "reduction_ratio", 0.0)),
+        },
+    }
+
+    try:
+        _append_jsonl(project_query_events_file(project_path), event)
+        _append_jsonl(global_query_events_file(), event)
+    except Exception:
+        return False
+    return True
+
+
+def log_wakeup_event(
+    project_path: str | Path,
+    result: Any,
+    session_id: str | None = None,
+) -> bool:
+    """Log a wakeup (L0+L1) event.
+
+    Distinct from query events because wakeups have no question and a
+    fixed layer set; the value is in the *absence* of a follow-up query
+    in the same session — that's the "L0/L1 was sufficient" signal the
+    selector tuner reads.
+    """
+    if not is_memory_logging_enabled():
+        return False
+
+    event = {
+        "event_type": "wakeup",
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "project_path": str(Path(project_path).resolve()),
+        "session_id": session_id or _current_session_id(),
+        "retrieval_summary": {
+            "layers_used": list(getattr(result, "layers_used", [])),
+            "tokens": int(getattr(getattr(result, "budget", None), "total", 0)),
         },
     }
 
@@ -162,6 +221,122 @@ def read_query_events(events_file: Path) -> list[dict[str, Any]]:
         pass
 
     return events
+
+
+def read_events(events_file: Path) -> list[dict[str, Any]]:
+    """Read all events (query + wakeup) from JSONL file.
+
+    Unlike read_query_events, this does not filter by event_type, so
+    aggregation helpers can compute cross-event-type signals like
+    wakeup_only_rate.
+    """
+    if not events_file.exists():
+        return []
+
+    events: list[dict[str, Any]] = []
+    try:
+        with events_file.open(encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    events.append(json.loads(line))
+                except json.JSONDecodeError:
+                    continue
+    except Exception:
+        pass
+    return events
+
+
+def recent_events(
+    events: list[dict[str, Any]],
+    *,
+    since_ts: str | None = None,
+    last_n: int | None = None,
+) -> list[dict[str, Any]]:
+    """Slice an event list by ISO timestamp window and/or trailing count."""
+    out = events
+    if since_ts is not None:
+        out = [e for e in out if (e.get("timestamp") or "") >= since_ts]
+    if last_n is not None:
+        out = out[-last_n:]
+    return out
+
+
+def escalation_rate(events: list[dict[str, Any]]) -> float:
+    """Fraction of *query* events whose layers_used includes L3.
+
+    L3 is the deep-search layer; high escalation suggests L2 community
+    summaries are under-recalling for the query distribution.
+    """
+    queries = [e for e in events if e.get("event_type") == "query"]
+    if not queries:
+        return 0.0
+    escalated = sum(
+        1
+        for e in queries
+        if "L3" in (e.get("retrieval_summary") or {}).get("layers_used", [])
+    )
+    return escalated / len(queries)
+
+
+def re_query_rate(events: list[dict[str, Any]]) -> float:
+    """Fraction of consecutive same-session queries with high overlap.
+
+    Two queries in the same session whose communities_loaded sets
+    overlap by >=50% (of the smaller set) suggest the first query
+    under-disclosed and the agent had to come back. Computed only over
+    consecutive query pairs, indexed by session_id.
+    """
+    queries_by_session: dict[str, list[dict[str, Any]]] = {}
+    for e in events:
+        if e.get("event_type") != "query":
+            continue
+        sid = e.get("session_id") or ""
+        queries_by_session.setdefault(sid, []).append(e)
+
+    re_query_count = 0
+    pairs = 0
+    for qs in queries_by_session.values():
+        for i in range(1, len(qs)):
+            pairs += 1
+            prev = set(
+                (qs[i - 1].get("retrieval_summary") or {}).get("communities_loaded", [])
+            )
+            cur = set(
+                (qs[i].get("retrieval_summary") or {}).get("communities_loaded", [])
+            )
+            denom = min(len(prev), len(cur))
+            if denom == 0:
+                continue
+            if len(prev & cur) / denom >= 0.5:
+                re_query_count += 1
+    return (re_query_count / pairs) if pairs else 0.0
+
+
+def wakeup_only_rate(events: list[dict[str, Any]]) -> float:
+    """Fraction of sessions whose only events are wakeups (no queries).
+
+    The positive signal for L0/L1 sufficiency: the agent woke up,
+    received the cheap context, and never needed a query.
+    """
+    sessions: dict[str, dict[str, int]] = {}
+    for e in events:
+        sid = e.get("session_id")
+        if not sid:
+            continue
+        kind = e.get("event_type")
+        if kind not in ("wakeup", "query"):
+            continue
+        slot = sessions.setdefault(sid, {"wakeup": 0, "query": 0})
+        slot[kind] += 1
+
+    eligible = [s for s in sessions.values() if s["wakeup"] >= 1]
+    if not eligible:
+        return 0.0
+    wakeup_only = sum(1 for s in eligible if s["query"] == 0)
+    return wakeup_only / len(eligible)
 
 
 def extract_module_ids_from_event(event: dict[str, Any]) -> list[str]:

--- a/neuralmind/memory.py
+++ b/neuralmind/memory.py
@@ -269,6 +269,10 @@ def escalation_rate(events: list[dict[str, Any]]) -> float:
 
     L3 is the deep-search layer; high escalation suggests L2 community
     summaries are under-recalling for the query distribution.
+
+    layers_used elements are decorated strings produced by the selector
+    (e.g. "L3:Search(4 results)"), so match by prefix rather than exact
+    membership.
     """
     queries = [e for e in events if e.get("event_type") == "query"]
     if not queries:
@@ -276,7 +280,10 @@ def escalation_rate(events: list[dict[str, Any]]) -> float:
     escalated = sum(
         1
         for e in queries
-        if "L3" in (e.get("retrieval_summary") or {}).get("layers_used", [])
+        if any(
+            str(layer).startswith("L3")
+            for layer in (e.get("retrieval_summary") or {}).get("layers_used", [])
+        )
     )
     return escalated / len(queries)
 

--- a/neuralmind/self_improve.py
+++ b/neuralmind/self_improve.py
@@ -68,22 +68,26 @@ def _read_current_k(store: SynapseStore) -> int:
 def _compute(project_path: str | Path, store: SynapseStore) -> dict:
     """Shared read-side computation for both tune_selector and selector_report.
 
-    Returns the current k, the windowed re_query_rate, and the total event
-    count — without writing anything.
+    Returns the current k, the windowed re_query_rate, and the query-event
+    counts — without writing anything.
     """
     events = read_events(project_query_events_file(project_path))
-    total = len(events)
+    # The warm-up / window gates and the signal both key off *query*
+    # events only. Wakeup events share the same JSONL file but carry no
+    # re_query signal — counting them toward the thresholds would let the
+    # tuner act (and drift `l2_recall_k` down) without query evidence.
+    queries = [e for e in events if e.get("event_type") == "query"]
     current = _read_current_k(store)
 
     since = store.get_meta(META_KEY_TUNED_AT)
     if since:
-        window = recent_events(events, since_ts=since)
+        window = recent_events(queries, since_ts=since)
     else:
-        window = recent_events(events, last_n=FALLBACK_WINDOW)
+        window = recent_events(queries, last_n=FALLBACK_WINDOW)
 
     return {
         "current": current,
-        "total_events": total,
+        "total_events": len(queries),
         "windowed_events": len(window),
         "re_query_rate": re_query_rate(window),
     }

--- a/neuralmind/self_improve.py
+++ b/neuralmind/self_improve.py
@@ -42,6 +42,12 @@ L2_RECALL_K_MAX = 6
 WARMUP_MIN_EVENTS = 50
 FALLBACK_WINDOW = 200
 
+# Minimum events *in the tuning window* for re_query_rate to carry signal.
+# Guards the common post-tune case: the window is keyed off the last tune
+# timestamp, so right after a tune (before fresh events arrive) it is
+# empty — and an empty window must mean "hold", not "rate is 0.0".
+WINDOW_MIN_EVENTS = 20
+
 # Provisional thresholds — re_query_rate is a weak, noisy signal and these
 # bounds are unvalidated guesses. Subsystem C (eval-driven tuning) will
 # replace this hand-tuned rule with a real fitness function.
@@ -112,6 +118,16 @@ def tune_selector(project_path: str | Path, *, now: datetime | None = None) -> d
                 "new": current,
                 "reason": "warmup",
                 "events": stats["total_events"],
+                "re_query_rate": stats["re_query_rate"],
+            }
+
+        if stats["windowed_events"] < WINDOW_MIN_EVENTS:
+            return {
+                "changed": False,
+                "old": current,
+                "new": current,
+                "reason": "insufficient_recent",
+                "events": stats["windowed_events"],
                 "re_query_rate": stats["re_query_rate"],
             }
 

--- a/neuralmind/self_improve.py
+++ b/neuralmind/self_improve.py
@@ -1,0 +1,165 @@
+"""
+self_improve.py — selector auto-tuning (self-improvement engine, subsystem A)
+
+NeuralMind logs query/wakeup events (see memory.py). This module reads the
+aggregated signal back and adjusts one selector parameter — `l2_recall_k`,
+the number of L2 community summaries surfaced per query — persisting it in
+the synapse store's meta table so it carries across sessions.
+
+The tuner is deliberately conservative:
+- driven by re_query_rate (consecutive same-session queries with high
+  community overlap → the agent had to come back → under-disclosure);
+- bounded to [L2_RECALL_K_MIN, L2_RECALL_K_MAX] with a single-step move;
+- a dead band between the two thresholds so it doesn't oscillate;
+- a warm-up gate so it never acts on thin data;
+- events windowed to *since the last tune* so it doesn't chase a
+  distribution it just perturbed.
+
+It is gated OFF by default at the call site (the SessionStart hook only
+runs it when NEURALMIND_SELECTOR_AUTOTUNE=1).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+from .memory import (
+    project_query_events_file,
+    re_query_rate,
+    read_events,
+    recent_events,
+)
+from .synapses import SynapseStore, default_db_path
+
+META_KEY = "l2_recall_k"
+META_KEY_TUNED_AT = "l2_recall_k_tuned_at"
+
+L2_RECALL_K_DEFAULT = 3
+L2_RECALL_K_MIN = 2
+L2_RECALL_K_MAX = 6
+
+WARMUP_MIN_EVENTS = 50
+FALLBACK_WINDOW = 200
+
+# Provisional thresholds — re_query_rate is a weak, noisy signal and these
+# bounds are unvalidated guesses. Subsystem C (eval-driven tuning) will
+# replace this hand-tuned rule with a real fitness function.
+RE_QUERY_RATE_HIGH = 0.40
+RE_QUERY_RATE_LOW = 0.15
+
+
+def _read_current_k(store: SynapseStore) -> int:
+    raw = store.get_meta(META_KEY)
+    if raw is None:
+        return L2_RECALL_K_DEFAULT
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return L2_RECALL_K_DEFAULT
+
+
+def _compute(project_path: str | Path, store: SynapseStore) -> dict:
+    """Shared read-side computation for both tune_selector and selector_report.
+
+    Returns the current k, the windowed re_query_rate, and the total event
+    count — without writing anything.
+    """
+    events = read_events(project_query_events_file(project_path))
+    total = len(events)
+    current = _read_current_k(store)
+
+    since = store.get_meta(META_KEY_TUNED_AT)
+    if since:
+        window = recent_events(events, since_ts=since)
+    else:
+        window = recent_events(events, last_n=FALLBACK_WINDOW)
+
+    return {
+        "current": current,
+        "total_events": total,
+        "windowed_events": len(window),
+        "re_query_rate": re_query_rate(window),
+    }
+
+
+def _decide(current: int, rate: float) -> tuple[int, str]:
+    """Apply the bounded, hysteretic tuning rule. Returns (new_k, reason)."""
+    if rate > RE_QUERY_RATE_HIGH:
+        new = min(current + 1, L2_RECALL_K_MAX)
+        return new, ("raised" if new != current else "at_max")
+    if rate < RE_QUERY_RATE_LOW:
+        new = max(current - 1, L2_RECALL_K_MIN)
+        return new, ("lowered" if new != current else "at_min")
+    return current, "dead_band"
+
+
+def tune_selector(project_path: str | Path, *, now: datetime | None = None) -> dict:
+    """Read recent events, adjust l2_recall_k, persist to the synapse meta table.
+
+    Never raises — any failure returns {"changed": False, "reason": "error"}.
+    Safe to call from the SessionStart hook.
+    """
+    try:
+        store = SynapseStore(default_db_path(project_path))
+        stats = _compute(project_path, store)
+        current = stats["current"]
+
+        if stats["total_events"] < WARMUP_MIN_EVENTS:
+            return {
+                "changed": False,
+                "old": current,
+                "new": current,
+                "reason": "warmup",
+                "events": stats["total_events"],
+                "re_query_rate": stats["re_query_rate"],
+            }
+
+        new, reason = _decide(current, stats["re_query_rate"])
+        changed = new != current
+        if changed:
+            ts = (now or datetime.now(timezone.utc)).isoformat()
+            store.set_meta(META_KEY, str(new))
+            store.set_meta(META_KEY_TUNED_AT, ts)
+
+        return {
+            "changed": changed,
+            "old": current,
+            "new": new,
+            "reason": reason,
+            "events": stats["windowed_events"],
+            "re_query_rate": stats["re_query_rate"],
+        }
+    except Exception:
+        return {
+            "changed": False,
+            "old": L2_RECALL_K_DEFAULT,
+            "new": L2_RECALL_K_DEFAULT,
+            "reason": "error",
+            "events": 0,
+            "re_query_rate": 0.0,
+        }
+
+
+def selector_report(project_path: str | Path) -> dict:
+    """Read-only view of the tuner state for the CLI. Never writes, never raises."""
+    try:
+        store = SynapseStore(default_db_path(project_path))
+        stats = _compute(project_path, store)
+        return {
+            "l2_recall_k": stats["current"],
+            "l2_recall_k_tuned_at": store.get_meta(META_KEY_TUNED_AT),
+            "total_events": stats["total_events"],
+            "windowed_events": stats["windowed_events"],
+            "re_query_rate": stats["re_query_rate"],
+            "warmed_up": stats["total_events"] >= WARMUP_MIN_EVENTS,
+        }
+    except Exception:
+        return {
+            "l2_recall_k": L2_RECALL_K_DEFAULT,
+            "l2_recall_k_tuned_at": None,
+            "total_events": 0,
+            "windowed_events": 0,
+            "re_query_rate": 0.0,
+            "warmed_up": False,
+        }

--- a/neuralmind/synapses.py
+++ b/neuralmind/synapses.py
@@ -220,6 +220,21 @@ class SynapseStore:
             remaining = cur.fetchone()[0]
         return {"pruned": pruned, "remaining": remaining}
 
+    def get_meta(self, key: str, default: str | None = None) -> str | None:
+        """Read a value from the key-value meta table."""
+        with self._connect() as conn:
+            cur = conn.execute("SELECT value FROM meta WHERE key = ?", (key,))
+            row = cur.fetchone()
+            return row[0] if row else default
+
+    def set_meta(self, key: str, value: str) -> None:
+        """Write a value to the key-value meta table."""
+        with self._connect() as conn:
+            conn.execute(
+                "INSERT OR REPLACE INTO meta(key, value) VALUES (?, ?)",
+                (key, str(value)),
+            )
+
     def neighbors(self, node_id: str, k: int = 5) -> list[tuple[str, float]]:
         """Return the strongest neighbors of a single node."""
         with self._connect() as conn:

--- a/neuralmind/synapses.py
+++ b/neuralmind/synapses.py
@@ -227,8 +227,8 @@ class SynapseStore:
             row = cur.fetchone()
             return row[0] if row else default
 
-    def set_meta(self, key: str, value: str) -> None:
-        """Write a value to the key-value meta table."""
+    def set_meta(self, key: str, value: object) -> None:
+        """Write a value to the key-value meta table (coerced to str)."""
         with self._connect() as conn:
             conn.execute(
                 "INSERT OR REPLACE INTO meta(key, value) VALUES (?, ?)",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -844,3 +844,51 @@ class TestCLIDemo:
         assert "How does authentication work" in captured.out
         assert "API endpoints" in captured.out
         assert "billing flow" in captured.out
+
+
+class TestCLISelfImprove:
+    """Tests for the self-improve status CLI command."""
+
+    def test_status_human_readable(self, tmp_path, capsys):
+        from neuralmind.cli import cmd_self_improve_status
+
+        args = MagicMock()
+        args.project_path = str(tmp_path)
+        args.json = False
+
+        cmd_self_improve_status(args)
+
+        captured = capsys.readouterr()
+        assert "l2_recall_k: 3" in captured.out
+        assert "Autotune enabled: False" in captured.out
+        assert "never" in captured.out
+
+    def test_status_json_output(self, tmp_path, capsys):
+        from neuralmind.cli import cmd_self_improve_status
+
+        args = MagicMock()
+        args.project_path = str(tmp_path)
+        args.json = True
+
+        cmd_self_improve_status(args)
+
+        captured = capsys.readouterr()
+        report = json.loads(captured.out)
+        assert report["l2_recall_k"] == 3
+        assert report["warmed_up"] is False
+        assert report["autotune_enabled"] is False
+
+    def test_status_reflects_tuned_value(self, tmp_path, capsys):
+        from neuralmind.cli import cmd_self_improve_status
+        from neuralmind.synapses import SynapseStore, default_db_path
+
+        SynapseStore(default_db_path(tmp_path)).set_meta("l2_recall_k", "5")
+
+        args = MagicMock()
+        args.project_path = str(tmp_path)
+        args.json = True
+
+        cmd_self_improve_status(args)
+
+        report = json.loads(capsys.readouterr().out)
+        assert report["l2_recall_k"] == 5

--- a/tests/test_context_selector.py
+++ b/tests/test_context_selector.py
@@ -752,9 +752,7 @@ class TestL2RecallKTuning:
         selector = ContextSelector(mock_embedder, str(temp_project), l2_recall_k="bogus")
         assert selector.l2_recall_k == ContextSelector.L2_RECALL_K_DEFAULT
 
-    def test_get_context_forwards_l2_recall_k_to_get_l2_context(
-        self, mock_embedder, temp_project
-    ):
+    def test_get_context_forwards_l2_recall_k_to_get_l2_context(self, mock_embedder, temp_project):
         """get_context must pass self.l2_recall_k through as max_communities."""
         from neuralmind.context_selector import ContextSelector
 

--- a/tests/test_context_selector.py
+++ b/tests/test_context_selector.py
@@ -723,3 +723,51 @@ class TestRerankerIntegration:
 
         # Should respect n parameter even after reranking
         assert hits <= 3
+
+
+class TestL2RecallKTuning:
+    """Tests for the tunable l2_recall_k parameter (self-improvement engine)."""
+
+    def test_defaults_to_three(self, mock_embedder, temp_project):
+        from neuralmind.context_selector import ContextSelector
+
+        selector = ContextSelector(mock_embedder, str(temp_project))
+        assert selector.l2_recall_k == 3
+
+    def test_accepts_tuned_value(self, mock_embedder, temp_project):
+        from neuralmind.context_selector import ContextSelector
+
+        selector = ContextSelector(mock_embedder, str(temp_project), l2_recall_k=5)
+        assert selector.l2_recall_k == 5
+
+    def test_clamps_out_of_range_values(self, mock_embedder, temp_project):
+        from neuralmind.context_selector import ContextSelector
+
+        assert ContextSelector(mock_embedder, str(temp_project), l2_recall_k=99).l2_recall_k == 10
+        assert ContextSelector(mock_embedder, str(temp_project), l2_recall_k=0).l2_recall_k == 1
+
+    def test_falls_back_on_non_numeric_value(self, mock_embedder, temp_project):
+        from neuralmind.context_selector import ContextSelector
+
+        selector = ContextSelector(mock_embedder, str(temp_project), l2_recall_k="bogus")
+        assert selector.l2_recall_k == ContextSelector.L2_RECALL_K_DEFAULT
+
+    def test_get_context_forwards_l2_recall_k_to_get_l2_context(
+        self, mock_embedder, temp_project
+    ):
+        """get_context must pass self.l2_recall_k through as max_communities."""
+        from neuralmind.context_selector import ContextSelector
+
+        selector = ContextSelector(mock_embedder, str(temp_project), l2_recall_k=5)
+
+        captured = {}
+        original = selector.get_l2_context
+
+        def spy(query, max_communities=3):
+            captured["max_communities"] = max_communities
+            return original(query, max_communities=max_communities)
+
+        selector.get_l2_context = spy
+        selector.get_context(query="how does auth work", include_l3=False)
+
+        assert captured["max_communities"] == 5

--- a/tests/test_hooks_synapses.py
+++ b/tests/test_hooks_synapses.py
@@ -105,6 +105,69 @@ def test_session_start_export_disabled_via_env(tmp_path, monkeypatch):
     assert not out.exists()
 
 
+def _write_query_events(project_path, n):
+    """Write n high-overlap query events so the tuner has warm-up data."""
+    from neuralmind.memory import project_query_events_file
+
+    path = project_query_events_file(project_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    event = {
+        "event_type": "query",
+        "timestamp": "2026-05-07T00:00:00+00:00",
+        "session_id": "s",
+        "retrieval_summary": {
+            "layers_used": ["L0:Identity", "L1:Summary", "L2:OnDemand(3 clusters)"],
+            "communities_loaded": [1, 2],
+        },
+    }
+    with path.open("w", encoding="utf-8") as f:
+        for _ in range(n):
+            f.write(json.dumps(event) + "\n")
+
+
+def test_session_start_runs_tuner_when_autotune_enabled(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path / "home"))
+    monkeypatch.setenv("NEURALMIND_SELECTOR_AUTOTUNE", "1")
+    _write_query_events(tmp_path, 60)  # high-overlap → tuner raises k
+
+    rc, _ = _run("session-start", {"cwd": str(tmp_path)})
+    assert rc == 0
+
+    store = SynapseStore(default_db_path(tmp_path))
+    assert store.get_meta("l2_recall_k") == "4"
+
+
+def test_session_start_skips_tuner_when_autotune_disabled(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path / "home"))
+    monkeypatch.delenv("NEURALMIND_SELECTOR_AUTOTUNE", raising=False)
+    _write_query_events(tmp_path, 60)
+
+    rc, _ = _run("session-start", {"cwd": str(tmp_path)})
+    assert rc == 0
+
+    store = SynapseStore(default_db_path(tmp_path))
+    assert store.get_meta("l2_recall_k") is None
+
+
+def test_session_start_survives_tuner_failure(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path / "home"))
+    monkeypatch.setenv("NEURALMIND_SELECTOR_AUTOTUNE", "1")
+
+    import neuralmind.self_improve as si
+
+    def boom(*_a, **_k):
+        raise RuntimeError("tuner exploded")
+
+    monkeypatch.setattr(si, "tune_selector", boom)
+
+    # Hook must still return 0 — tuner failures are swallowed.
+    rc, _ = _run("session-start", {"cwd": str(tmp_path)})
+    assert rc == 0
+
+
 def test_pre_compact_normalizes_hubs(tmp_path):
     db = default_db_path(tmp_path)
     store = SynapseStore(db)

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -247,6 +247,14 @@ class TestMemoryAggregations:
         assert memory.escalation_rate([]) == 0.0
         assert memory.escalation_rate([self._w("s")]) == 0.0
 
+    def test_escalation_rate_does_not_match_l3_prefix_collision(self):
+        """The predicate must match the L3 layer exactly ("L3" or
+        "L3:..."), not any string that merely starts with "L3"."""
+        from neuralmind import memory
+
+        events = [self._q("s", ["L0:Identity", "L30:Hypothetical"], [1])]
+        assert memory.escalation_rate(events) == 0.0
+
     def test_re_query_rate_counts_high_overlap_consecutive_queries(self):
         from neuralmind import memory
 
@@ -267,6 +275,39 @@ class TestMemoryAggregations:
             self._q("a", ["L0"], [1]),
             self._q("b", ["L0"], [1]),  # different session, not a pair
         ]
+        assert memory.re_query_rate(events) == 0.0
+
+    def test_re_query_rate_excludes_empty_community_pairs(self):
+        """A pair where either query loaded no communities carries no
+        overlap signal — it must not count toward the denominator."""
+        from neuralmind import memory
+
+        events = [
+            self._q("a", ["L0", "L1", "L2"], []),  # no communities
+            self._q("a", ["L0", "L1", "L2"], [1, 2]),  # denom == 0 for this pair
+            self._q("a", ["L0", "L1", "L2"], [1, 2]),  # real pair, full overlap
+        ]
+        # Only the (a:1, a:2) pair carries signal → 1/1, not 1/2.
+        assert memory.re_query_rate(events) == 1.0
+
+    def test_re_query_rate_skips_events_without_session_id(self):
+        """Events with no session_id (pre-D1 logs) can't be ordered into
+        sessions and must be skipped, not lumped under one shared key."""
+        from neuralmind import memory
+
+        events = [
+            {
+                "event_type": "query",
+                "timestamp": "2026-05-07T00:00:00+00:00",
+                "retrieval_summary": {"communities_loaded": [1, 2]},
+            },
+            {
+                "event_type": "query",
+                "timestamp": "2026-05-07T00:01:00+00:00",
+                "retrieval_summary": {"communities_loaded": [1, 2]},
+            },
+        ]
+        # Without session_id these are not a valid consecutive pair.
         assert memory.re_query_rate(events) == 0.0
 
     def test_wakeup_only_rate(self):

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -67,6 +67,203 @@ class TestMemoryLogging:
         assert payload["retrieval_summary"]["search_hits"] == 3
 
 
+class TestSessionId:
+    """Tests for session id resolution used by event logging."""
+
+    def test_session_id_honors_claude_session_env(self, monkeypatch):
+        from neuralmind import memory
+
+        monkeypatch.setenv("CLAUDE_SESSION_ID", "abc-123")
+        assert memory._current_session_id() == "abc-123"
+
+    def test_session_id_falls_back_to_stable_process_uuid(self, monkeypatch):
+        from neuralmind import memory
+
+        monkeypatch.delenv("CLAUDE_SESSION_ID", raising=False)
+        monkeypatch.setattr(memory, "_PROCESS_SESSION_ID", None)
+        first = memory._current_session_id()
+        second = memory._current_session_id()
+        assert first == second
+        assert len(first) > 0
+
+
+class TestWakeupLogging:
+    """Tests for wakeup event logging."""
+
+    def _result(self):
+        from neuralmind.context_selector import ContextResult, TokenBudget
+
+        return ContextResult(
+            context="ctx",
+            budget=TokenBudget(l0_identity=10, l1_summary=20),
+            layers_used=["L0", "L1"],
+            communities_loaded=[],
+            search_hits=0,
+            reduction_ratio=0.0,
+        )
+
+    def test_log_wakeup_event_writes_project_and_global_jsonl(
+        self, monkeypatch, tmp_path
+    ):
+        from neuralmind import memory
+
+        project_path = tmp_path / "project"
+        project_path.mkdir()
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setenv("USERPROFILE", str(tmp_path))
+        monkeypatch.setenv("CLAUDE_SESSION_ID", "session-1")
+        memory.write_consent_sentinel(True)
+
+        logged = memory.log_wakeup_event(project_path, self._result())
+        assert logged is True
+
+        line = (
+            memory.project_query_events_file(project_path)
+            .read_text(encoding="utf-8")
+            .strip()
+            .splitlines()[0]
+        )
+        payload = json.loads(line)
+        assert payload["event_type"] == "wakeup"
+        assert payload["session_id"] == "session-1"
+        assert payload["retrieval_summary"]["layers_used"] == ["L0", "L1"]
+        assert "query" not in payload
+
+    def test_log_wakeup_event_without_consent_is_noop(self, monkeypatch, tmp_path):
+        from neuralmind import memory
+
+        project_path = tmp_path / "project"
+        project_path.mkdir()
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setenv("USERPROFILE", str(tmp_path))
+        # No consent written.
+
+        assert memory.log_wakeup_event(project_path, self._result()) is False
+        assert not memory.project_query_events_file(project_path).exists()
+
+    def test_log_query_event_includes_session_id(self, monkeypatch, tmp_path):
+        from neuralmind import memory
+        from neuralmind.context_selector import ContextResult, TokenBudget
+
+        project_path = tmp_path / "project"
+        project_path.mkdir()
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setenv("USERPROFILE", str(tmp_path))
+        monkeypatch.setenv("CLAUDE_SESSION_ID", "session-q")
+        memory.write_consent_sentinel(True)
+
+        result = ContextResult(
+            context="c",
+            budget=TokenBudget(l0_identity=10),
+            layers_used=["L0", "L1", "L2", "L3"],
+            communities_loaded=[1],
+            search_hits=2,
+            reduction_ratio=4.0,
+        )
+        memory.log_query_event(project_path, "q", result)
+
+        payload = json.loads(
+            memory.project_query_events_file(project_path)
+            .read_text(encoding="utf-8")
+            .strip()
+            .splitlines()[0]
+        )
+        assert payload["session_id"] == "session-q"
+
+
+class TestMemoryAggregations:
+    """Tests for the aggregation helpers used by the selector tuner."""
+
+    def _q(self, session_id, layers, communities, ts="2026-05-07T00:00:00+00:00"):
+        return {
+            "event_type": "query",
+            "timestamp": ts,
+            "session_id": session_id,
+            "retrieval_summary": {
+                "layers_used": layers,
+                "communities_loaded": communities,
+            },
+        }
+
+    def _w(self, session_id, ts="2026-05-07T00:00:00+00:00"):
+        return {
+            "event_type": "wakeup",
+            "timestamp": ts,
+            "session_id": session_id,
+            "retrieval_summary": {"layers_used": ["L0", "L1"]},
+        }
+
+    def test_recent_events_filters_by_since_and_last_n(self):
+        from neuralmind import memory
+
+        events = [
+            self._q("s", ["L0"], [], ts="2026-05-01T00:00:00+00:00"),
+            self._q("s", ["L0"], [], ts="2026-05-05T00:00:00+00:00"),
+            self._q("s", ["L0"], [], ts="2026-05-07T00:00:00+00:00"),
+        ]
+        windowed = memory.recent_events(events, since_ts="2026-05-04T00:00:00+00:00")
+        assert len(windowed) == 2
+        last = memory.recent_events(events, last_n=1)
+        assert last[0]["timestamp"] == "2026-05-07T00:00:00+00:00"
+
+    def test_escalation_rate_only_counts_queries_with_l3(self):
+        from neuralmind import memory
+
+        events = [
+            self._q("s", ["L0", "L1", "L2"], [1]),
+            self._q("s", ["L0", "L1", "L2", "L3"], [1]),
+            self._q("s", ["L0", "L1", "L2", "L3"], [2]),
+            self._w("s"),  # wakeups don't count
+        ]
+        assert abs(memory.escalation_rate(events) - 2 / 3) < 1e-9
+
+    def test_escalation_rate_zero_on_empty(self):
+        from neuralmind import memory
+
+        assert memory.escalation_rate([]) == 0.0
+        assert memory.escalation_rate([self._w("s")]) == 0.0
+
+    def test_re_query_rate_counts_high_overlap_consecutive_queries(self):
+        from neuralmind import memory
+
+        events = [
+            self._q("a", ["L0", "L1", "L2"], [1, 2]),
+            self._q("a", ["L0", "L1", "L2"], [1, 2, 3]),  # 2/2 overlap → re-query
+            self._q("a", ["L0", "L1", "L2"], [9]),       # no overlap
+            self._q("b", ["L0", "L1", "L2"], [4]),
+            self._q("b", ["L0", "L1", "L2"], [4]),       # full overlap → re-query
+        ]
+        # Pairs: (a:0,a:1) re-query, (a:1,a:2) not, (b:0,b:1) re-query → 2/3
+        assert abs(memory.re_query_rate(events) - 2 / 3) < 1e-9
+
+    def test_re_query_rate_isolates_sessions(self):
+        from neuralmind import memory
+
+        events = [
+            self._q("a", ["L0"], [1]),
+            self._q("b", ["L0"], [1]),  # different session, not a pair
+        ]
+        assert memory.re_query_rate(events) == 0.0
+
+    def test_wakeup_only_rate(self):
+        from neuralmind import memory
+
+        events = [
+            self._w("s1"),                         # wakeup-only session
+            self._w("s2"),
+            self._q("s2", ["L0", "L1"], [1]),     # s2 had a query, not wakeup-only
+            self._q("s3", ["L0"], [1]),           # no wakeup → ineligible
+        ]
+        # Eligible (wakeup>=1): s1, s2. Wakeup-only: s1. → 1/2
+        assert abs(memory.wakeup_only_rate(events) - 0.5) < 1e-9
+
+    def test_wakeup_only_rate_zero_when_no_wakeups(self):
+        from neuralmind import memory
+
+        events = [self._q("s", ["L0"], [1])]
+        assert memory.wakeup_only_rate(events) == 0.0
+
+
 class TestMemoryPatternLearning:
     """Tests for cooccurrence pattern learning."""
 

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -210,12 +210,38 @@ class TestMemoryAggregations:
         from neuralmind import memory
 
         events = [
-            self._q("s", ["L0", "L1", "L2"], [1]),
-            self._q("s", ["L0", "L1", "L2", "L3"], [1]),
-            self._q("s", ["L0", "L1", "L2", "L3"], [2]),
+            self._q("s", ["L0:Identity", "L1:Summary", "L2:OnDemand(3 clusters)"], [1]),
+            self._q(
+                "s",
+                ["L0:Identity", "L1:Summary", "L2:OnDemand(3 clusters)", "L3:Search(4 results)"],
+                [1],
+            ),
+            self._q(
+                "s",
+                ["L0:Identity", "L1:Summary", "L2:OnDemand(2 clusters)", "L3:Search(4 results)"],
+                [2],
+            ),
             self._w("s"),  # wakeups don't count
         ]
         assert abs(memory.escalation_rate(events) - 2 / 3) < 1e-9
+
+    def test_escalation_rate_matches_decorated_layer_strings(self):
+        """layers_used elements are decorated by the selector — escalation_rate
+        must match the 'L3:Search(...)' prefix, not a bare 'L3' element."""
+        from neuralmind import memory
+
+        escalated = [
+            self._q(
+                "s",
+                ["L0:Identity", "L1:Summary", "L3:Search(4 results)"],
+                [1],
+            )
+        ]
+        not_escalated = [
+            self._q("s", ["L0:Identity", "L1:Summary", "L2:OnDemand(3 clusters)"], [1])
+        ]
+        assert memory.escalation_rate(escalated) == 1.0
+        assert memory.escalation_rate(not_escalated) == 0.0
 
     def test_escalation_rate_zero_on_empty(self):
         from neuralmind import memory

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -102,9 +102,7 @@ class TestWakeupLogging:
             reduction_ratio=0.0,
         )
 
-    def test_log_wakeup_event_writes_project_and_global_jsonl(
-        self, monkeypatch, tmp_path
-    ):
+    def test_log_wakeup_event_writes_project_and_global_jsonl(self, monkeypatch, tmp_path):
         from neuralmind import memory
 
         project_path = tmp_path / "project"
@@ -255,9 +253,9 @@ class TestMemoryAggregations:
         events = [
             self._q("a", ["L0", "L1", "L2"], [1, 2]),
             self._q("a", ["L0", "L1", "L2"], [1, 2, 3]),  # 2/2 overlap → re-query
-            self._q("a", ["L0", "L1", "L2"], [9]),       # no overlap
+            self._q("a", ["L0", "L1", "L2"], [9]),  # no overlap
             self._q("b", ["L0", "L1", "L2"], [4]),
-            self._q("b", ["L0", "L1", "L2"], [4]),       # full overlap → re-query
+            self._q("b", ["L0", "L1", "L2"], [4]),  # full overlap → re-query
         ]
         # Pairs: (a:0,a:1) re-query, (a:1,a:2) not, (b:0,b:1) re-query → 2/3
         assert abs(memory.re_query_rate(events) - 2 / 3) < 1e-9
@@ -275,10 +273,10 @@ class TestMemoryAggregations:
         from neuralmind import memory
 
         events = [
-            self._w("s1"),                         # wakeup-only session
+            self._w("s1"),  # wakeup-only session
             self._w("s2"),
-            self._q("s2", ["L0", "L1"], [1]),     # s2 had a query, not wakeup-only
-            self._q("s3", ["L0"], [1]),           # no wakeup → ineligible
+            self._q("s2", ["L0", "L1"], [1]),  # s2 had a query, not wakeup-only
+            self._q("s3", ["L0"], [1]),  # no wakeup → ineligible
         ]
         # Eligible (wakeup>=1): s1, s2. Wakeup-only: s1. → 1/2
         assert abs(memory.wakeup_only_rate(events) - 0.5) < 1e-9

--- a/tests/test_self_improve.py
+++ b/tests/test_self_improve.py
@@ -89,6 +89,30 @@ def test_warmup_gate_blocks_tuning_below_threshold(tmp_path):
     assert store.get_meta(META_KEY) is None
 
 
+def test_wakeup_events_do_not_count_toward_warmup(tmp_path):
+    """Only query events carry re_query signal — a project flooded with
+    wakeups but few queries must stay warmup-gated, not drift k down."""
+    project = tmp_path / "project"
+    project.mkdir()
+    wakeups = [
+        {
+            "event_type": "wakeup",
+            "timestamp": "2026-05-07T00:00:00+00:00",
+            "session_id": f"w{i}",
+            "retrieval_summary": {"layers_used": ["L0:Identity", "L1:Summary"]},
+        }
+        for i in range(100)
+    ]
+    queries = _query_events(10, communities=[1])  # well under WARMUP_MIN_EVENTS
+    _write_events(project, wakeups + queries)
+
+    result = tune_selector(project)
+    assert result["changed"] is False
+    assert result["reason"] == "warmup"
+    store = SynapseStore(default_db_path(project))
+    assert store.get_meta(META_KEY) is None
+
+
 def test_raise_path_persists_higher_k(tmp_path):
     project = tmp_path / "project"
     project.mkdir()

--- a/tests/test_self_improve.py
+++ b/tests/test_self_improve.py
@@ -1,0 +1,209 @@
+"""Tests for selector auto-tuning (self-improvement engine, subsystem A)."""
+
+from __future__ import annotations
+
+import json
+
+from neuralmind import self_improve
+from neuralmind.memory import project_query_events_file
+from neuralmind.self_improve import (
+    L2_RECALL_K_DEFAULT,
+    L2_RECALL_K_MAX,
+    L2_RECALL_K_MIN,
+    META_KEY,
+    META_KEY_TUNED_AT,
+    _decide,
+    selector_report,
+    tune_selector,
+)
+from neuralmind.synapses import SynapseStore, default_db_path
+
+
+def _write_events(project_path, events):
+    """Write query events straight to the JSONL file the tuner reads."""
+    path = project_query_events_file(project_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as f:
+        for e in events:
+            f.write(json.dumps(e) + "\n")
+
+
+def _query_events(n, *, session_id="s", communities, ts="2026-05-07T00:00:00+00:00"):
+    """n query events in one session, all with the same communities_loaded.
+
+    Identical communities → every consecutive pair fully overlaps →
+    re_query_rate == 1.0 (when n >= 2).
+    """
+    return [
+        {
+            "event_type": "query",
+            "timestamp": ts,
+            "session_id": session_id,
+            "retrieval_summary": {
+                "layers_used": ["L0:Identity", "L1:Summary", "L2:OnDemand(3 clusters)"],
+                "communities_loaded": list(communities),
+            },
+        }
+        for _ in range(n)
+    ]
+
+
+# --- _decide: the pure tuning rule ------------------------------------------
+
+
+def test_decide_raises_above_high_threshold():
+    assert _decide(3, 0.9) == (4, "raised")
+
+
+def test_decide_lowers_below_low_threshold():
+    assert _decide(3, 0.0) == (2, "lowered")
+
+
+def test_decide_holds_in_dead_band():
+    assert _decide(3, 0.25) == (3, "dead_band")
+
+
+def test_decide_caps_at_max():
+    assert _decide(L2_RECALL_K_MAX, 0.9) == (L2_RECALL_K_MAX, "at_max")
+
+
+def test_decide_floors_at_min():
+    assert _decide(L2_RECALL_K_MIN, 0.0) == (L2_RECALL_K_MIN, "at_min")
+
+
+# --- tune_selector: integration ---------------------------------------------
+
+
+def test_warmup_gate_blocks_tuning_below_threshold(tmp_path):
+    project = tmp_path / "project"
+    project.mkdir()
+    # 10 events — well under WARMUP_MIN_EVENTS.
+    _write_events(project, _query_events(10, communities=[1]))
+
+    result = tune_selector(project)
+
+    assert result["changed"] is False
+    assert result["reason"] == "warmup"
+    store = SynapseStore(default_db_path(project))
+    assert store.get_meta(META_KEY) is None
+
+
+def test_raise_path_persists_higher_k(tmp_path):
+    project = tmp_path / "project"
+    project.mkdir()
+    # 60 identical-community queries → re_query_rate == 1.0 → raise.
+    _write_events(project, _query_events(60, communities=[1, 2]))
+
+    result = tune_selector(project)
+
+    assert result["changed"] is True
+    assert result["reason"] == "raised"
+    assert result["old"] == L2_RECALL_K_DEFAULT
+    assert result["new"] == L2_RECALL_K_DEFAULT + 1
+    store = SynapseStore(default_db_path(project))
+    assert store.get_meta(META_KEY) == str(L2_RECALL_K_DEFAULT + 1)
+    assert store.get_meta(META_KEY_TUNED_AT) is not None
+
+
+def test_lower_path_persists_lower_k(tmp_path):
+    project = tmp_path / "project"
+    project.mkdir()
+    # 60 queries each touching a distinct community → no overlap → rate 0.0.
+    events = [
+        _query_events(1, session_id="s", communities=[i])[0] for i in range(60)
+    ]
+    _write_events(project, events)
+
+    result = tune_selector(project)
+
+    assert result["changed"] is True
+    assert result["reason"] == "lowered"
+    assert result["new"] == L2_RECALL_K_DEFAULT - 1
+    store = SynapseStore(default_db_path(project))
+    assert store.get_meta(META_KEY) == str(L2_RECALL_K_DEFAULT - 1)
+
+
+def test_step_is_bounded_to_one_per_tick(tmp_path):
+    project = tmp_path / "project"
+    project.mkdir()
+    _write_events(project, _query_events(60, communities=[1]))
+    # Pre-seed k at the default; one tick must move it by exactly 1.
+    store = SynapseStore(default_db_path(project))
+    store.set_meta(META_KEY, "3")
+
+    result = tune_selector(project)
+    assert result["new"] == 4
+
+
+def test_windowing_uses_last_tuned_at_timestamp(tmp_path):
+    project = tmp_path / "project"
+    project.mkdir()
+    # 40 old low-overlap events + 40 recent high-overlap events.
+    old = [
+        _query_events(1, session_id="old", communities=[i], ts="2026-01-01T00:00:00+00:00")[0]
+        for i in range(40)
+    ]
+    recent = _query_events(40, communities=[7], ts="2026-06-01T00:00:00+00:00")
+    _write_events(project, old + recent)
+
+    store = SynapseStore(default_db_path(project))
+    # Last tune happened between the two batches — only recent events count.
+    store.set_meta(META_KEY_TUNED_AT, "2026-03-01T00:00:00+00:00")
+
+    result = tune_selector(project)
+    # Window is the 40 recent high-overlap events, not all 80.
+    assert result["events"] == 40
+    assert result["reason"] == "raised"
+
+
+def test_tune_selector_fails_open_on_corrupt_events_file(tmp_path):
+    project = tmp_path / "project"
+    project.mkdir()
+    path = project_query_events_file(project)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("not json at all\n{partial", encoding="utf-8")
+
+    # read_events skips bad lines, so this degrades to "too few events".
+    result = tune_selector(project)
+    assert result["changed"] is False
+
+
+def test_tune_selector_never_raises_on_unwritable_db(tmp_path, monkeypatch):
+    project = tmp_path / "project"
+    project.mkdir()
+    _write_events(project, _query_events(60, communities=[1]))
+
+    def boom(*_a, **_k):
+        raise OSError("disk gone")
+
+    monkeypatch.setattr(self_improve.SynapseStore, "set_meta", boom)
+    result = tune_selector(project)
+    assert result["changed"] is False
+    assert result["reason"] == "error"
+
+
+# --- selector_report: read-only view ----------------------------------------
+
+
+def test_selector_report_is_read_only(tmp_path):
+    project = tmp_path / "project"
+    project.mkdir()
+    _write_events(project, _query_events(60, communities=[1]))
+
+    report = selector_report(project)
+    assert report["l2_recall_k"] == L2_RECALL_K_DEFAULT
+    assert report["total_events"] == 60
+    assert report["warmed_up"] is True
+    assert report["re_query_rate"] == 1.0
+    # Nothing was persisted.
+    store = SynapseStore(default_db_path(project))
+    assert store.get_meta(META_KEY) is None
+
+
+def test_selector_report_on_empty_project(tmp_path):
+    project = tmp_path / "project"
+    project.mkdir()
+    report = selector_report(project)
+    assert report["l2_recall_k"] == L2_RECALL_K_DEFAULT
+    assert report["total_events"] == 0
+    assert report["warmed_up"] is False

--- a/tests/test_self_improve.py
+++ b/tests/test_self_improve.py
@@ -12,6 +12,7 @@ from neuralmind.self_improve import (
     L2_RECALL_K_MIN,
     META_KEY,
     META_KEY_TUNED_AT,
+    WINDOW_MIN_EVENTS,
     _decide,
     selector_report,
     tune_selector,
@@ -154,6 +155,46 @@ def test_windowing_uses_last_tuned_at_timestamp(tmp_path):
     # Window is the 40 recent high-overlap events, not all 80.
     assert result["events"] == 40
     assert result["reason"] == "raised"
+
+
+def test_empty_window_after_tune_holds_instead_of_lowering(tmp_path):
+    """Regression: right after a tune, the window (keyed off the tune
+    timestamp) is empty until fresh events arrive. An empty window is
+    'no signal' — the tuner must hold, not read re_query_rate 0.0 as a
+    reason to lower k."""
+    project = tmp_path / "project"
+    project.mkdir()
+    _write_events(project, _query_events(60, communities=[1], ts="2026-05-07T00:00:00+00:00"))
+
+    store = SynapseStore(default_db_path(project))
+    # Last tune is dated *after* every logged event → window is empty.
+    store.set_meta(META_KEY_TUNED_AT, "2026-09-01T00:00:00+00:00")
+    store.set_meta(META_KEY, "4")
+
+    result = tune_selector(project)
+    assert result["changed"] is False
+    assert result["reason"] == "insufficient_recent"
+    assert store.get_meta(META_KEY) == "4"  # untouched
+
+
+def test_insufficient_recent_events_holds(tmp_path):
+    project = tmp_path / "project"
+    project.mkdir()
+    # 60 total events (passes warm-up) but fewer than WINDOW_MIN_EVENTS
+    # fall inside the post-tune window.
+    old = _query_events(
+        55, session_id="old", communities=[1], ts="2026-01-01T00:00:00+00:00"
+    )
+    recent = _query_events(
+        WINDOW_MIN_EVENTS - 1, communities=[1], ts="2026-06-01T00:00:00+00:00"
+    )
+    _write_events(project, old + recent)
+    store = SynapseStore(default_db_path(project))
+    store.set_meta(META_KEY_TUNED_AT, "2026-03-01T00:00:00+00:00")
+
+    result = tune_selector(project)
+    assert result["changed"] is False
+    assert result["reason"] == "insufficient_recent"
 
 
 def test_tune_selector_fails_open_on_corrupt_events_file(tmp_path):

--- a/tests/test_self_improve.py
+++ b/tests/test_self_improve.py
@@ -110,9 +110,7 @@ def test_lower_path_persists_lower_k(tmp_path):
     project = tmp_path / "project"
     project.mkdir()
     # 60 queries each touching a distinct community → no overlap → rate 0.0.
-    events = [
-        _query_events(1, session_id="s", communities=[i])[0] for i in range(60)
-    ]
+    events = [_query_events(1, session_id="s", communities=[i])[0] for i in range(60)]
     _write_events(project, events)
 
     result = tune_selector(project)
@@ -182,12 +180,8 @@ def test_insufficient_recent_events_holds(tmp_path):
     project.mkdir()
     # 60 total events (passes warm-up) but fewer than WINDOW_MIN_EVENTS
     # fall inside the post-tune window.
-    old = _query_events(
-        55, session_id="old", communities=[1], ts="2026-01-01T00:00:00+00:00"
-    )
-    recent = _query_events(
-        WINDOW_MIN_EVENTS - 1, communities=[1], ts="2026-06-01T00:00:00+00:00"
-    )
+    old = _query_events(55, session_id="old", communities=[1], ts="2026-01-01T00:00:00+00:00")
+    recent = _query_events(WINDOW_MIN_EVENTS - 1, communities=[1], ts="2026-06-01T00:00:00+00:00")
     _write_events(project, old + recent)
     store = SynapseStore(default_db_path(project))
     store.set_meta(META_KEY_TUNED_AT, "2026-03-01T00:00:00+00:00")

--- a/tests/test_synapses.py
+++ b/tests/test_synapses.py
@@ -146,3 +146,28 @@ def test_decay_constant_is_sane():
     # Sanity: a single decay tick on a max-weight non-LTP edge must not
     # immediately delete it. This guards against accidental config changes.
     assert WEIGHT_CAP * (1.0 - DECAY_RATE) > PRUNE_THRESHOLD
+
+
+def test_get_meta_returns_default_when_absent(tmp_path):
+    s = _store(tmp_path)
+    assert s.get_meta("l2_recall_k") is None
+    assert s.get_meta("l2_recall_k", "3") == "3"
+
+
+def test_set_meta_then_get_meta_round_trips(tmp_path):
+    s = _store(tmp_path)
+    s.set_meta("l2_recall_k", "4")
+    assert s.get_meta("l2_recall_k") == "4"
+
+
+def test_set_meta_overwrites_existing_value(tmp_path):
+    s = _store(tmp_path)
+    s.set_meta("l2_recall_k", "4")
+    s.set_meta("l2_recall_k", "5")
+    assert s.get_meta("l2_recall_k") == "5"
+
+
+def test_set_meta_coerces_non_string_values(tmp_path):
+    s = _store(tmp_path)
+    s.set_meta("l2_recall_k", 6)
+    assert s.get_meta("l2_recall_k") == "6"


### PR DESCRIPTION
## Summary

Phases 1–2 of the self-improvement engine — the outer loop that tunes
NeuralMind's retrieval behavior from observed agent usage. Both the
data layer and the first tuning loop ship **off by default**; there is
no behavior change for users who don't opt in.

- **Planning docs** — `evals/self_improvement/PLAN.md` (the full
  engine: subsystems A/B/C) and `evals/faithfulness/PLAN.md` (the eval
  that subsystem C will later use as a fitness function).
- **D1 — logging substrate** (`memory.py`): wakeup-event logging,
  `session_id` on events, and read-side aggregation helpers
  (`recent_events`, `escalation_rate`, `re_query_rate`,
  `wakeup_only_rate`).
- **D2 — subsystem A, selector auto-tuning**: a tuner that adjusts
  `l2_recall_k` (L2 community recall count) from `re_query_rate`,
  persisted across sessions in the synapse `meta` table.

## D2 details

- `synapses.py` — `get_meta`/`set_meta` helpers on `SynapseStore`.
- `self_improve.py` (new) — `tune_selector()` (re_query_rate-driven,
  bounded `[2,6]`, hysteretic dead band, 50-event warm-up, signal
  windowed off the last tune timestamp, fail-open) and
  `selector_report()`.
- `context_selector.py` + `core.py` — `l2_recall_k` threads from the
  synapse meta table through to `get_l2_context`, read once at
  construction, fully guarded against a missing DB.
- `hooks.py` — SessionStart runs the tuner when
  `NEURALMIND_SELECTOR_AUTOTUNE=1` (opt-in); tuner failures are
  swallowed so the hook always exits 0.
- `cli.py` — `neuralmind self-improve status [project]` (read-only,
  `--json`).
- **Bug fix** — D1's `escalation_rate` used a bare `"L3" in
  layers_used` check that never matched real decorated layer strings
  (`"L3:Search(...)"`); fixed to match by prefix.

## Scope notes

- D2 tunes **only `l2_recall_k`**. The originally-planned
  `l3_escalation_threshold` was dropped: L3 deep search currently runs
  unconditionally, so gating it is net-new behavior — deferred until
  `evals/faithfulness/` can validate it's safe. `PLAN.md` documents
  this.
- `re_query_rate` is a deliberately weak signal and the thresholds are
  provisional — which is exactly why the tuner is off by default.
  Subsystem C (eval-driven) is the real answer; D2 builds the
  mechanism.

## Test plan

- [x] Full suite green locally (pre-existing skips only: missing
  graphify fixtures, firewall-blocked S3 model download).
- [x] New coverage: `test_synapses.py` (meta helpers),
  `test_memory.py` (escalation_rate fix + D1 aggregations),
  `test_self_improve.py` (16 cases — rule, warm-up/window guards,
  windowing, fail-open), `test_context_selector.py` (l2_recall_k
  threading), `test_hooks_synapses.py` (autotune gate + fail-open),
  `test_cli.py` (status command).
- [x] Manual tuner round-trip: 60 high-overlap events → tick raises
  `l2_recall_k` 3→4 and persists; second tick correctly holds.

https://claude.ai/code/session_01KPSwpRuBicQJYjcwVcArnH

---
_Generated by [Claude Code](https://claude.ai/code/session_01KPSwpRuBicQJYjcwVcArnH)_