### PR TITLE
docs: correct v0.5.4 release labels in about page

### DIFF
--- a/docs/about.html
+++ b/docs/about.html
@@ -151,13 +151,13 @@
     <section>
         <div class="container">
             <h2>Status & Roadmap</h2>
-            <h3>Current Release: v0.6.0 — Graph View</h3>
+            <h3>Current Release: v0.5.4 — Graph View</h3>
             <p>Adds <code>neuralmind serve</code>: a local, dependency-free, Obsidian-style graph view over the existing index and synapse store. Code nodes coloured by community; structural edges and Hebbian synapses drawn together; backlinks, synaptic neighbours, semantic quick-switch, and one-click open-in-editor. Builds on v0.5.x's bundled MCP server and v0.4.0's brain-like synapse layer — no migration needed.</p>
 
             <h3>Future Releases</h3>
             <ul>
-                <li><strong>v0.6.x</strong> — Live activity feed of synapse co-activations (the brain learning in real time), edge tooltips that explain "why are these two nodes related?", and a "replay last query" overlay that highlights the L3 hits the agent received.</li>
-                <li><strong>v0.7.0</strong> — Auto-watcher launch from <code>SessionStart</code> (<a href="https://github.com/dfrostar/neuralmind/issues/78">#78</a>); synapse import/export so teams can share a learned brain (<a href="https://github.com/dfrostar/neuralmind/issues/79">#79</a>); benchmarks measuring retrieval quality with vs without synapses (<a href="https://github.com/dfrostar/neuralmind/issues/80">#80</a>); PostgreSQL pgvector scale testing; expanded backend ecosystem.</li>
+                <li><strong>Next patch releases</strong> — Live activity feed of synapse co-activations (the brain learning in real time), edge tooltips that explain "why are these two nodes related?", and a "replay last query" overlay that highlights the L3 hits the agent received.</li>
+                <li><strong>Later</strong> — Auto-watcher launch from <code>SessionStart</code> (<a href="https://github.com/dfrostar/neuralmind/issues/78">#78</a>); synapse import/export so teams can share a learned brain (<a href="https://github.com/dfrostar/neuralmind/issues/79">#79</a>); benchmarks measuring retrieval quality with vs without synapses (<a href="https://github.com/dfrostar/neuralmind/issues/80">#80</a>); PostgreSQL pgvector scale testing; expanded backend ecosystem.</li>
                 <li><strong>v1.0.0 (Target Q1 2027)</strong> — Stable API guarantee, 2-year LTS support, commercial support options.</li>
             </ul>
 


### PR DESCRIPTION
## Summary

Quick correction to `docs/about.html` — the version labels I wrote in PR #101 assumed `release-please` would minor-bump (0.5.3 → 0.6.0), but the project's `release-please-config.json` has `bump-patch-for-minor-pre-major: true`, so `feat:` becomes a **patch** bump while pre-1.0. The release PR (#102) is bumping to **v0.5.4**.

### Changes

- `Current Release: v0.6.0 — Graph View` → **`v0.5.4 — Graph View`**
- Future-release bullets drop the speculative `v0.6.x` / `v0.7.0` labels (which would have rotted on the next release anyway) in favour of `Next patch releases` / `Later`.

Tiny — single file, three line changes.

### Test plan

- [x] HTML structure unchanged; only label text edited.
- [x] No code, no tests touched.

This should land before (or right after) #102 so the published Pages site doesn't show the wrong version number.

https://claude.ai/code/session_012ETGqFvnHc93J3ToqawKbU

---
_Generated by [Claude Code](https://claude.ai/code/session_012ETGqFvnHc93J3ToqawKbU)_