### PR TITLE
feat: Obsidian-style graph view (`neuralmind serve`) + editor jump, auth, layout persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,7 +456,39 @@ neuralmind init-hook .
 neuralmind wakeup .
 neuralmind query . "How does authentication work?"
 neuralmind skeleton src/auth/handlers.py
+
+# Or browse it: Obsidian-style graph view of your codebase + learned synapses
+neuralmind serve .
 ```
+
+---
+
+## 🕸️ Graph view (`neuralmind serve`)
+
+`neuralmind serve` opens a local web UI that makes the same index your AI agent
+queries inspectable by a human. Same ChromaDB index, same `synapses.db`, just
+made navigable.
+
+- **Force-directed graph** of code nodes coloured by community.
+- **Structural edges** (calls / imports) layered with the **Hebbian synapse overlay** —
+  edges thicken as the brain learns which nodes co-activate.
+- **Backlinks, outgoing links, and synaptic neighbours** for any node you click,
+  Obsidian-style.
+- **Semantic quick-switcher** — type a phrase, jump to the node.
+- **Open in editor** — click a node, opens `$EDITOR` (or `--editor code`/`cursor`/
+  `vim`/`subl`/`idea`) at the right file and line.
+- **Local-first**: stdlib HTTP server, vanilla-JS canvas, no CDN, per-session
+  access token bound to 127.0.0.1 by default.
+
+```bash
+neuralmind serve .                       # opens http://127.0.0.1:8765/?token=…
+neuralmind serve . --editor "code -n"    # override the editor
+neuralmind serve . --no-auth             # skip the token (trusted hosts only)
+```
+
+Why it matters: the agent-facing brain has always been a black box — you couldn't
+see what NeuralMind retrieved, whether the graph was reasonable, or what the
+synapse layer had actually learned. The graph view exposes all three.
 
 ---
 

--- a/docs/about.html
+++ b/docs/about.html
@@ -80,10 +80,11 @@
     <section>
         <div class="container">
             <h2>How We Solve It</h2>
-            <h3>Three-Phase Architecture</h3>
+            <h3>Four-Phase Architecture</h3>
             <p><strong>Phase 1 — Smart Retrieval:</strong> Instead of loading entire files, NeuralMind uses a 4-layer semantic index to surface only the ~800 tokens of code your question actually needs.</p>
             <p><strong>Phase 2 — Output Compression:</strong> PostToolUse hooks compress Read, Bash, and Grep output 88–91% smaller before agents see it.</p>
             <p><strong>Phase 3 — Brain-like Memory <em>(v0.4.0)</em>:</strong> A second brain runs alongside the LLM — a persistent weighted graph that learns associations between code nodes from how the agent and the codebase actually interact. Stronger connections form between code that gets used together, weaker ones decay, and the agent's prompts trigger spreading-activation recall over the learned graph.</p>
+            <p><strong>Phase 4 — Graph View <em>(new)</em>:</strong> <code>neuralmind serve</code> renders the whole system as an Obsidian-style force-directed graph in the browser. Structural edges, the learned synapse overlay, backlinks, a semantic quick-switcher, and one-click open-in-editor. The brain stops being a black box — you can finally see what it retrieved and what it has learned.</p>
             <p><strong>Result:</strong> 40–70× per-query token reduction (50K+ tokens of raw source compressed into ~800 tokens of structured context) and 40–70% bill drops on real codebases. Retrieval that gets sharper the longer the system runs on a codebase.</p>
 
             <h3>Enterprise Ready</h3>
@@ -122,6 +123,10 @@
             </ul>
             <p>The synapse store is local SQLite, project-scoped, and inspectable. It exports a markdown summary that Claude Code's auto-memory system loads natively, so the learned associations show up in every session — no MCP tool call required.</p>
 
+            <h3>Graph View — <code>neuralmind serve</code> <em>(new)</em></h3>
+            <p>The agent-facing brain is now also a human-facing tool. A stdlib HTTP server renders a force-directed graph of the entire codebase in the browser — structural edges (calls and imports) drawn together with the learned synapse overlay, where edge thickness encodes weight. Each node has Obsidian-style backlinks and outgoing-links panels, a "synaptic neighbours" list with weights and activation counts, and a one-click "open in editor" button (smart support for VS Code, Cursor, vim, sublime, JetBrains). A semantic quick-switcher lets you type a phrase and jump straight to the matching node. Zero CDN dependencies; per-session access token bound to 127.0.0.1.</p>
+            <p>Why it matters: NeuralMind's retrieval used to be a black box — the agent claimed to use it, but you couldn't see what was found, what was missed, or whether the synapse layer was actually learning. The graph view exposes the whole index so retrievals are inspectable, debuggable, and trustable.</p>
+
             <h3>Compliance-First Design</h3>
             <p>Every query is logged with full provenance: which code was retrieved, why, which embeddings were used, code state (git commit). Export for NIST AI RMF, SOC 2, GDPR, HIPAA.</p>
         </div>
@@ -146,14 +151,14 @@
     <section>
         <div class="container">
             <h2>Status & Roadmap</h2>
-            <h3>Current Release: v0.4.0 — Brain-like Synapse Layer</h3>
-            <p>Production-ready with NIST AI RMF audit trail, MCP security hardening, pluggable embedding backends, and the new brain-like synapse layer with always-on file watcher and Claude Code lifecycle hooks. Actively maintained and tested.</p>
+            <h3>Current Release: v0.6.0 — Graph View</h3>
+            <p>Adds <code>neuralmind serve</code>: a local, dependency-free, Obsidian-style graph view over the existing index and synapse store. Code nodes coloured by community; structural edges and Hebbian synapses drawn together; backlinks, synaptic neighbours, semantic quick-switch, and one-click open-in-editor. Builds on v0.5.x's bundled MCP server and v0.4.0's brain-like synapse layer — no migration needed.</p>
 
             <h3>Future Releases</h3>
             <ul>
-                <li><strong>v0.5.0 (Next)</strong> — MCP server bundled in the default install (no more <code>[mcp]</code> extra trap). Packaging-only release: the public API, CLI, MCP tools, hooks, and on-disk state are unchanged from v0.4.0.</li>
-                <li><strong>v0.5.x / v0.6.0</strong> — Auto-watcher launch from <code>SessionStart</code> (<a href="https://github.com/dfrostar/neuralmind/issues/78">#78</a>); synapse import/export so teams can share a learned brain (<a href="https://github.com/dfrostar/neuralmind/issues/79">#79</a>); benchmarks measuring retrieval quality with vs without synapses (<a href="https://github.com/dfrostar/neuralmind/issues/80">#80</a>); PostgreSQL pgvector scale testing; advanced observability dashboard; expanded backend ecosystem</li>
-                <li><strong>v1.0.0 (Target Q1 2027)</strong> — Stable API guarantee, 2-year LTS support, commercial support options</li>
+                <li><strong>v0.6.x</strong> — Live activity feed of synapse co-activations (the brain learning in real time), edge tooltips that explain "why are these two nodes related?", and a "replay last query" overlay that highlights the L3 hits the agent received.</li>
+                <li><strong>v0.7.0</strong> — Auto-watcher launch from <code>SessionStart</code> (<a href="https://github.com/dfrostar/neuralmind/issues/78">#78</a>); synapse import/export so teams can share a learned brain (<a href="https://github.com/dfrostar/neuralmind/issues/79">#79</a>); benchmarks measuring retrieval quality with vs without synapses (<a href="https://github.com/dfrostar/neuralmind/issues/80">#80</a>); PostgreSQL pgvector scale testing; expanded backend ecosystem.</li>
+                <li><strong>v1.0.0 (Target Q1 2027)</strong> — Stable API guarantee, 2-year LTS support, commercial support options.</li>
             </ul>
 
             <p><a href="../docs/FUTURE-PROOFING-PLAN.md">See the full roadmap →</a></p>

--- a/docs/index.html
+++ b/docs/index.html
@@ -131,6 +131,10 @@
                     <p>A persistent weighted graph runs alongside the LLM, learning Hebbian associations between co-active code nodes. Decay prunes stale links; long-term potentiation protects frequently-used ones; spreading activation surfaces related code on every prompt — no MCP call required.</p>
                 </div>
                 <div class="feature-card">
+                    <h3>Phase 4: Graph View <em>(new)</em></h3>
+                    <p><code>neuralmind serve</code> opens an Obsidian-style force-directed graph of your codebase in the browser. Structural edges, the learned synapse overlay, backlinks, a semantic quick-switcher, and one-click "open in editor". Makes the brain inspectable — no more black-box retrieval.</p>
+                </div>
+                <div class="feature-card">
                     <h3>Result: 40–70× Reduction</h3>
                     <p>50K+ tokens of raw source compressed to ~800 tokens of structured context per code question. Cost bills drop 40–70%. The brain-like layer makes retrieval get sharper the longer NeuralMind runs on a codebase.</p>
                 </div>

--- a/neuralmind/cli.py
+++ b/neuralmind/cli.py
@@ -435,10 +435,12 @@ def cmd_watch(args):
 def cmd_serve(args):
     """Start the local graph-view UI server.
 
-    Builds the index, then serves an Obsidian-style force-directed graph
-    of the codebase (structural edges + learned synapse overlay) with
-    backlinks, local-graph focus, a community browser, and semantic
-    quick-switch search. Read-only — never writes to the index.
+    Builds the index (writes/updates ``graphify-out/neuralmind_db/`` the
+    same way ``neuralmind build`` does), then serves an Obsidian-style
+    force-directed graph of the codebase (structural edges + learned
+    synapse overlay) with backlinks, local-graph focus, a community
+    browser, and semantic quick-switch search. The HTTP handlers
+    themselves are read-only.
     """
     from neuralmind.server import serve
 

--- a/neuralmind/cli.py
+++ b/neuralmind/cli.py
@@ -453,6 +453,8 @@ def cmd_serve(args):
             host=args.host,
             port=args.port,
             open_browser=not args.no_browser,
+            auth=not args.no_auth,
+            editor=args.editor,
         )
     except RuntimeError as exc:
         print(f"serve failed: {exc}")
@@ -791,6 +793,17 @@ def main():
         "--no-browser",
         action="store_true",
         help="Don't auto-open a browser window",
+    )
+    serve_p.add_argument(
+        "--no-auth",
+        action="store_true",
+        help="Disable the per-session access token. Use only on trusted hosts.",
+    )
+    serve_p.add_argument(
+        "--editor",
+        default=None,
+        help="Editor command for 'open in editor' clicks (defaults to $EDITOR/$VISUAL). "
+        "Examples: 'code', 'cursor', 'vim', 'subl', 'code -n'.",
     )
     serve_p.set_defaults(func=cmd_serve)
 

--- a/neuralmind/cli.py
+++ b/neuralmind/cli.py
@@ -432,6 +432,36 @@ def cmd_watch(args):
             print(f"\nWatcher stopped. Reinforced {activations_total} synapse pair(s) total.")
 
 
+def cmd_serve(args):
+    """Start the local graph-view UI server.
+
+    Builds the index, then serves an Obsidian-style force-directed graph
+    of the codebase (structural edges + learned synapse overlay) with
+    backlinks, local-graph focus, a community browser, and semantic
+    quick-switch search. Read-only — never writes to the index.
+    """
+    from neuralmind.server import serve
+
+    project_path = args.project_path or "."
+    path = Path(project_path)
+    if not path.is_dir():
+        print(f"serve failed: not a directory: {project_path}")
+        sys.exit(1)
+    try:
+        serve(
+            str(path),
+            host=args.host,
+            port=args.port,
+            open_browser=not args.no_browser,
+        )
+    except RuntimeError as exc:
+        print(f"serve failed: {exc}")
+        sys.exit(1)
+    except OSError as exc:
+        print(f"serve failed: could not bind {args.host}:{args.port} ({exc})")
+        sys.exit(1)
+
+
 def cmd_demo(args):
     """Run the bundled 30-second demo.
 
@@ -734,6 +764,35 @@ def main():
         help="Suppress per-batch logging",
     )
     watch_p.set_defaults(func=cmd_watch)
+
+    # serve command — local graph-view UI (Obsidian-style)
+    serve_p = subparsers.add_parser(
+        "serve",
+        help="Start the local graph-view UI (Obsidian-style graph of your code + synapses)",
+    )
+    serve_p.add_argument(
+        "project_path",
+        nargs="?",
+        default=".",
+        help="Project root (default: current directory)",
+    )
+    serve_p.add_argument(
+        "--host",
+        default="127.0.0.1",
+        help="Host to bind (default: 127.0.0.1)",
+    )
+    serve_p.add_argument(
+        "--port",
+        type=int,
+        default=8765,
+        help="Port to bind (default: 8765)",
+    )
+    serve_p.add_argument(
+        "--no-browser",
+        action="store_true",
+        help="Don't auto-open a browser window",
+    )
+    serve_p.set_defaults(func=cmd_serve)
 
     # demo command — runs against bundled sample_project, no git checkout needed
     demo_p = subparsers.add_parser(

--- a/neuralmind/core.py
+++ b/neuralmind/core.py
@@ -636,6 +636,10 @@ class NeuralMind:
 
         return {
             "project": self.project_path.name,
+            # Full absolute path so the UI can key per-project state (e.g.
+            # saved canvas layouts) without collisions between two repos
+            # that happen to share a basename.
+            "project_path": str(self.project_path.resolve()),
             "nodes": nodes,
             "edges": edges,
             "synapses": synapses,

--- a/neuralmind/core.py
+++ b/neuralmind/core.py
@@ -568,6 +568,84 @@ class NeuralMind:
                 stats["synapses"] = None
         return stats
 
+    def graph_data(
+        self, synapse_min_weight: float = 0.05, synapse_limit: int = 2000
+    ) -> dict:
+        """Return the full code graph for the ``serve`` graph-view UI.
+
+        Combines structural edges (calls/imports from graph.json) with the
+        learned synapse overlay. Node ids are the embedder's graph ids so
+        the overlay lines up with the structural nodes. Read-only — never
+        mutates the index or the synapse store.
+        """
+        self._ensure_built()
+        raw_nodes = list(getattr(self.embedder, "nodes", []) or [])
+        raw_edges = list(getattr(self.embedder, "edges", []) or [])
+
+        nodes = []
+        for n in raw_nodes:
+            nid = str(n.get("id", n.get("label", "")))
+            if not nid:
+                continue
+            nodes.append(
+                {
+                    "id": nid,
+                    "label": n.get("label", nid),
+                    "file_type": n.get("file_type", "unknown"),
+                    "source_file": n.get("source_file", ""),
+                    "source_location": n.get("source_location", ""),
+                    "community": int(n.get("community", -1)),
+                }
+            )
+        node_ids = {n["id"] for n in nodes}
+
+        edges = []
+        for e in raw_edges:
+            src = e.get("_src") or e.get("source")
+            tgt = e.get("_tgt") or e.get("target")
+            if src not in node_ids or tgt not in node_ids:
+                continue
+            edges.append(
+                {
+                    "source": src,
+                    "target": tgt,
+                    "relation": e.get("relation", "related"),
+                }
+            )
+
+        synapses = []
+        store = self.synapses
+        if store is not None:
+            try:
+                for a, b, weight, count in store.edges(
+                    min_weight=synapse_min_weight, limit=synapse_limit
+                ):
+                    # Synapse ids can include community_* pseudo-nodes that
+                    # aren't real graph nodes — keep only edges we can draw.
+                    if a in node_ids and b in node_ids:
+                        synapses.append(
+                            {
+                                "source": a,
+                                "target": b,
+                                "weight": round(weight, 4),
+                                "activation_count": count,
+                            }
+                        )
+            except Exception:
+                pass
+
+        return {
+            "project": self.project_path.name,
+            "nodes": nodes,
+            "edges": edges,
+            "synapses": synapses,
+            "stats": {
+                "nodes": len(nodes),
+                "edges": len(edges),
+                "synapses": len(synapses),
+            },
+        }
+
     def synaptic_neighbors(
         self, query: str, depth: int = 2, top_k: int = 10
     ) -> list[tuple[str, float]]:

--- a/neuralmind/core.py
+++ b/neuralmind/core.py
@@ -568,9 +568,7 @@ class NeuralMind:
                 stats["synapses"] = None
         return stats
 
-    def graph_data(
-        self, synapse_min_weight: float = 0.05, synapse_limit: int = 2000
-    ) -> dict:
+    def graph_data(self, synapse_min_weight: float = 0.05, synapse_limit: int = 2000) -> dict:
         """Return the full code graph for the ``serve`` graph-view UI.
 
         Combines structural edges (calls/imports from graph.json) with the

--- a/neuralmind/server.py
+++ b/neuralmind/server.py
@@ -1,0 +1,165 @@
+"""
+server.py — Local graph-view UI for NeuralMind.
+
+``neuralmind serve`` starts a stdlib HTTP server that renders the code
+graph (structural edges from graph.json) with the learned synapse
+overlay on top. Obsidian-style: force-directed graph, backlinks panel,
+local graph, community browser, and semantic quick-switch search.
+
+No external dependencies, no CDN — the frontend is vanilla JS served
+from ``neuralmind/web/``. Everything runs against the existing index and
+``.neuralmind/synapses.db``; the server is read-only and never writes.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from urllib.parse import parse_qs, urlparse
+
+from .core import NeuralMind
+
+WEB_DIR = Path(__file__).parent / "web"
+
+_CONTENT_TYPES = {
+    ".html": "text/html; charset=utf-8",
+    ".js": "application/javascript; charset=utf-8",
+    ".css": "text/css; charset=utf-8",
+}
+
+
+def _build_graph_payload(mind: NeuralMind) -> dict:
+    """Materialize the graph payload once; the graph is static per session."""
+    data = mind.graph_data()
+    counts: dict[int, int] = {}
+    for node in data["nodes"]:
+        cid = node.get("community", -1)
+        counts[cid] = counts.get(cid, 0) + 1
+    data["communities"] = [
+        {"id": cid, "size": size} for cid, size in sorted(counts.items())
+    ]
+    return data
+
+
+def _search(mind: NeuralMind, query: str, n: int = 12) -> list[dict]:
+    if not query:
+        return []
+    try:
+        hits = mind.search(query, n=n)
+    except Exception:
+        return []
+    results = []
+    for hit in hits:
+        meta = hit.get("metadata", {})
+        results.append(
+            {
+                "id": str(hit.get("id", "")),
+                "label": meta.get("label", hit.get("id", "")),
+                "source_file": meta.get("source_file", ""),
+                "community": meta.get("community", -1),
+                "score": round(float(hit.get("score", 0.0)), 3),
+            }
+        )
+    return results
+
+
+class _Handler(BaseHTTPRequestHandler):
+    # Set by serve() before the server starts; shared across threads.
+    mind: NeuralMind | None = None
+    _graph_cache: dict | None = None
+    _graph_lock = threading.Lock()
+
+    def log_message(self, *args):  # noqa: D102 - silence default request logging
+        pass
+
+    def _graph(self) -> dict:
+        cls = type(self)
+        with cls._graph_lock:
+            if cls._graph_cache is None:
+                cls._graph_cache = _build_graph_payload(cls.mind)
+            return cls._graph_cache
+
+    def _send_json(self, payload: dict, status: int = 200) -> None:
+        body = json.dumps(payload).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _send_static(self, name: str) -> None:
+        path = (WEB_DIR / name).resolve()
+        # Guard against path traversal — only serve files inside web/.
+        if not str(path).startswith(str(WEB_DIR.resolve())) or not path.is_file():
+            self.send_error(404)
+            return
+        body = path.read_bytes()
+        self.send_response(200)
+        self.send_header(
+            "Content-Type",
+            _CONTENT_TYPES.get(path.suffix, "application/octet-stream"),
+        )
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self) -> None:  # noqa: N802 - http.server API
+        parsed = urlparse(self.path)
+        route = parsed.path
+
+        if route in ("/", "/index.html"):
+            self._send_static("index.html")
+        elif route in ("/app.js", "/style.css"):
+            self._send_static(route.lstrip("/"))
+        elif route == "/api/graph":
+            self._send_json(self._graph())
+        elif route == "/api/search":
+            query = (parse_qs(parsed.query).get("q") or [""])[0].strip()
+            self._send_json(
+                {"query": query, "results": _search(type(self).mind, query)}
+            )
+        else:
+            self.send_error(404)
+
+
+def serve(
+    project_path: str,
+    host: str = "127.0.0.1",
+    port: int = 8765,
+    open_browser: bool = True,
+) -> None:
+    """Build the index and serve the graph-view UI until interrupted."""
+    mind = NeuralMind(str(project_path))
+    build = mind.build()
+    if not build.get("success"):
+        raise RuntimeError(build.get("error", "build failed"))
+
+    _Handler.mind = mind
+    _Handler._graph_cache = None
+
+    httpd = ThreadingHTTPServer((host, port), _Handler)
+    url = f"http://{host}:{port}/"
+    stats = mind.graph_data()["stats"]
+    print(f"NeuralMind graph view: {url}")
+    print(
+        f"  {stats['nodes']} nodes · {stats['edges']} structural edges · "
+        f"{stats['synapses']} learned synapses"
+    )
+    print("  Ctrl-C to stop.")
+
+    if open_browser:
+        try:
+            import webbrowser
+
+            webbrowser.open(url)
+        except Exception:
+            pass
+
+    try:
+        httpd.serve_forever()
+    except KeyboardInterrupt:
+        print("\nStopping NeuralMind graph view.")
+    finally:
+        httpd.server_close()

--- a/neuralmind/server.py
+++ b/neuralmind/server.py
@@ -8,12 +8,18 @@ local graph, community browser, and semantic quick-switch search.
 
 No external dependencies, no CDN — the frontend is vanilla JS served
 from ``neuralmind/web/``. Everything runs against the existing index and
-``.neuralmind/synapses.db``; the server is read-only and never writes.
+``.neuralmind/synapses.db``; the server only writes when the user
+explicitly clicks "open in editor".
 """
 
 from __future__ import annotations
 
 import json
+import os
+import secrets
+import shlex
+import shutil
+import subprocess
 import threading
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
@@ -28,6 +34,8 @@ _CONTENT_TYPES = {
     ".js": "application/javascript; charset=utf-8",
     ".css": "text/css; charset=utf-8",
 }
+
+_AUTH_COOKIE = "nm_token"
 
 
 def _build_graph_payload(mind: NeuralMind) -> dict:
@@ -65,9 +73,80 @@ def _search(mind: NeuralMind, query: str, n: int = 12) -> list[dict]:
     return results
 
 
+def _editor_command(editor: str, path: str, line: int | None) -> list[str]:
+    """Build the argv for opening ``path`` at ``line`` in ``editor``.
+
+    Respects the user's $EDITOR (split with shlex so values like
+    ``"code -n"`` work) and chooses a sensible jump-to-line flag for
+    well-known editors. Unknown editors get the path with no line.
+    """
+    parts = shlex.split(editor) if editor else []
+    if not parts:
+        return []
+    name = Path(parts[0]).name.lower()
+    base = parts
+    if name in {"code", "code-insiders", "codium", "vscodium", "cursor", "windsurf"}:
+        target = f"{path}:{line}" if line else path
+        return base + ["--goto", target]
+    if name in {"vim", "nvim", "vi", "nano", "emacs", "emacsclient"}:
+        return base + ([f"+{line}", path] if line else [path])
+    if name in {"subl", "sublime_text"}:
+        return base + ([f"{path}:{line}"] if line else [path])
+    if name == "idea" or name.startswith("idea") or name == "pycharm":
+        return base + (["--line", str(line), path] if line else [path])
+    return base + [path]
+
+
+def _resolve_open_target(
+    mind: NeuralMind, node_id: str
+) -> tuple[Path | None, int | None, str]:
+    """Map a node id to (absolute file path under project, line, label).
+
+    Returns ``(None, None, reason)`` if the node is unknown, has no
+    source file, or the resolved path escapes the project root.
+    """
+    nodes = getattr(mind.embedder, "nodes", []) or []
+    node = next((n for n in nodes if str(n.get("id")) == node_id), None)
+    if node is None:
+        return None, None, "unknown node id"
+
+    src = node.get("source_file") or ""
+    if not src:
+        return None, None, "node has no source file"
+
+    project_root = Path(mind.project_path).resolve()
+    candidate = Path(src)
+    if not candidate.is_absolute():
+        candidate = project_root / candidate
+    try:
+        resolved = candidate.resolve()
+    except Exception:
+        return None, None, "could not resolve source file"
+
+    try:
+        resolved.relative_to(project_root)
+    except ValueError:
+        return None, None, "source file is outside the project root"
+
+    if not resolved.is_file():
+        return None, None, f"file does not exist: {resolved}"
+
+    loc = str(node.get("source_location") or "")
+    line: int | None = None
+    if loc:
+        try:
+            line = int(loc.lstrip("Ll"))
+        except ValueError:
+            line = None
+
+    return resolved, line, node.get("label", node_id)
+
+
 class _Handler(BaseHTTPRequestHandler):
     # Set by serve() before the server starts; shared across threads.
     mind: NeuralMind | None = None
+    auth_token: str | None = None  # None disables auth
+    editor: str | None = None
     _graph_cache: dict | None = None
     _graph_lock = threading.Lock()
 
@@ -81,17 +160,50 @@ class _Handler(BaseHTTPRequestHandler):
                 cls._graph_cache = _build_graph_payload(cls.mind)
             return cls._graph_cache
 
-    def _send_json(self, payload: dict, status: int = 200) -> None:
+    def _check_auth(self, parsed) -> tuple[bool, str | None]:
+        """Return (allowed, new_cookie_value).
+
+        The token may arrive via ?token= (first visit, becomes a cookie)
+        or as the persisted cookie on subsequent requests. When auth is
+        disabled, everything is allowed.
+        """
+        cls = type(self)
+        if cls.auth_token is None:
+            return True, None
+
+        cookie_header = self.headers.get("Cookie", "")
+        cookies = {}
+        for piece in cookie_header.split(";"):
+            piece = piece.strip()
+            if "=" in piece:
+                k, v = piece.split("=", 1)
+                cookies[k.strip()] = v.strip()
+        if cookies.get(_AUTH_COOKIE) == cls.auth_token:
+            return True, None
+
+        query_token = (parse_qs(parsed.query).get("token") or [None])[0]
+        if query_token and secrets.compare_digest(query_token, cls.auth_token):
+            return True, cls.auth_token
+
+        return False, None
+
+    def _send_json(
+        self, payload: dict, status: int = 200, set_cookie: str | None = None
+    ) -> None:
         body = json.dumps(payload).encode("utf-8")
         self.send_response(status)
         self.send_header("Content-Type", "application/json; charset=utf-8")
         self.send_header("Content-Length", str(len(body)))
+        if set_cookie:
+            self.send_header(
+                "Set-Cookie",
+                f"{_AUTH_COOKIE}={set_cookie}; Path=/; HttpOnly; SameSite=Strict",
+            )
         self.end_headers()
         self.wfile.write(body)
 
-    def _send_static(self, name: str) -> None:
+    def _send_static(self, name: str, set_cookie: str | None = None) -> None:
         path = (WEB_DIR / name).resolve()
-        # Guard against path traversal — only serve files inside web/.
         if not str(path).startswith(str(WEB_DIR.resolve())) or not path.is_file():
             self.send_error(404)
             return
@@ -102,26 +214,161 @@ class _Handler(BaseHTTPRequestHandler):
             _CONTENT_TYPES.get(path.suffix, "application/octet-stream"),
         )
         self.send_header("Content-Length", str(len(body)))
+        if set_cookie:
+            self.send_header(
+                "Set-Cookie",
+                f"{_AUTH_COOKIE}={set_cookie}; Path=/; HttpOnly; SameSite=Strict",
+            )
         self.end_headers()
         self.wfile.write(body)
+
+    def _deny(self, route: str) -> None:
+        if route in ("/", "/index.html"):
+            # Friendlier landing page than a raw 401.
+            body = (
+                b"<!doctype html><meta charset=utf-8>"
+                b"<title>NeuralMind</title>"
+                b"<style>body{font-family:system-ui;background:#1a1b1e;"
+                b"color:#d6d7da;padding:48px;line-height:1.5}</style>"
+                b"<h1>NeuralMind graph view</h1>"
+                b"<p>This URL is missing the access token. Re-open the link "
+                b"printed by <code>neuralmind serve</code> "
+                b"(it ends with <code>?token=&hellip;</code>), or pass "
+                b"<code>--no-auth</code> when starting the server."
+            )
+            self.send_response(401)
+            self.send_header("Content-Type", "text/html; charset=utf-8")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+        else:
+            self.send_error(401, "missing or invalid token")
+
+    def _read_json_body(self) -> dict:
+        length = int(self.headers.get("Content-Length") or 0)
+        if length <= 0:
+            return {}
+        raw = self.rfile.read(length)
+        try:
+            return json.loads(raw.decode("utf-8"))
+        except (ValueError, UnicodeDecodeError):
+            return {}
 
     def do_GET(self) -> None:  # noqa: N802 - http.server API
         parsed = urlparse(self.path)
         route = parsed.path
+        ok, new_cookie = self._check_auth(parsed)
+        if not ok:
+            self._deny(route)
+            return
 
         if route in ("/", "/index.html"):
-            self._send_static("index.html")
+            self._send_static("index.html", set_cookie=new_cookie)
         elif route in ("/app.js", "/style.css"):
-            self._send_static(route.lstrip("/"))
+            self._send_static(route.lstrip("/"), set_cookie=new_cookie)
         elif route == "/api/graph":
-            self._send_json(self._graph())
+            self._send_json(self._graph(), set_cookie=new_cookie)
         elif route == "/api/search":
             query = (parse_qs(parsed.query).get("q") or [""])[0].strip()
             self._send_json(
-                {"query": query, "results": _search(type(self).mind, query)}
+                {"query": query, "results": _search(type(self).mind, query)},
+                set_cookie=new_cookie,
             )
         else:
             self.send_error(404)
+
+    def do_POST(self) -> None:  # noqa: N802 - http.server API
+        parsed = urlparse(self.path)
+        route = parsed.path
+        ok, new_cookie = self._check_auth(parsed)
+        if not ok:
+            self._deny(route)
+            return
+
+        if route == "/api/open":
+            body = self._read_json_body()
+            node_id = str(body.get("id") or "")
+            cls = type(self)
+            path, line, label = _resolve_open_target(cls.mind, node_id)
+            if path is None:
+                self._send_json(
+                    {"ok": False, "error": label},
+                    status=400,
+                    set_cookie=new_cookie,
+                )
+                return
+
+            editor = cls.editor
+            if not editor:
+                self._send_json(
+                    {
+                        "ok": False,
+                        "error": "no editor configured (set $EDITOR or use --editor)",
+                        "file": str(path),
+                        "line": line,
+                    },
+                    status=400,
+                    set_cookie=new_cookie,
+                )
+                return
+
+            argv = _editor_command(editor, str(path), line)
+            if not argv or not shutil.which(argv[0]):
+                self._send_json(
+                    {
+                        "ok": False,
+                        "error": f"editor not found on PATH: {argv[0] if argv else editor}",
+                        "file": str(path),
+                        "line": line,
+                    },
+                    status=400,
+                    set_cookie=new_cookie,
+                )
+                return
+
+            try:
+                subprocess.Popen(  # noqa: S603 - argv list, no shell
+                    argv,
+                    stdin=subprocess.DEVNULL,
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                    close_fds=True,
+                )
+            except OSError as exc:
+                self._send_json(
+                    {"ok": False, "error": f"failed to launch editor: {exc}"},
+                    status=500,
+                    set_cookie=new_cookie,
+                )
+                return
+
+            self._send_json(
+                {"ok": True, "file": str(path), "line": line, "label": label},
+                set_cookie=new_cookie,
+            )
+        else:
+            self.send_error(404)
+
+
+def _ensure_graph_or_explain(project_path: Path) -> None:
+    """Raise a user-friendly error when graphify hasn't run yet.
+
+    Without this the build call surfaces a terse "Could not load graph
+    from ..." message that doesn't tell first-time users what to do.
+    """
+    graph_path = project_path / "graphify-out" / "graph.json"
+    if graph_path.exists():
+        return
+    msg = (
+        f"no graph found at {graph_path}\n"
+        f"\n"
+        f"NeuralMind needs a graphify build first. To generate one:\n"
+        f"  pip install graphify         # if not already installed\n"
+        f"  graphify build {project_path}\n"
+        f"\n"
+        f"Then re-run: neuralmind serve {project_path}"
+    )
+    raise RuntimeError(msg)
 
 
 def serve(
@@ -129,31 +376,46 @@ def serve(
     host: str = "127.0.0.1",
     port: int = 8765,
     open_browser: bool = True,
+    auth: bool = True,
+    editor: str | None = None,
 ) -> None:
     """Build the index and serve the graph-view UI until interrupted."""
+    project_path = Path(project_path).resolve()
+    _ensure_graph_or_explain(project_path)
+
     mind = NeuralMind(str(project_path))
     build = mind.build()
     if not build.get("success"):
         raise RuntimeError(build.get("error", "build failed"))
 
+    token = secrets.token_urlsafe(16) if auth else None
     _Handler.mind = mind
+    _Handler.auth_token = token
+    _Handler.editor = editor or os.environ.get("EDITOR") or os.environ.get("VISUAL")
     _Handler._graph_cache = None
 
     httpd = ThreadingHTTPServer((host, port), _Handler)
-    url = f"http://{host}:{port}/"
+    base = f"http://{host}:{port}/"
+    landing = f"{base}?token={token}" if token else base
     stats = mind.graph_data()["stats"]
-    print(f"NeuralMind graph view: {url}")
+    print(f"NeuralMind graph view: {landing}")
     print(
         f"  {stats['nodes']} nodes · {stats['edges']} structural edges · "
         f"{stats['synapses']} learned synapses"
     )
+    if _Handler.editor:
+        print(f"  Editor: {_Handler.editor}")
+    else:
+        print("  Editor: not set (clicks to open will be no-ops; set $EDITOR)")
+    if token:
+        print("  Access token required. Share the URL above to re-open this session.")
     print("  Ctrl-C to stop.")
 
     if open_browser:
         try:
             import webbrowser
 
-            webbrowser.open(url)
+            webbrowser.open(landing)
         except Exception:
             pass
 

--- a/neuralmind/server.py
+++ b/neuralmind/server.py
@@ -99,6 +99,36 @@ def _editor_command(editor: str, path: str, line: int | None) -> list[str]:
     return base + [path]
 
 
+def _compute_allowed_open_paths(mind: NeuralMind) -> set[str]:
+    """Pre-compute the set of absolute path strings ``/api/open`` may launch.
+
+    Built once from local graph data (not HTTP input), so a hit in this
+    set is positive proof that a path is safe to pass to ``Popen``. The
+    handler does an explicit membership check against this set right
+    before spawning the editor — a redundant defense layer on top of
+    ``_resolve_open_target``'s path checks, and one that taint trackers
+    recognize as sanitization.
+    """
+    project_root = Path(mind.project_path).resolve()
+    allowed: set[str] = set()
+    for node in getattr(mind.embedder, "nodes", []) or []:
+        src = node.get("source_file") or ""
+        if not src:
+            continue
+        candidate = Path(src)
+        if not candidate.is_absolute():
+            candidate = project_root / candidate
+        try:
+            resolved = candidate.resolve()
+            resolved.relative_to(project_root)
+        except (ValueError, OSError):
+            continue
+        s = str(resolved)
+        if resolved.is_file() and resolved.is_absolute() and not s.startswith("-"):
+            allowed.add(s)
+    return allowed
+
+
 def _resolve_open_target(mind: NeuralMind, node_id: str) -> tuple[Path | None, int | None, str]:
     """Map a node id to (absolute file path under project, line, label).
 
@@ -154,6 +184,7 @@ class _Handler(BaseHTTPRequestHandler):
     mind: NeuralMind | None = None
     auth_token: str | None = None  # None disables auth
     editor: str | None = None
+    allowed_open_paths: set[str] = set()
     _graph_cache: dict | None = None
     _graph_lock = threading.Lock()
 
@@ -317,7 +348,21 @@ class _Handler(BaseHTTPRequestHandler):
                 )
                 return
 
-            argv = _editor_command(editor, str(path), line)
+            # Allowlist check: only paths the server pre-validated at
+            # startup (from local graph data, not HTTP input) may be
+            # passed to Popen. Layered with the checks in
+            # _resolve_open_target so a regression in either one fails
+            # closed.
+            safe_path = str(path)
+            if safe_path not in cls.allowed_open_paths:
+                self._send_json(
+                    {"ok": False, "error": "path not in open allowlist"},
+                    status=400,
+                    set_cookie=new_cookie,
+                )
+                return
+
+            argv = _editor_command(editor, safe_path, line)
             if not argv or not shutil.which(argv[0]):
                 self._send_json(
                     {
@@ -397,6 +442,7 @@ def serve(
     _Handler.mind = mind
     _Handler.auth_token = token
     _Handler.editor = editor or os.environ.get("EDITOR") or os.environ.get("VISUAL")
+    _Handler.allowed_open_paths = _compute_allowed_open_paths(mind)
     _Handler._graph_cache = None
 
     httpd = ThreadingHTTPServer((host, port), _Handler)

--- a/neuralmind/server.py
+++ b/neuralmind/server.py
@@ -46,9 +46,7 @@ def _build_graph_payload(mind: NeuralMind) -> dict:
     for node in data["nodes"]:
         cid = node.get("community", -1)
         counts[cid] = counts.get(cid, 0) + 1
-    data["communities"] = [
-        {"id": cid, "size": size} for cid, size in sorted(counts.items())
-    ]
+    data["communities"] = [{"id": cid, "size": size} for cid, size in sorted(counts.items())]
     return data
 
 
@@ -101,9 +99,7 @@ def _editor_command(editor: str, path: str, line: int | None) -> list[str]:
     return base + [path]
 
 
-def _resolve_open_target(
-    mind: NeuralMind, node_id: str
-) -> tuple[Path | None, int | None, str]:
+def _resolve_open_target(mind: NeuralMind, node_id: str) -> tuple[Path | None, int | None, str]:
     """Map a node id to (absolute file path under project, line, label).
 
     Returns ``(None, None, reason)`` if the node is unknown, has no
@@ -198,9 +194,7 @@ class _Handler(BaseHTTPRequestHandler):
 
         return False, None
 
-    def _send_json(
-        self, payload: dict, status: int = 200, set_cookie: str | None = None
-    ) -> None:
+    def _send_json(self, payload: dict, status: int = 200, set_cookie: str | None = None) -> None:
         body = json.dumps(payload).encode("utf-8")
         self.send_response(status)
         self.send_header("Content-Type", "application/json; charset=utf-8")

--- a/neuralmind/server.py
+++ b/neuralmind/server.py
@@ -7,9 +7,10 @@ overlay on top. Obsidian-style: force-directed graph, backlinks panel,
 local graph, community browser, and semantic quick-switch search.
 
 No external dependencies, no CDN — the frontend is vanilla JS served
-from ``neuralmind/web/``. Everything runs against the existing index and
-``.neuralmind/synapses.db``; the server only writes when the user
-explicitly clicks "open in editor".
+from ``neuralmind/web/``. The HTTP handlers themselves are read-only,
+but ``serve()`` calls ``mind.build()`` on startup, which writes/updates
+the embedding index under ``graphify-out/neuralmind_db/`` — same
+side-effects as ``neuralmind build``.
 """
 
 from __future__ import annotations
@@ -80,7 +81,10 @@ def _editor_command(editor: str, path: str, line: int | None) -> list[str]:
     ``"code -n"`` work) and chooses a sensible jump-to-line flag for
     well-known editors. Unknown editors get the path with no line.
     """
-    parts = shlex.split(editor) if editor else []
+    # shlex defaults to POSIX rules, which strip backslashes — that
+    # mangles Windows paths like ``C:\Program Files\...\code.exe``.
+    # Fall back to the non-POSIX tokenizer on Windows so those keep working.
+    parts = shlex.split(editor, posix=(os.name != "nt")) if editor else []
     if not parts:
         return []
     name = Path(parts[0]).name.lower()
@@ -130,6 +134,13 @@ def _resolve_open_target(
 
     if not resolved.is_file():
         return None, None, f"file does not exist: {resolved}"
+
+    # Defense in depth: resolve() always returns an absolute path, but we
+    # still want to be loud if that ever stops being true — and an absolute
+    # path can't start with '-', which is what would make Popen treat it
+    # as an editor flag rather than a filename.
+    if not resolved.is_absolute() or str(resolved).startswith("-"):
+        return None, None, "refusing to open suspicious path"
 
     loc = str(node.get("source_location") or "")
     line: int | None = None
@@ -363,8 +374,8 @@ def _ensure_graph_or_explain(project_path: Path) -> None:
         f"no graph found at {graph_path}\n"
         f"\n"
         f"NeuralMind needs a graphify build first. To generate one:\n"
-        f"  pip install graphify         # if not already installed\n"
-        f"  graphify build {project_path}\n"
+        f"  pip install graphifyy        # if not already installed\n"
+        f"  graphify update {project_path}\n"
         f"\n"
         f"Then re-run: neuralmind serve {project_path}"
     )

--- a/neuralmind/synapses.py
+++ b/neuralmind/synapses.py
@@ -295,6 +295,28 @@ class SynapseStore:
         ranked = sorted(activation.items(), key=lambda x: x[1], reverse=True)
         return ranked[:top_k]
 
+    def edges(
+        self, min_weight: float = 0.0, limit: int = 2000
+    ) -> list[tuple[str, str, float, int]]:
+        """Return synapse edges as (node_a, node_b, weight, activation_count).
+
+        Strongest first. Used by the graph-view UI to overlay learned
+        associations on top of the structural code graph, and is a
+        convenient read-only view for inspection.
+        """
+        with self._connect() as conn:
+            cur = conn.execute(
+                """
+                SELECT node_a, node_b, weight, activation_count
+                FROM synapses
+                WHERE weight >= ?
+                ORDER BY weight DESC
+                LIMIT ?
+                """,
+                (min_weight, limit),
+            )
+            return [(r[0], r[1], float(r[2]), int(r[3])) for r in cur.fetchall()]
+
     def normalize_hubs(self, max_degree: int = HUB_DEGREE) -> int:
         """Trim weights on nodes that have grown into runaway hubs.
 

--- a/neuralmind/web/app.js
+++ b/neuralmind/web/app.js
@@ -38,11 +38,14 @@
     showLabels: false,
     activeCommunity: null,
     project: "",
+    projectKey: "",        // absolute project path; stable across same-name repos
     searchHitIds: null,    // Set when filter-to-search is on
     alpha: 1,
   };
 
-  const LS_KEY = (project) => `nm:layout:${project}`;
+  // Keying layout by the absolute project path stops two repos with the
+  // same basename from overwriting each other's pinned positions.
+  const LS_KEY = (key) => `nm:layout:${key}`;
 
   /* ---------- data loading ---------- */
 
@@ -50,11 +53,12 @@
     const res = await fetch("/api/graph");
     const data = await res.json();
     state.project = data.project || "";
+    state.projectKey = data.project_path || data.project || "";
     document.getElementById("project-name").textContent = state.project;
 
     const W = canvas.clientWidth || 800;
     const H = canvas.clientHeight || 600;
-    const saved = loadLayout(state.project);
+    const saved = loadLayout(state.projectKey);
     state.nodes = data.nodes.map((n) => {
       const pos = saved && saved[n.id];
       return {
@@ -304,10 +308,24 @@
     ctx.globalAlpha = 1;
   }
 
+  // Pause the render loop when the layout is idle so we don't spin at
+  // 60fps drawing the same static graph forever. Interactions call wake()
+  // to kick it back on.
+  let paused = false;
   function tick() {
     simulate();
     draw();
-    requestAnimationFrame(tick);
+    if (state.alpha < 0.005 && !dragNode) {
+      paused = true;
+    } else {
+      requestAnimationFrame(tick);
+    }
+  }
+  function wake() {
+    if (paused) {
+      paused = false;
+      requestAnimationFrame(tick);
+    }
   }
 
   /* ---------- canvas sizing ---------- */
@@ -320,7 +338,10 @@
     canvas.width = w * dpr;
     canvas.height = h * dpr;
   }
-  window.addEventListener("resize", resize);
+  window.addEventListener("resize", () => {
+    resize();
+    wake();
+  });
 
   /* ---------- interaction ---------- */
 
@@ -367,6 +388,7 @@
       panning = true;
     }
     last = { x: sx, y: sy };
+    wake();
   });
 
   window.addEventListener("mousemove", (ev) => {
@@ -379,11 +401,14 @@
       dragNode.x = w.x;
       dragNode.y = w.y;
       state.alpha = Math.max(state.alpha, 0.2);
+      wake();
     } else if (panning) {
       state.transform.x += sx - last.x;
       state.transform.y += sy - last.y;
+      wake();
     } else {
       const hit = nodeAt(sx, sy);
+      const hoverChanged = hit !== state.hovered;
       state.hovered = hit;
       if (hit) {
         tooltip.hidden = false;
@@ -395,6 +420,7 @@
       } else {
         tooltip.hidden = true;
       }
+      if (hoverChanged) wake();
     }
     last = { x: sx, y: sy };
   });
@@ -406,14 +432,16 @@
       if (!moved) {
         dragNode.pinned = false;
         selectNode(dragNode);
-      } else {
-        // A real drag pins the node — persist so the layout sticks.
-        saveLayout();
       }
+      // Either branch changes the pinned-set: a drag pinned the node,
+      // a click unpinned it. Persist both so refreshes match what the
+      // user just did.
+      saveLayout();
     }
     dragNode = null;
     panning = false;
     downAt = null;
+    wake();
   });
 
   canvas.addEventListener(
@@ -430,6 +458,7 @@
       t.k = Math.min(6, Math.max(0.1, t.k * factor));
       t.x = sx - wx * t.k;
       t.y = sy - wy * t.k;
+      wake();
     },
     { passive: false }
   );
@@ -440,6 +469,7 @@
     state.selected = node;
     renderDetail(node);
     syncCommunityActive();
+    wake();
   }
 
   function focusNode(node) {
@@ -449,6 +479,7 @@
     t.x = canvas.clientWidth / 2 - node.x * t.k;
     t.y = canvas.clientHeight / 2 - node.y * t.k;
     state.alpha = Math.max(state.alpha, 0.15);
+    wake();
   }
 
   function linkRow(node, meta) {
@@ -554,6 +585,7 @@
         state.activeCommunity =
           state.activeCommunity === c.id ? null : c.id;
         syncCommunityActive();
+        wake();
       });
       ul.appendChild(li);
     }
@@ -573,24 +605,40 @@
   const searchInput = document.getElementById("search");
   const searchResults = document.getElementById("search-results");
   let searchTimer = null;
+  let searchAbort = null;
 
   searchInput.addEventListener("input", () => {
     clearTimeout(searchTimer);
     const q = searchInput.value.trim();
     if (!q) {
+      // Cancel any in-flight request so a slow stale response can't
+      // overwrite the cleared state half a second later.
+      if (searchAbort) searchAbort.abort();
       searchResults.innerHTML = "";
       state.searchHitIds = null;
+      wake();
       return;
     }
     searchTimer = setTimeout(async () => {
+      if (searchAbort) searchAbort.abort();
+      searchAbort = new AbortController();
+      const mySignal = searchAbort.signal;
       try {
-        const res = await fetch("/api/search?q=" + encodeURIComponent(q));
+        const res = await fetch(
+          "/api/search?q=" + encodeURIComponent(q),
+          { signal: mySignal }
+        );
+        if (mySignal.aborted) return;
         const data = await res.json();
+        if (mySignal.aborted) return;
         renderSearchResults(data.results || []);
         state.searchHitIds = new Set((data.results || []).map((r) => r.id));
+        wake();
       } catch (e) {
+        if (e && e.name === "AbortError") return;
         searchResults.innerHTML = "";
         state.searchHitIds = null;
+        wake();
       }
     }, 180);
   });
@@ -644,10 +692,10 @@
 
   /* ---------- layout persistence ---------- */
 
-  function loadLayout(project) {
-    if (!project) return null;
+  function loadLayout(key) {
+    if (!key) return null;
     try {
-      const raw = localStorage.getItem(LS_KEY(project));
+      const raw = localStorage.getItem(LS_KEY(key));
       if (!raw) return null;
       return JSON.parse(raw);
     } catch {
@@ -657,7 +705,7 @@
 
   let saveTimer = null;
   function saveLayout() {
-    if (!state.project) return;
+    if (!state.projectKey) return;
     clearTimeout(saveTimer);
     // Debounce — drags fire many events; we only need the resting state.
     saveTimer = setTimeout(() => {
@@ -666,7 +714,7 @@
         if (n.pinned) out[n.id] = { x: n.x, y: n.y, pinned: true };
       }
       try {
-        localStorage.setItem(LS_KEY(state.project), JSON.stringify(out));
+        localStorage.setItem(LS_KEY(state.projectKey), JSON.stringify(out));
       } catch {
         // localStorage may be full or disabled — non-critical.
       }
@@ -679,6 +727,7 @@
     const el = document.getElementById(id);
     el.addEventListener("change", () => {
       state[key] = el.checked;
+      wake();
     });
   };
   bind("toggle-synapses", "showSynapses");
@@ -689,9 +738,9 @@
   bind("toggle-labels", "showLabels");
 
   document.getElementById("reset-layout").addEventListener("click", () => {
-    if (!state.project) return;
+    if (!state.projectKey) return;
     try {
-      localStorage.removeItem(LS_KEY(state.project));
+      localStorage.removeItem(LS_KEY(state.projectKey));
     } catch {}
     for (const n of state.nodes) {
       n.pinned = false;
@@ -699,6 +748,7 @@
       n.y = canvas.clientHeight / 2 + (Math.random() - 0.5) * canvas.clientHeight * 0.8;
     }
     state.alpha = 1;
+    wake();
   });
 
   /* ---------- boot ---------- */

--- a/neuralmind/web/app.js
+++ b/neuralmind/web/app.js
@@ -1,0 +1,593 @@
+/*
+ * app.js — NeuralMind graph-view UI.
+ *
+ * Vanilla canvas force-directed graph over the code graph returned by
+ * /api/graph. Structural edges (calls/imports) and the learned synapse
+ * overlay are drawn together; the sidebar gives Obsidian-style backlinks,
+ * a local-graph focus mode, a community browser, and semantic quick-switch.
+ */
+(() => {
+  "use strict";
+
+  const canvas = document.getElementById("graph");
+  const ctx = canvas.getContext("2d");
+  const tooltip = document.getElementById("tooltip");
+  const loading = document.getElementById("loading");
+
+  const PALETTE = [
+    "#7c6cf0", "#e0a458", "#5fb37a", "#d9694f", "#4fa3d9",
+    "#c45fb3", "#8aab4a", "#d97fae", "#5fc7c0", "#b08a5f",
+  ];
+  const communityColor = (c) =>
+    c < 0 ? "#6b6d75" : PALETTE[c % PALETTE.length];
+
+  const state = {
+    nodes: [],
+    structuralEdges: [],
+    synapseEdges: [],
+    nodeById: new Map(),
+    structAdj: new Map(),   // id -> Set of {edge}
+    selected: null,
+    hovered: null,
+    transform: { x: 0, y: 0, k: 1 },
+    showSynapses: true,
+    showStructural: true,
+    localOnly: false,
+    showLabels: false,
+    activeCommunity: null,
+    alpha: 1,
+  };
+
+  /* ---------- data loading ---------- */
+
+  async function load() {
+    const res = await fetch("/api/graph");
+    const data = await res.json();
+    document.getElementById("project-name").textContent = data.project || "";
+
+    const W = canvas.clientWidth || 800;
+    const H = canvas.clientHeight || 600;
+    state.nodes = data.nodes.map((n) => ({
+      ...n,
+      x: W / 2 + (Math.random() - 0.5) * W * 0.8,
+      y: H / 2 + (Math.random() - 0.5) * H * 0.8,
+      vx: 0,
+      vy: 0,
+      degree: 0,
+      pinned: false,
+    }));
+    state.nodeById = new Map(state.nodes.map((n) => [n.id, n]));
+
+    const resolve = (e) => {
+      const s = state.nodeById.get(e.source);
+      const t = state.nodeById.get(e.target);
+      return s && t ? { ...e, s, t } : null;
+    };
+    state.structuralEdges = data.edges.map(resolve).filter(Boolean);
+    state.synapseEdges = data.synapses.map(resolve).filter(Boolean);
+
+    for (const e of state.structuralEdges) {
+      e.s.degree++;
+      e.t.degree++;
+      if (!state.structAdj.has(e.s.id)) state.structAdj.set(e.s.id, []);
+      if (!state.structAdj.has(e.t.id)) state.structAdj.set(e.t.id, []);
+      state.structAdj.get(e.s.id).push(e);
+      state.structAdj.get(e.t.id).push(e);
+    }
+
+    renderCommunities(data.communities);
+    document.getElementById("stats").innerHTML =
+      `${data.stats.nodes} nodes · ${data.stats.edges} structural edges<br>` +
+      `${data.stats.synapses} learned synapses<br>` +
+      `<span class="muted">scroll to zoom · drag to pan · drag a node to pin</span>`;
+
+    loading.classList.add("hidden");
+    state.alpha = 1;
+    requestAnimationFrame(tick);
+  }
+
+  /* ---------- force simulation ---------- */
+
+  const REPULSION = 2400;
+  const SPRING_LEN = 70;
+  const SPRING_K = 0.02;
+  const SYNAPSE_K = 0.06;
+  const CENTER_K = 0.015;
+  const DAMPING = 0.82;
+
+  function simulate() {
+    if (state.alpha < 0.005) return;
+    const nodes = state.nodes;
+    const W = canvas.clientWidth;
+    const H = canvas.clientHeight;
+    const cx = W / 2;
+    const cy = H / 2;
+
+    // Grid-bucketed repulsion so large graphs stay interactive.
+    const cell = 90;
+    const grid = new Map();
+    const key = (gx, gy) => gx + "," + gy;
+    for (const n of nodes) {
+      const gx = Math.floor(n.x / cell);
+      const gy = Math.floor(n.y / cell);
+      const k = key(gx, gy);
+      if (!grid.has(k)) grid.set(k, []);
+      grid.get(k).push(n);
+    }
+    for (const n of nodes) {
+      const gx = Math.floor(n.x / cell);
+      const gy = Math.floor(n.y / cell);
+      for (let dx = -1; dx <= 1; dx++) {
+        for (let dy = -1; dy <= 1; dy++) {
+          const bucket = grid.get(key(gx + dx, gy + dy));
+          if (!bucket) continue;
+          for (const m of bucket) {
+            if (m === n) continue;
+            let ddx = n.x - m.x;
+            let ddy = n.y - m.y;
+            let d2 = ddx * ddx + ddy * ddy;
+            if (d2 < 0.01) {
+              ddx = Math.random() - 0.5;
+              ddy = Math.random() - 0.5;
+              d2 = 1;
+            }
+            if (d2 > cell * cell * 4) continue;
+            const force = REPULSION / d2;
+            const d = Math.sqrt(d2);
+            n.vx += (ddx / d) * force * state.alpha;
+            n.vy += (ddy / d) * force * state.alpha;
+          }
+        }
+      }
+    }
+
+    const spring = (e, k, restMul) => {
+      const dx = e.t.x - e.s.x;
+      const dy = e.t.y - e.s.y;
+      const d = Math.sqrt(dx * dx + dy * dy) || 1;
+      const rest = SPRING_LEN * restMul;
+      const f = (d - rest) * k * state.alpha;
+      const fx = (dx / d) * f;
+      const fy = (dy / d) * f;
+      e.s.vx += fx;
+      e.s.vy += fy;
+      e.t.vx -= fx;
+      e.t.vy -= fy;
+    };
+    for (const e of state.structuralEdges) spring(e, SPRING_K, 1);
+    for (const e of state.synapseEdges) spring(e, SYNAPSE_K * e.weight, 0.7);
+
+    for (const n of nodes) {
+      n.vx += (cx - n.x) * CENTER_K * state.alpha;
+      n.vy += (cy - n.y) * CENTER_K * state.alpha;
+      if (n.pinned || n === dragNode) {
+        n.vx = 0;
+        n.vy = 0;
+        continue;
+      }
+      n.vx *= DAMPING;
+      n.vy *= DAMPING;
+      n.x += n.vx;
+      n.y += n.vy;
+    }
+    state.alpha *= 0.99;
+  }
+
+  /* ---------- rendering ---------- */
+
+  const nodeRadius = (n) => 3.5 + Math.sqrt(n.degree);
+
+  function visibleSet() {
+    if (!state.localOnly || !state.selected) return null;
+    const set = new Set([state.selected.id]);
+    for (const e of state.structuralEdges) {
+      if (e.s.id === state.selected.id) set.add(e.t.id);
+      if (e.t.id === state.selected.id) set.add(e.s.id);
+    }
+    for (const e of state.synapseEdges) {
+      if (e.s.id === state.selected.id) set.add(e.t.id);
+      if (e.t.id === state.selected.id) set.add(e.s.id);
+    }
+    return set;
+  }
+
+  function neighborIds(node) {
+    const set = new Set();
+    if (!node) return set;
+    for (const e of state.structuralEdges) {
+      if (e.s.id === node.id) set.add(e.t.id);
+      if (e.t.id === node.id) set.add(e.s.id);
+    }
+    for (const e of state.synapseEdges) {
+      if (e.s.id === node.id) set.add(e.t.id);
+      if (e.t.id === node.id) set.add(e.s.id);
+    }
+    return set;
+  }
+
+  function draw() {
+    const W = canvas.width;
+    const H = canvas.height;
+    ctx.setTransform(1, 0, 0, 1, 0, 0);
+    ctx.clearRect(0, 0, W, H);
+    const t = state.transform;
+    ctx.setTransform(t.k * dpr, 0, 0, t.k * dpr, t.x * dpr, t.y * dpr);
+
+    const vis = visibleSet();
+    const isVisible = (n) => !vis || vis.has(n.id);
+    const focus = state.hovered || state.selected;
+    const highlight = focus ? neighborIds(focus) : null;
+
+    // structural edges
+    if (state.showStructural) {
+      ctx.lineWidth = 0.7 / t.k;
+      for (const e of state.structuralEdges) {
+        if (!isVisible(e.s) || !isVisible(e.t)) continue;
+        const lit =
+          focus && (e.s.id === focus.id || e.t.id === focus.id);
+        ctx.strokeStyle = lit ? "#9aa0b8" : "#3a3c45";
+        ctx.globalAlpha = focus && !lit ? 0.25 : 0.7;
+        ctx.beginPath();
+        ctx.moveTo(e.s.x, e.s.y);
+        ctx.lineTo(e.t.x, e.t.y);
+        ctx.stroke();
+      }
+    }
+
+    // synapse overlay
+    if (state.showSynapses) {
+      for (const e of state.synapseEdges) {
+        if (!isVisible(e.s) || !isVisible(e.t)) continue;
+        const lit =
+          focus && (e.s.id === focus.id || e.t.id === focus.id);
+        ctx.strokeStyle = "#e0a458";
+        ctx.globalAlpha = (focus && !lit ? 0.2 : 0.85) * (0.35 + e.weight * 0.65);
+        ctx.lineWidth = (0.6 + e.weight * 2.4) / t.k;
+        ctx.beginPath();
+        ctx.moveTo(e.s.x, e.s.y);
+        ctx.lineTo(e.t.x, e.t.y);
+        ctx.stroke();
+      }
+    }
+
+    // nodes
+    ctx.globalAlpha = 1;
+    for (const n of state.nodes) {
+      if (!isVisible(n)) continue;
+      const r = nodeRadius(n);
+      const dim =
+        (state.activeCommunity != null && n.community !== state.activeCommunity) ||
+        (focus && focus.id !== n.id && highlight && !highlight.has(n.id));
+      ctx.globalAlpha = dim ? 0.25 : 1;
+      ctx.beginPath();
+      ctx.arc(n.x, n.y, r, 0, Math.PI * 2);
+      ctx.fillStyle = communityColor(n.community);
+      ctx.fill();
+      if (n === state.selected) {
+        ctx.lineWidth = 2 / t.k;
+        ctx.strokeStyle = "#fff";
+        ctx.stroke();
+      }
+      if (state.showLabels || n === focus || n === state.selected) {
+        ctx.globalAlpha = dim ? 0.4 : 1;
+        ctx.fillStyle = "#d6d7da";
+        ctx.font = `${11 / t.k}px sans-serif`;
+        ctx.fillText(n.label, n.x + r + 2 / t.k, n.y + 3 / t.k);
+      }
+    }
+    ctx.globalAlpha = 1;
+  }
+
+  function tick() {
+    simulate();
+    draw();
+    requestAnimationFrame(tick);
+  }
+
+  /* ---------- canvas sizing ---------- */
+
+  let dpr = window.devicePixelRatio || 1;
+  function resize() {
+    dpr = window.devicePixelRatio || 1;
+    const w = canvas.clientWidth;
+    const h = canvas.clientHeight;
+    canvas.width = w * dpr;
+    canvas.height = h * dpr;
+  }
+  window.addEventListener("resize", resize);
+
+  /* ---------- interaction ---------- */
+
+  let dragNode = null;
+  let panning = false;
+  let last = { x: 0, y: 0 };
+  let downAt = null;
+
+  const toWorld = (sx, sy) => ({
+    x: (sx - state.transform.x) / state.transform.k,
+    y: (sy - state.transform.y) / state.transform.k,
+  });
+
+  function nodeAt(sx, sy) {
+    const w = toWorld(sx, sy);
+    let best = null;
+    let bestD = Infinity;
+    const vis = visibleSet();
+    for (const n of state.nodes) {
+      if (vis && !vis.has(n.id)) continue;
+      const r = nodeRadius(n) + 4;
+      const dx = n.x - w.x;
+      const dy = n.y - w.y;
+      const d = dx * dx + dy * dy;
+      if (d < r * r && d < bestD) {
+        bestD = d;
+        best = n;
+      }
+    }
+    return best;
+  }
+
+  canvas.addEventListener("mousedown", (ev) => {
+    const rect = canvas.getBoundingClientRect();
+    const sx = ev.clientX - rect.left;
+    const sy = ev.clientY - rect.top;
+    downAt = { x: sx, y: sy };
+    const hit = nodeAt(sx, sy);
+    if (hit) {
+      dragNode = hit;
+      dragNode.pinned = true;
+      state.alpha = Math.max(state.alpha, 0.3);
+    } else {
+      panning = true;
+    }
+    last = { x: sx, y: sy };
+  });
+
+  window.addEventListener("mousemove", (ev) => {
+    const rect = canvas.getBoundingClientRect();
+    const sx = ev.clientX - rect.left;
+    const sy = ev.clientY - rect.top;
+
+    if (dragNode) {
+      const w = toWorld(sx, sy);
+      dragNode.x = w.x;
+      dragNode.y = w.y;
+      state.alpha = Math.max(state.alpha, 0.2);
+    } else if (panning) {
+      state.transform.x += sx - last.x;
+      state.transform.y += sy - last.y;
+    } else {
+      const hit = nodeAt(sx, sy);
+      state.hovered = hit;
+      if (hit) {
+        tooltip.hidden = false;
+        tooltip.textContent = hit.source_file
+          ? `${hit.label}  —  ${hit.source_file}`
+          : hit.label;
+        tooltip.style.left = sx + 12 + "px";
+        tooltip.style.top = sy + 12 + "px";
+      } else {
+        tooltip.hidden = true;
+      }
+    }
+    last = { x: sx, y: sy };
+  });
+
+  window.addEventListener("mouseup", (ev) => {
+    if (dragNode && downAt) {
+      const moved =
+        Math.hypot(last.x - downAt.x, last.y - downAt.y) > 4;
+      if (!moved) {
+        dragNode.pinned = false;
+        selectNode(dragNode);
+      }
+    }
+    dragNode = null;
+    panning = false;
+    downAt = null;
+  });
+
+  canvas.addEventListener(
+    "wheel",
+    (ev) => {
+      ev.preventDefault();
+      const rect = canvas.getBoundingClientRect();
+      const sx = ev.clientX - rect.left;
+      const sy = ev.clientY - rect.top;
+      const factor = ev.deltaY < 0 ? 1.12 : 1 / 1.12;
+      const t = state.transform;
+      const wx = (sx - t.x) / t.k;
+      const wy = (sy - t.y) / t.k;
+      t.k = Math.min(6, Math.max(0.1, t.k * factor));
+      t.x = sx - wx * t.k;
+      t.y = sy - wy * t.k;
+    },
+    { passive: false }
+  );
+
+  /* ---------- selection + detail panel ---------- */
+
+  function selectNode(node) {
+    state.selected = node;
+    renderDetail(node);
+    syncCommunityActive();
+  }
+
+  function focusNode(node) {
+    // center the viewport on a node (used by search / link clicks)
+    selectNode(node);
+    const t = state.transform;
+    t.x = canvas.clientWidth / 2 - node.x * t.k;
+    t.y = canvas.clientHeight / 2 - node.y * t.k;
+    state.alpha = Math.max(state.alpha, 0.15);
+  }
+
+  function linkRow(node, meta) {
+    const li = document.createElement("li");
+    li.className = "link-item";
+    const label = document.createElement("span");
+    label.className = "link-label";
+    label.textContent = node.label;
+    const m = document.createElement("span");
+    m.className = "link-meta";
+    m.textContent = meta || "";
+    li.append(label, m);
+    li.addEventListener("click", () => focusNode(node));
+    return li;
+  }
+
+  function renderDetail(node) {
+    const panel = document.getElementById("detail-panel");
+    if (!node) {
+      panel.innerHTML =
+        '<h2>Node</h2><p class="muted">Click a node to inspect its links.</p>';
+      return;
+    }
+
+    const backlinks = [];
+    const outgoing = [];
+    for (const e of state.structAdj.get(node.id) || []) {
+      if (e.t.id === node.id) backlinks.push({ node: e.s, rel: e.relation });
+      if (e.s.id === node.id) outgoing.push({ node: e.t, rel: e.relation });
+    }
+    const synaptic = [];
+    for (const e of state.synapseEdges) {
+      if (e.s.id === node.id) synaptic.push({ node: e.t, w: e.weight, c: e.activation_count });
+      else if (e.t.id === node.id) synaptic.push({ node: e.s, w: e.weight, c: e.activation_count });
+    }
+    synaptic.sort((a, b) => b.w - a.w);
+
+    panel.innerHTML = "<h2>Node</h2>";
+    const title = document.createElement("p");
+    title.className = "detail-title";
+    title.textContent = node.label;
+    const sub = document.createElement("p");
+    sub.className = "detail-sub";
+    sub.textContent =
+      (node.source_file || "no source file") +
+      (node.source_location ? `  ·  ${node.source_location}` : "") +
+      `  ·  community ${node.community}  ·  ${node.file_type}`;
+    panel.append(title, sub);
+
+    const section = (heading, items, builder) => {
+      const div = document.createElement("div");
+      div.className = "detail-section" + (items.length ? "" : " empty");
+      const h = document.createElement("h3");
+      h.textContent = `${heading} (${items.length})`;
+      div.appendChild(h);
+      const ul = document.createElement("ul");
+      items.slice(0, 30).forEach((it) => ul.appendChild(builder(it)));
+      div.appendChild(ul);
+      panel.appendChild(div);
+    };
+
+    section("Outgoing links", outgoing, (it) => linkRow(it.node, it.rel));
+    section("Backlinks", backlinks, (it) => linkRow(it.node, it.rel));
+    section("Synaptic neighbors", synaptic, (it) =>
+      linkRow(it.node, `w ${it.w.toFixed(2)} · ${it.c}×`)
+    );
+  }
+
+  /* ---------- community browser ---------- */
+
+  function renderCommunities(communities) {
+    const ul = document.getElementById("community-list");
+    ul.innerHTML = "";
+    for (const c of communities) {
+      const li = document.createElement("li");
+      li.className = "community-row";
+      li.dataset.community = c.id;
+      const wrap = document.createElement("span");
+      wrap.className = "label-wrap";
+      const dot = document.createElement("span");
+      dot.className = "dot";
+      dot.style.background = communityColor(c.id);
+      const label = document.createElement("span");
+      label.className = "result-label";
+      label.textContent = c.id < 0 ? "ungrouped" : `community ${c.id}`;
+      wrap.append(dot, label);
+      const meta = document.createElement("span");
+      meta.className = "result-meta";
+      meta.textContent = c.size;
+      li.append(wrap, meta);
+      li.addEventListener("click", () => {
+        state.activeCommunity =
+          state.activeCommunity === c.id ? null : c.id;
+        syncCommunityActive();
+      });
+      ul.appendChild(li);
+    }
+  }
+
+  function syncCommunityActive() {
+    document.querySelectorAll("#community-list li").forEach((li) => {
+      li.classList.toggle(
+        "active",
+        Number(li.dataset.community) === state.activeCommunity
+      );
+    });
+  }
+
+  /* ---------- semantic quick-switch ---------- */
+
+  const searchInput = document.getElementById("search");
+  const searchResults = document.getElementById("search-results");
+  let searchTimer = null;
+
+  searchInput.addEventListener("input", () => {
+    clearTimeout(searchTimer);
+    const q = searchInput.value.trim();
+    if (!q) {
+      searchResults.innerHTML = "";
+      return;
+    }
+    searchTimer = setTimeout(async () => {
+      try {
+        const res = await fetch("/api/search?q=" + encodeURIComponent(q));
+        const data = await res.json();
+        renderSearchResults(data.results || []);
+      } catch (e) {
+        searchResults.innerHTML = "";
+      }
+    }, 180);
+  });
+
+  function renderSearchResults(results) {
+    searchResults.innerHTML = "";
+    for (const r of results) {
+      const li = document.createElement("li");
+      const label = document.createElement("span");
+      label.className = "result-label";
+      label.textContent = r.label;
+      const meta = document.createElement("span");
+      meta.className = "result-meta";
+      meta.textContent = r.score;
+      li.append(label, meta);
+      li.addEventListener("click", () => {
+        const node = state.nodeById.get(r.id);
+        if (node) focusNode(node);
+      });
+      searchResults.appendChild(li);
+    }
+  }
+
+  /* ---------- toggles ---------- */
+
+  const bind = (id, key) => {
+    const el = document.getElementById(id);
+    el.addEventListener("change", () => {
+      state[key] = el.checked;
+    });
+  };
+  bind("toggle-synapses", "showSynapses");
+  bind("toggle-structural", "showStructural");
+  bind("toggle-local", "localOnly");
+  bind("toggle-labels", "showLabels");
+
+  /* ---------- boot ---------- */
+
+  resize();
+  load().catch((e) => {
+    loading.textContent = "Failed to load graph: " + e;
+  });
+})();

--- a/neuralmind/web/app.js
+++ b/neuralmind/web/app.js
@@ -33,29 +33,40 @@
     showSynapses: true,
     showStructural: true,
     localOnly: false,
+    soloCommunity: false,
+    filterToSearch: false,
     showLabels: false,
     activeCommunity: null,
+    project: "",
+    searchHitIds: null,    // Set when filter-to-search is on
     alpha: 1,
   };
+
+  const LS_KEY = (project) => `nm:layout:${project}`;
 
   /* ---------- data loading ---------- */
 
   async function load() {
     const res = await fetch("/api/graph");
     const data = await res.json();
-    document.getElementById("project-name").textContent = data.project || "";
+    state.project = data.project || "";
+    document.getElementById("project-name").textContent = state.project;
 
     const W = canvas.clientWidth || 800;
     const H = canvas.clientHeight || 600;
-    state.nodes = data.nodes.map((n) => ({
-      ...n,
-      x: W / 2 + (Math.random() - 0.5) * W * 0.8,
-      y: H / 2 + (Math.random() - 0.5) * H * 0.8,
-      vx: 0,
-      vy: 0,
-      degree: 0,
-      pinned: false,
-    }));
+    const saved = loadLayout(state.project);
+    state.nodes = data.nodes.map((n) => {
+      const pos = saved && saved[n.id];
+      return {
+        ...n,
+        x: pos ? pos.x : W / 2 + (Math.random() - 0.5) * W * 0.8,
+        y: pos ? pos.y : H / 2 + (Math.random() - 0.5) * H * 0.8,
+        vx: 0,
+        vy: 0,
+        degree: 0,
+        pinned: !!(pos && pos.pinned),
+      };
+    });
     state.nodeById = new Map(state.nodes.map((n) => [n.id, n]));
 
     const resolve = (e) => {
@@ -178,15 +189,30 @@
   const nodeRadius = (n) => 3.5 + Math.sqrt(n.degree);
 
   function visibleSet() {
-    if (!state.localOnly || !state.selected) return null;
-    const set = new Set([state.selected.id]);
-    for (const e of state.structuralEdges) {
-      if (e.s.id === state.selected.id) set.add(e.t.id);
-      if (e.t.id === state.selected.id) set.add(e.s.id);
+    let set = null;
+    if (state.localOnly && state.selected) {
+      set = new Set([state.selected.id]);
+      for (const e of state.structuralEdges) {
+        if (e.s.id === state.selected.id) set.add(e.t.id);
+        if (e.t.id === state.selected.id) set.add(e.s.id);
+      }
+      for (const e of state.synapseEdges) {
+        if (e.s.id === state.selected.id) set.add(e.t.id);
+        if (e.t.id === state.selected.id) set.add(e.s.id);
+      }
     }
-    for (const e of state.synapseEdges) {
-      if (e.s.id === state.selected.id) set.add(e.t.id);
-      if (e.t.id === state.selected.id) set.add(e.s.id);
+    if (state.soloCommunity && state.activeCommunity != null) {
+      const solo = new Set(
+        state.nodes
+          .filter((n) => n.community === state.activeCommunity)
+          .map((n) => n.id)
+      );
+      set = set ? new Set([...set].filter((id) => solo.has(id))) : solo;
+    }
+    if (state.filterToSearch && state.searchHitIds) {
+      set = set
+        ? new Set([...set].filter((id) => state.searchHitIds.has(id)))
+        : new Set(state.searchHitIds);
     }
     return set;
   }
@@ -380,6 +406,9 @@
       if (!moved) {
         dragNode.pinned = false;
         selectNode(dragNode);
+      } else {
+        // A real drag pins the node — persist so the layout sticks.
+        saveLayout();
       }
     }
     dragNode = null;
@@ -469,6 +498,17 @@
       `  ·  community ${node.community}  ·  ${node.file_type}`;
     panel.append(title, sub);
 
+    if (node.source_file) {
+      const openBtn = document.createElement("button");
+      openBtn.type = "button";
+      openBtn.className = "open-btn";
+      openBtn.textContent = "Open in editor";
+      const status = document.createElement("span");
+      status.className = "open-status";
+      openBtn.addEventListener("click", () => openInEditor(node, status, openBtn));
+      panel.append(openBtn, status);
+    }
+
     const section = (heading, items, builder) => {
       const div = document.createElement("div");
       div.className = "detail-section" + (items.length ? "" : " empty");
@@ -539,6 +579,7 @@
     const q = searchInput.value.trim();
     if (!q) {
       searchResults.innerHTML = "";
+      state.searchHitIds = null;
       return;
     }
     searchTimer = setTimeout(async () => {
@@ -546,8 +587,10 @@
         const res = await fetch("/api/search?q=" + encodeURIComponent(q));
         const data = await res.json();
         renderSearchResults(data.results || []);
+        state.searchHitIds = new Set((data.results || []).map((r) => r.id));
       } catch (e) {
         searchResults.innerHTML = "";
+        state.searchHitIds = null;
       }
     }, 180);
   });
@@ -571,6 +614,65 @@
     }
   }
 
+  /* ---------- open in editor ---------- */
+
+  async function openInEditor(node, statusEl, btn) {
+    btn.disabled = true;
+    statusEl.textContent = "Opening…";
+    statusEl.classList.remove("error");
+    try {
+      const res = await fetch("/api/open", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ id: node.id }),
+      });
+      const data = await res.json();
+      if (data.ok) {
+        const tail = data.line ? `:${data.line}` : "";
+        statusEl.textContent = `Opened ${data.file}${tail}`;
+      } else {
+        statusEl.classList.add("error");
+        statusEl.textContent = data.error || "Could not open file.";
+      }
+    } catch (err) {
+      statusEl.classList.add("error");
+      statusEl.textContent = "Network error: " + err;
+    } finally {
+      btn.disabled = false;
+    }
+  }
+
+  /* ---------- layout persistence ---------- */
+
+  function loadLayout(project) {
+    if (!project) return null;
+    try {
+      const raw = localStorage.getItem(LS_KEY(project));
+      if (!raw) return null;
+      return JSON.parse(raw);
+    } catch {
+      return null;
+    }
+  }
+
+  let saveTimer = null;
+  function saveLayout() {
+    if (!state.project) return;
+    clearTimeout(saveTimer);
+    // Debounce — drags fire many events; we only need the resting state.
+    saveTimer = setTimeout(() => {
+      const out = {};
+      for (const n of state.nodes) {
+        if (n.pinned) out[n.id] = { x: n.x, y: n.y, pinned: true };
+      }
+      try {
+        localStorage.setItem(LS_KEY(state.project), JSON.stringify(out));
+      } catch {
+        // localStorage may be full or disabled — non-critical.
+      }
+    }, 250);
+  }
+
   /* ---------- toggles ---------- */
 
   const bind = (id, key) => {
@@ -582,7 +684,22 @@
   bind("toggle-synapses", "showSynapses");
   bind("toggle-structural", "showStructural");
   bind("toggle-local", "localOnly");
+  bind("toggle-solo", "soloCommunity");
+  bind("toggle-filter-search", "filterToSearch");
   bind("toggle-labels", "showLabels");
+
+  document.getElementById("reset-layout").addEventListener("click", () => {
+    if (!state.project) return;
+    try {
+      localStorage.removeItem(LS_KEY(state.project));
+    } catch {}
+    for (const n of state.nodes) {
+      n.pinned = false;
+      n.x = canvas.clientWidth / 2 + (Math.random() - 0.5) * canvas.clientWidth * 0.8;
+      n.y = canvas.clientHeight / 2 + (Math.random() - 0.5) * canvas.clientHeight * 0.8;
+    }
+    state.alpha = 1;
+  });
 
   /* ---------- boot ---------- */
 

--- a/neuralmind/web/index.html
+++ b/neuralmind/web/index.html
@@ -61,7 +61,12 @@
     </aside>
 
     <main id="canvas-wrap">
-      <canvas id="graph"></canvas>
+      <canvas
+        id="graph"
+        role="img"
+        tabindex="0"
+        aria-label="Force-directed graph of code nodes. Use the search box, community list, and node detail panel on the left for keyboard-accessible navigation."
+      ></canvas>
       <div id="tooltip" hidden></div>
       <div id="loading">Building index &amp; loading graph…</div>
     </main>

--- a/neuralmind/web/index.html
+++ b/neuralmind/web/index.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>NeuralMind — Graph View</title>
+  <link rel="stylesheet" href="/style.css" />
+</head>
+<body>
+  <div id="app">
+    <aside id="sidebar">
+      <header>
+        <h1>NeuralMind</h1>
+        <span id="project-name"></span>
+      </header>
+
+      <section class="panel">
+        <input id="search" type="search" placeholder="Quick switch — semantic search…" autocomplete="off" />
+        <ul id="search-results"></ul>
+      </section>
+
+      <section class="panel">
+        <label class="toggle">
+          <input type="checkbox" id="toggle-synapses" checked />
+          Learned synapses (Hebbian)
+        </label>
+        <label class="toggle">
+          <input type="checkbox" id="toggle-structural" checked />
+          Structural edges (calls / imports)
+        </label>
+        <label class="toggle">
+          <input type="checkbox" id="toggle-local" />
+          Local graph (focus selection)
+        </label>
+        <label class="toggle">
+          <input type="checkbox" id="toggle-labels" />
+          Always show labels
+        </label>
+      </section>
+
+      <section class="panel" id="detail-panel">
+        <h2>Node</h2>
+        <p class="muted">Click a node to inspect its links.</p>
+      </section>
+
+      <section class="panel">
+        <h2>Communities</h2>
+        <ul id="community-list"></ul>
+      </section>
+
+      <footer id="stats"></footer>
+    </aside>
+
+    <main id="canvas-wrap">
+      <canvas id="graph"></canvas>
+      <div id="tooltip" hidden></div>
+      <div id="loading">Building index &amp; loading graph…</div>
+    </main>
+  </div>
+  <script src="/app.js"></script>
+</body>
+</html>

--- a/neuralmind/web/index.html
+++ b/neuralmind/web/index.html
@@ -33,9 +33,18 @@
           Local graph (focus selection)
         </label>
         <label class="toggle">
+          <input type="checkbox" id="toggle-solo" />
+          Solo selected community
+        </label>
+        <label class="toggle">
+          <input type="checkbox" id="toggle-filter-search" />
+          Limit graph to search hits
+        </label>
+        <label class="toggle">
           <input type="checkbox" id="toggle-labels" />
           Always show labels
         </label>
+        <button id="reset-layout" type="button" class="ghost">Reset saved layout</button>
       </section>
 
       <section class="panel" id="detail-panel">

--- a/neuralmind/web/style.css
+++ b/neuralmind/web/style.css
@@ -187,7 +187,14 @@ button.ghost:disabled, .open-btn:disabled {
   position: relative;
   overflow: hidden;
 }
-#graph { display: block; cursor: grab; }
+#graph {
+  display: block;
+  width: 100%;
+  height: 100%;
+  cursor: grab;
+  outline: none;
+}
+#graph:focus-visible { outline: 1px solid var(--accent); outline-offset: -1px; }
 #graph:active { cursor: grabbing; }
 
 #tooltip {

--- a/neuralmind/web/style.css
+++ b/neuralmind/web/style.css
@@ -112,6 +112,32 @@ ul {
   cursor: pointer;
 }
 
+button.ghost, .open-btn {
+  background: var(--bg-elev);
+  color: var(--text);
+  border: 1px solid var(--border);
+  padding: 6px 10px;
+  border-radius: 5px;
+  cursor: pointer;
+  font-size: 12px;
+  margin-top: 8px;
+}
+button.ghost:hover, .open-btn:hover {
+  background: var(--border);
+}
+button.ghost:disabled, .open-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.open-status {
+  display: block;
+  margin-top: 6px;
+  font-size: 11px;
+  color: var(--text-dim);
+}
+.open-status.error { color: #d9694f; }
+
 .muted { color: var(--text-dim); }
 
 #detail-panel .detail-title {

--- a/neuralmind/web/style.css
+++ b/neuralmind/web/style.css
@@ -1,0 +1,201 @@
+:root {
+  --bg: #1a1b1e;
+  --bg-panel: #232428;
+  --bg-elev: #2c2d32;
+  --border: #383a40;
+  --text: #d6d7da;
+  --text-dim: #8a8c93;
+  --accent: #7c6cf0;
+  --accent-warm: #e0a458;
+  --synapse: #e0a458;
+  --structural: #4a4c55;
+}
+
+* { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  height: 100%;
+  background: var(--bg);
+  color: var(--text);
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  font-size: 13px;
+  overflow: hidden;
+}
+
+#app { display: flex; height: 100vh; }
+
+#sidebar {
+  width: 320px;
+  flex-shrink: 0;
+  background: var(--bg-panel);
+  border-right: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;
+}
+
+#sidebar header {
+  padding: 16px;
+  border-bottom: 1px solid var(--border);
+}
+#sidebar header h1 {
+  margin: 0;
+  font-size: 16px;
+  letter-spacing: 0.5px;
+}
+#project-name {
+  color: var(--text-dim);
+  font-size: 12px;
+}
+
+.panel {
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--border);
+}
+.panel h2 {
+  margin: 0 0 8px;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.8px;
+  color: var(--text-dim);
+}
+
+#search {
+  width: 100%;
+  padding: 8px 10px;
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--text);
+  font-size: 13px;
+}
+#search:focus { outline: 1px solid var(--accent); }
+
+ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+#search-results, #community-list { margin-top: 8px; }
+#search-results:empty { display: none; }
+
+#search-results li, #community-list li, .link-item {
+  padding: 6px 8px;
+  border-radius: 5px;
+  cursor: pointer;
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  align-items: baseline;
+}
+#search-results li:hover, #community-list li:hover, .link-item:hover {
+  background: var(--bg-elev);
+}
+.result-label, .link-label {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.result-meta, .link-meta {
+  color: var(--text-dim);
+  font-size: 11px;
+  flex-shrink: 0;
+}
+
+.toggle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 0;
+  cursor: pointer;
+}
+
+.muted { color: var(--text-dim); }
+
+#detail-panel .detail-title {
+  font-size: 14px;
+  font-weight: 600;
+  margin: 0 0 4px;
+  word-break: break-word;
+}
+#detail-panel .detail-sub {
+  color: var(--text-dim);
+  font-size: 11px;
+  margin: 0 0 10px;
+  word-break: break-all;
+}
+.detail-section { margin-top: 10px; }
+.detail-section h3 {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.6px;
+  color: var(--text-dim);
+  margin: 0 0 4px;
+}
+.detail-section.empty { display: none; }
+.dot {
+  width: 8px; height: 8px;
+  border-radius: 50%;
+  display: inline-block;
+  flex-shrink: 0;
+}
+.community-row { align-items: center; }
+.community-row .label-wrap {
+  display: flex; align-items: center; gap: 8px;
+  overflow: hidden;
+}
+#community-list li.active { background: var(--bg-elev); outline: 1px solid var(--accent); }
+
+#stats {
+  margin-top: auto;
+  padding: 12px 16px;
+  color: var(--text-dim);
+  font-size: 11px;
+  line-height: 1.6;
+}
+
+#canvas-wrap {
+  flex: 1;
+  position: relative;
+  overflow: hidden;
+}
+#graph { display: block; cursor: grab; }
+#graph:active { cursor: grabbing; }
+
+#tooltip {
+  position: absolute;
+  pointer-events: none;
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
+  padding: 4px 8px;
+  border-radius: 5px;
+  font-size: 12px;
+  max-width: 280px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  z-index: 10;
+}
+
+#loading {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-dim);
+  background: var(--bg);
+}
+#loading.hidden { display: none; }
+
+.legend {
+  font-size: 11px;
+  color: var(--text-dim);
+  display: flex;
+  gap: 14px;
+  margin-top: 6px;
+}
+.legend span { display: flex; align-items: center; gap: 5px; }
+.swatch { width: 14px; height: 2px; display: inline-block; }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,12 +125,14 @@ Changelog = "https://github.com/dfrostar/neuralmind/releases"
 packages = ["neuralmind"]
 include = [
     "neuralmind/demo_data/**",
+    "neuralmind/web/**",
 ]
 
 [tool.hatch.build.targets.sdist]
 include = [
     "neuralmind/**/*.py",
     "neuralmind/demo_data/**",
+    "neuralmind/web/**",
     "README.md",
     "LICENSE",
     "CHANGELOG.md"

--- a/tests/test_graph_view.py
+++ b/tests/test_graph_view.py
@@ -1,0 +1,57 @@
+"""Tests for the graph-view data layer (SynapseStore.edges + graph_data)."""
+
+from __future__ import annotations
+
+from neuralmind.core import NeuralMind
+from neuralmind.synapses import SynapseStore
+
+
+def test_synapse_edges_returns_sorted_filtered_view(tmp_path):
+    store = SynapseStore(tmp_path / "synapses.db")
+    store.reinforce(["a", "b"])  # one pair, weight = LEARNING_RATE
+    store.reinforce(["a", "b"])  # reinforce same pair -> heavier
+    store.reinforce(["c", "d"])  # lighter pair
+
+    edges = store.edges()
+    assert len(edges) == 2
+    # strongest first
+    assert edges[0][0:2] == ("a", "b")
+    assert edges[0][2] > edges[1][2]
+    # activation_count is carried through
+    assert edges[0][3] == 2
+
+    # min_weight filters out the lighter pair
+    heavy = store.edges(min_weight=edges[0][2])
+    assert [e[0:2] for e in heavy] == [("a", "b")]
+
+
+def test_graph_data_shape_and_synapse_overlay(temp_project):
+    mind = NeuralMind(str(temp_project), backend_type="in_memory")
+    mind.build()
+
+    # Learn an association so the overlay is non-empty.
+    mind.activate(["node_1", "node_2"])
+
+    data = mind.graph_data()
+
+    assert data["project"] == temp_project.name
+    assert data["stats"]["nodes"] == len(data["nodes"])
+    assert data["stats"]["edges"] == len(data["edges"])
+    assert data["stats"]["synapses"] == len(data["synapses"])
+
+    # Nodes carry the fields the UI renders.
+    node = data["nodes"][0]
+    assert {"id", "label", "file_type", "source_file", "community"} <= node.keys()
+
+    # Structural edges only reference real nodes.
+    node_ids = {n["id"] for n in data["nodes"]}
+    for edge in data["edges"]:
+        assert edge["source"] in node_ids
+        assert edge["target"] in node_ids
+
+    # The reinforced pair shows up in the synapse overlay.
+    pairs = {(s["source"], s["target"]) for s in data["synapses"]}
+    assert ("node_1", "node_2") in pairs
+    for syn in data["synapses"]:
+        assert syn["weight"] > 0
+        assert syn["source"] in node_ids and syn["target"] in node_ids

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -45,7 +44,11 @@ def test_ensure_graph_or_explain_missing(tmp_path):
         _ensure_graph_or_explain(tmp_path)
     msg = str(exc.value)
     assert "no graph found" in msg
-    assert "graphify build" in msg
+    # The supported graphify entrypoint is `graphify update`; the package
+    # on PyPI is `graphifyy` (yes, two y's). Lock in both so we don't
+    # quietly regress to the deprecated `graphify build` guidance.
+    assert "graphifyy" in msg
+    assert "graphify update" in msg
 
 
 def test_ensure_graph_or_explain_present(tmp_path):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -7,6 +7,7 @@ from types import SimpleNamespace
 import pytest
 
 from neuralmind.server import (
+    _compute_allowed_open_paths,
     _editor_command,
     _ensure_graph_or_explain,
     _resolve_open_target,
@@ -121,3 +122,30 @@ def test_resolve_open_target_no_source_file(tmp_path):
     path, line, reason = _resolve_open_target(mind, "n1")
     assert path is None
     assert reason == "node has no source file"
+
+
+def test_allowed_open_paths_only_includes_in_project_files(tmp_path):
+    # In-project file -> allowed; missing/outside files -> excluded.
+    keep = tmp_path / "auth" / "handlers.py"
+    keep.parent.mkdir(parents=True)
+    keep.write_text("x")
+
+    outside = tmp_path.parent / "evil.py"
+    outside.write_text("x")
+
+    try:
+        mind = SimpleNamespace(
+            project_path=tmp_path,
+            embedder=SimpleNamespace(
+                nodes=[
+                    {"id": "ok", "source_file": "auth/handlers.py"},
+                    {"id": "missing", "source_file": "auth/missing.py"},
+                    {"id": "escape", "source_file": str(outside)},
+                    {"id": "blank", "source_file": ""},
+                ]
+            ),
+        )
+        allowed = _compute_allowed_open_paths(mind)
+        assert allowed == {str(keep.resolve())}
+    finally:
+        outside.unlink()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,120 @@
+"""Tests for the local graph-view server (auth, editor open, first-run)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from neuralmind.server import (
+    _editor_command,
+    _ensure_graph_or_explain,
+    _resolve_open_target,
+)
+
+
+def test_editor_command_vscode_family():
+    cmd = _editor_command("code", "/x/y.py", 42)
+    assert cmd == ["code", "--goto", "/x/y.py:42"]
+
+    cmd = _editor_command("cursor", "/x/y.py", None)
+    assert cmd == ["cursor", "--goto", "/x/y.py"]
+
+    # shlex parsing preserves user flags like `code -n`.
+    cmd = _editor_command("code -n", "/x/y.py", 7)
+    assert cmd == ["code", "-n", "--goto", "/x/y.py:7"]
+
+
+def test_editor_command_vim_family():
+    assert _editor_command("vim", "/x/y.py", 12) == ["vim", "+12", "/x/y.py"]
+    assert _editor_command("nvim", "/x/y.py", None) == ["nvim", "/x/y.py"]
+
+
+def test_editor_command_unknown_drops_line():
+    cmd = _editor_command("weirdeditor", "/x/y.py", 9)
+    assert cmd == ["weirdeditor", "/x/y.py"]
+
+
+def test_editor_command_empty_returns_empty():
+    assert _editor_command("", "/x/y.py", 1) == []
+
+
+def test_ensure_graph_or_explain_missing(tmp_path):
+    with pytest.raises(RuntimeError) as exc:
+        _ensure_graph_or_explain(tmp_path)
+    msg = str(exc.value)
+    assert "no graph found" in msg
+    assert "graphify build" in msg
+
+
+def test_ensure_graph_or_explain_present(tmp_path):
+    (tmp_path / "graphify-out").mkdir()
+    (tmp_path / "graphify-out" / "graph.json").write_text("{}")
+    # Should not raise.
+    _ensure_graph_or_explain(tmp_path)
+
+
+def test_resolve_open_target_happy_path(tmp_path):
+    # Build a fake mind with an embedder exposing one in-project node.
+    src = tmp_path / "auth" / "handlers.py"
+    src.parent.mkdir(parents=True)
+    src.write_text("def login(): pass\n")
+    mind = SimpleNamespace(
+        project_path=tmp_path,
+        embedder=SimpleNamespace(
+            nodes=[
+                {
+                    "id": "n1",
+                    "label": "login",
+                    "source_file": "auth/handlers.py",
+                    "source_location": "L17",
+                }
+            ]
+        ),
+    )
+    path, line, label = _resolve_open_target(mind, "n1")
+    assert path == src.resolve()
+    assert line == 17
+    assert label == "login"
+
+
+def test_resolve_open_target_escapes_project_root(tmp_path):
+    # A node whose source_file points outside the project must be rejected.
+    outside = tmp_path.parent / "elsewhere.py"
+    outside.write_text("x")
+    try:
+        mind = SimpleNamespace(
+            project_path=tmp_path,
+            embedder=SimpleNamespace(
+                nodes=[
+                    {
+                        "id": "n1",
+                        "source_file": str(outside),
+                        "source_location": "L1",
+                    }
+                ]
+            ),
+        )
+        path, line, reason = _resolve_open_target(mind, "n1")
+        assert path is None
+        assert "outside the project root" in reason
+    finally:
+        outside.unlink()
+
+
+def test_resolve_open_target_unknown_node(tmp_path):
+    mind = SimpleNamespace(project_path=tmp_path, embedder=SimpleNamespace(nodes=[]))
+    path, line, reason = _resolve_open_target(mind, "missing")
+    assert path is None
+    assert reason == "unknown node id"
+
+
+def test_resolve_open_target_no_source_file(tmp_path):
+    mind = SimpleNamespace(
+        project_path=tmp_path,
+        embedder=SimpleNamespace(nodes=[{"id": "n1", "source_file": ""}]),
+    )
+    path, line, reason = _resolve_open_target(mind, "n1")
+    assert path is None
+    assert reason == "node has no source file"


### PR DESCRIPTION
## Summary

Adds **`neuralmind serve`** — a local, dependency-free, Obsidian-style graph view over the existing ChromaDB index and synapse store. The agent-facing brain is now also a human-facing tool. Code nodes coloured by community, structural edges and Hebbian synapses drawn together, backlinks + synaptic neighbours panel, semantic quick-switch search, and one-click "open in editor".

This closes the biggest gap in NeuralMind today: retrieval used to be a black box. You couldn't see what the agent fetched, whether the graph was reasonable, or whether the synapse layer was actually learning. The graph view exposes all three.

### What's in the box

- **`neuralmind serve`** — stdlib HTTP server, vanilla-JS canvas force-directed graph, no CDN.
- **`/api/graph`** — unified payload of nodes + structural edges + learned synapse overlay.
- **`/api/search`** — semantic search powers the quick-switcher.
- **`/api/open`** — opens the node's source file at the right line via `$EDITOR` / `--editor`. Smart argv for VS Code, Cursor, vim, sublime, JetBrains. Path is resolved and constrained to the project root.
- **Per-session access token** — random `?token=…` printed by the CLI, bound to a cookie. `--no-auth` opt-out for embedded use.
- **First-run guidance** — when `graphify-out/graph.json` is missing, prints the exact commands to fix it instead of a cryptic build error.
- **Sidebar controls** — solo selected community, limit graph to search hits, always-show-labels, local-graph focus, reset saved layout.
- **Layout persistence** — pinned node positions saved to `localStorage` per project.

### Why now

User asked for "features of both" Obsidian and NeuralMind, one-stop shopping. NeuralMind already had the *agent-facing* brain (semantic index, Hebbian synapses, spreading activation). It was missing Obsidian's *human-facing* surface. This PR bolts that on without splitting the tool in two — same `synapses.db`, same ChromaDB index.

### User problems addressed

1. **Trust / verifiability** — agent's retrieval is now inspectable.
2. **Debugging bad retrievals** — search visually for a concept, see if it's even reachable.
3. **Validating the Hebbian claim** — synapses become a visible overlay with weights and activation counts.
4. **Onboarding to an unfamiliar codebase** — Obsidian-graph use case, but for code.
5. **Spotting bad graphs from graphify** — visual exposes disconnected components / miscategorized nodes.

## Test plan

- [x] Unit: `tests/test_graph_view.py` covers `SynapseStore.edges()` and `NeuralMind.graph_data()` shape + synapse overlay alignment.
- [x] Unit: `tests/test_server.py` covers `_editor_command` (VS Code / vim / unknown / empty), `_ensure_graph_or_explain` (missing/present), and `_resolve_open_target` (happy path, escape-from-root, unknown id, no source file).
- [x] All 103 tests in cli/core/synapses/synapse_integration suites pass.
- [x] Server smoke-tested end-to-end against the bundled demo project:
  - 401 without token, 200 with `?token=` query, 200 on subsequent requests via cookie
  - `/api/open` returns `ok: true` with correct `file` + `line` for indexed nodes; 400 with `unknown node id` for invalid ids
  - First-run guard fires with friendly RuntimeError when `graphify-out/graph.json` is missing
  - Path-traversal returns 404
- [ ] **Cannot test in CI:** canvas rendering, force simulation, pan/zoom, drag-to-pin, layout persistence — verified manually by maintainer with `neuralmind serve .`.

## Release path

This branch uses `feat:` commits, so release-please should auto-open a release PR bumping `0.5.3 → 0.6.0`. Merging the release PR triggers the `release.yml` workflow and PyPI Trusted Publishing.

`docs/about.html` already labels v0.6.0 as the Graph View release; if release-please picks a different bump, that line should be tweaked in the release PR.

https://claude.ai/code/session_012ETGqFvnHc93J3ToqawKbU

---
_Generated by [Claude Code](https://claude.ai/code/session_012ETGqFvnHc93J3ToqawKbU)_