### PR TITLE
docs: refresh roadmap + landing pages with current graph-view plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -490,6 +490,14 @@ Why it matters: the agent-facing brain has always been a black box — you could
 see what NeuralMind retrieved, whether the graph was reasonable, or what the
 synapse layer had actually learned. The graph view exposes all three.
 
+**Coming next (graph-view Phase B):** a
+[replay-last-query overlay](https://github.com/dfrostar/neuralmind/pull/105)
+that highlights the L3 hits the agent received,
+[edge tooltips + a min-weight synapse slider](https://github.com/dfrostar/neuralmind/pull/106)
+answering "why are these two nodes related?", pin UX, and a
+`Cmd/Ctrl-K` quick-switch. Then Phase C: a live activity feed of
+synapse co-activations. Full plan in [ROADMAP.md](ROADMAP.md).
+
 ---
 
 ## 🔧 How It Works
@@ -1327,6 +1335,19 @@ neuralmind query . "question"     # get context for a specific question
 </details>
 
 ---
+
+## ✨ What's New in v0.5.4 — Graph view
+
+`neuralmind serve` ships in v0.5.4 — see the
+[Graph view section above](#-graph-view-neuralmind-serve). The
+**next patch release (v0.5.5)** lands graph-view Phase B: the
+replay-last-query overlay
+([#105](https://github.com/dfrostar/neuralmind/pull/105)), edge
+tooltips + min-weight synapse slider
+([#106](https://github.com/dfrostar/neuralmind/pull/106)), pin UX,
+and a `Cmd/Ctrl-K` quick-switch. Phase C after that: a live activity
+feed of synapse co-activations. Full plan in
+[ROADMAP.md](ROADMAP.md).
 
 ## ✨ What's New in v0.4.0 — Brain-like Synapse Layer
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,29 +8,70 @@ For the longer-horizon engineering plan (release cadence, monitoring,
 compliance, scale targets), see
 [`docs/FUTURE-PROOFING-PLAN.md`](docs/FUTURE-PROOFING-PLAN.md).
 
-## Now (next ~6 weeks)
+## Now (active — v0.5.x)
 
-- **One-command demo on the bundled fixture.** `bash scripts/demo.sh`
-  — proves the headline reduction claim in under a minute on real
-  code. ✅ shipped.
-- **Fact-based business case + honest assessment docs.**
-  [`BUSINESS-CASE.md`](docs/BUSINESS-CASE.md) makes the compelling
-  argument with provable claims; [`HONEST-ASSESSMENT.md`](docs/HONEST-ASSESSMENT.md)
-  documents where it isn't worth installing. ✅ shipped.
-- **README slim.** Cut the inflated savings table, the duplicate
-  "who is this for" section, and the Enterprise Use Cases marketing
-  wall (moved to [`ENTERPRISE.md`](docs/ENTERPRISE.md) with honest
-  framing). ✅ shipped (first pass; further trimming possible).
+The current development thread is the **graph view** (`neuralmind
+serve`), introduced in v0.5.4. We're iterating it in small,
+independently-mergeable slices — "Phase B" below — before tackling
+the bigger live-activity feed step in Phase C.
+
+### Graph view — Phase B (small UX wins)
+
+- **Replay-last-query overlay.** Reads
+  `~/.neuralmind/memory/query_events.jsonl`, highlights the L3 hits
+  the agent received, draws a pulse from the query into them.
+  Answers "what did the agent actually see?"
+  [`#105`](https://github.com/dfrostar/neuralmind/pull/105) — green, awaiting merge.
+- **Edge tooltips + min-weight synapse slider.** Hover any edge to
+  see the relationship (`calls`, or `learned · w 0.42 · 7×`); a
+  sidebar slider hides weak synapses on dense graphs.
+  [`#106`](https://github.com/dfrostar/neuralmind/pull/106) — green, awaiting merge.
+- **Pin UX.** Drag already pins silently; add a visible pin glyph, a
+  detail-panel "Pin / Unpin" toggle, and a sidebar "Unpin all".
+  Pure frontend.
+- **Quick-switch keyboard shortcut.** Bind `Cmd/Ctrl-K` (and `/`) to
+  focus the search input from anywhere on the canvas; Esc to clear.
+
+### Graph view — Phase C (the next bigger lift)
+
+- **Live activity feed.** Server-sent events stream synapse
+  activations and file-watcher events into a small sidebar log so
+  you can *see* the brain learning in real time. Touches
+  `server.py`, `synapses.py`, `watcher.py`, and the frontend.
+
+### Other in-flight maintenance
+
 - **Seed community benchmarks with 3–5 outside submissions** so the
-  table doesn't look maintainer-only. **Maintainer action needed:**
-  best path is running `neuralmind benchmark . --contribute` on
-  Mempalace, the cmmc20 project, and 2–3 well-known OSS Python/TS
-  repos with permission. Each seed: ~10 min wall time. See
+  table doesn't look maintainer-only. Best path is running
+  `neuralmind benchmark . --contribute` on Mempalace, the cmmc20
+  project, and 2–3 well-known OSS Python/TS repos with permission.
+  Each seed: ~10 min wall time. See
   [`docs/community-benchmarks.json`](docs/community-benchmarks.json).
 - **Asciinema clip of the demo** embedded at the top of the README.
   Runbook in [`docs/RECORDING-DEMO.md`](docs/RECORDING-DEMO.md);
   needs to be recorded by the maintainer (can't run in CI because
   of the chromadb model download).
+
+### Shipped recently
+
+- **Graph view UI base** (v0.5.4) — `neuralmind serve` ships a
+  local, dependency-free Obsidian-style force-directed graph with
+  the synapse overlay, backlinks, semantic quick-switch,
+  open-in-editor, per-session auth token, and layout persistence.
+- **Bundled MCP server** (v0.5.0) — the `[mcp]` extra is now a no-op;
+  `pip install neuralmind` ships the MCP server by default. Closes
+  the most common install footgun.
+- **One-command demo on the bundled fixture** — `bash scripts/demo.sh`
+  proves the headline reduction claim in under a minute on real
+  code.
+- **Fact-based business case + honest assessment docs** —
+  [`BUSINESS-CASE.md`](docs/BUSINESS-CASE.md) makes the compelling
+  argument with provable claims;
+  [`HONEST-ASSESSMENT.md`](docs/HONEST-ASSESSMENT.md) documents
+  where NeuralMind isn't worth installing.
+- **README slim** — moved the Enterprise wall to
+  [`ENTERPRISE.md`](docs/ENTERPRISE.md), cut the inflated savings
+  table, killed the duplicate audiences section.
 
 ## Next (~1–2 quarters)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -18,8 +18,8 @@ the bigger live-activity feed step in Phase C.
 ### Graph view — Phase B (small UX wins)
 
 - **Replay-last-query overlay.** Reads
-  `~/.neuralmind/memory/query_events.jsonl`, highlights the L3 hits
-  the agent received, draws a pulse from the query into them.
+  `<project>/.neuralmind/recent_queries.jsonl`, highlights the L3
+  hits the agent received, draws a pulse from the query into them.
   Answers "what did the agent actually see?"
   [`#105`](https://github.com/dfrostar/neuralmind/pull/105) — green, awaiting merge.
 - **Edge tooltips + min-weight synapse slider.** Hover any edge to

--- a/docs/about.html
+++ b/docs/about.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="About NeuralMind: Open-source semantic code intelligence with a brain-like synapse layer that learns associations between code from how you actually use it. 100% local, NIST AI RMF compliant, enterprise-ready.">
-    <meta name="keywords" content="NeuralMind, semantic code search, AI agents, token optimization, local-first, open-source, NIST AI RMF, brain-like learning, hebbian learning, synapse layer, claude code memory">
+    <meta name="description" content="About NeuralMind: Open-source semantic code intelligence with a brain-like synapse layer that learns associations between code from how you actually use it, plus an Obsidian-style graph view that makes the index inspectable. 100% local, NIST AI RMF compliant, enterprise-ready.">
+    <meta name="keywords" content="NeuralMind, semantic code search, AI agents, token optimization, local-first, open-source, NIST AI RMF, brain-like learning, hebbian learning, synapse layer, claude code memory, graph view, neuralmind serve, Obsidian-style code graph, force-directed graph, MCP server, code visualization">
     <title>About NeuralMind - Semantic Code Intelligence with Brain-like Memory</title>
     <style>
         * { margin: 0; padding: 0; box-sizing: border-box; }

--- a/docs/about.html
+++ b/docs/about.html
@@ -156,7 +156,7 @@
 
             <h3>Future Releases</h3>
             <ul>
-                <li><strong>Next patch releases</strong> — Live activity feed of synapse co-activations (the brain learning in real time), edge tooltips that explain "why are these two nodes related?", and a "replay last query" overlay that highlights the L3 hits the agent received.</li>
+                <li><strong>v0.5.5 (next patch release)</strong> — Graph-view Phase B: a <a href="https://github.com/dfrostar/neuralmind/pull/105">"replay last query" overlay</a> highlighting the L3 hits the agent received, <a href="https://github.com/dfrostar/neuralmind/pull/106">edge tooltips + a min-weight synapse slider</a> answering "why are these two nodes related?" on hover, plus pin UX and a <code>Cmd/Ctrl-K</code> quick-switch shortcut. <strong>Phase C</strong> after: a live activity feed of synapse co-activations so you can watch the brain learning in real time.</li>
                 <li><strong>Later</strong> — Auto-watcher launch from <code>SessionStart</code> (<a href="https://github.com/dfrostar/neuralmind/issues/78">#78</a>); synapse import/export so teams can share a learned brain (<a href="https://github.com/dfrostar/neuralmind/issues/79">#79</a>); benchmarks measuring retrieval quality with vs without synapses (<a href="https://github.com/dfrostar/neuralmind/issues/80">#80</a>); PostgreSQL pgvector scale testing; expanded backend ecosystem.</li>
                 <li><strong>v1.0.0 (Target Q1 2027)</strong> — Stable API guarantee, 2-year LTS support, commercial support options.</li>
             </ul>

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="NeuralMind: Semantic code intelligence for AI agents. Reduce token costs 40–70× with local code indexing, smart retrieval, and NIST AI RMF compliance.">
-    <meta name="keywords" content="semantic code search, AI coding agents, token optimization, code intelligence, local-first, NIST AI RMF, Claude, Cursor">
+    <meta name="description" content="NeuralMind: Semantic code intelligence for AI agents. Reduce token costs 40–70× with local code indexing, a brain-like synapse layer that learns from co-activation, and an Obsidian-style graph view over your codebase. NIST AI RMF compliant.">
+    <meta name="keywords" content="semantic code search, AI coding agents, token optimization, code intelligence, local-first, NIST AI RMF, Claude, Cursor, MCP server, graph view, neuralmind serve, Obsidian-style code graph, force-directed graph, synapse layer, Hebbian learning, code visualization">
     <title>NeuralMind - Semantic Code Intelligence for AI Agents | 40–70× Token Reduction</title>
     <meta property="og:title" content="NeuralMind - Semantic Code Intelligence for AI Agents">
     <meta property="og:description" content="Local-first code indexing with 40–70× per-query token reduction (50K → ~800 tokens). Zero data exfiltration, 100% offline, enterprise-ready.">

--- a/docs/index.html
+++ b/docs/index.html
@@ -298,12 +298,12 @@ neuralmind stats .</code></pre>
             <h2>Status & Future</h2>
             <div class="highlight-grid">
                 <div class="highlight-item">
-                    <strong>✅ v0.4.0 (Current)</strong>
-                    <p>Brain-like synapse layer, NIST AI RMF, MCP security, pluggable backends.</p>
+                    <strong>✅ v0.5.4 (Current)</strong>
+                    <p>Graph view (<code>neuralmind serve</code>) — Obsidian-style force-directed graph over the index and synapse store, with backlinks, semantic quick-switch, and one-click open-in-editor. Stacks on v0.5.0's bundled MCP server and v0.4.0's brain-like synapse layer.</p>
                 </div>
                 <div class="highlight-item">
-                    <strong>📋 v0.5.0 (Next)</strong>
-                    <p>MCP server bundled by default — closes the install footgun. Packaging-only; API unchanged. Coming after: auto-watcher (<a href="https://github.com/dfrostar/neuralmind/issues/78">#78</a>), synapse import/export (<a href="https://github.com/dfrostar/neuralmind/issues/79">#79</a>), retrieval-quality benchmark (<a href="https://github.com/dfrostar/neuralmind/issues/80">#80</a>).</p>
+                    <strong>📋 v0.5.5 (Next)</strong>
+                    <p>Graph-view Phase B: replay-last-query overlay (<a href="https://github.com/dfrostar/neuralmind/pull/105">#105</a>), edge tooltips + min-weight synapse slider (<a href="https://github.com/dfrostar/neuralmind/pull/106">#106</a>), pin UX, Cmd-K quick-switch. Then Phase C: live activity feed of synapse co-activations.</p>
                 </div>
                 <div class="highlight-item">
                     <strong>🎯 v1.0.0 (Target Q1 2027)</strong>

--- a/docs/wiki/CLI-Reference.md
+++ b/docs/wiki/CLI-Reference.md
@@ -632,6 +632,66 @@ neuralmind watch . --decay-interval 0
 
 ---
 
+### serve *(v0.5.4+)*
+
+Start the graph-view UI — a local, dependency-free, Obsidian-style
+force-directed graph over the same index and synapse store your AI
+agent queries. Renders code nodes coloured by community, structural
+edges and Hebbian synapses drawn together, plus backlinks, synaptic
+neighbours, a semantic quick-switcher, and one-click open-in-editor.
+Stops cleanly on Ctrl-C.
+
+The server binds to 127.0.0.1 by default and prints a per-session
+auth-token URL on startup; pass that URL to the browser so untrusted
+local processes can't read your graph.
+
+```bash
+neuralmind serve [project_path] [--port PORT] [--no-browser] [--editor EDITOR] [--no-auth]
+```
+
+#### Arguments
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `project_path` | No | Project root (default: current directory) |
+
+#### Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--port` | `8765` | TCP port to bind to |
+| `--no-browser` | off | Don't auto-open a browser tab on startup |
+| `--editor` | `$EDITOR` | Editor command used by the "Open in editor" button — `code`, `code -n`, `cursor`, `vim`, `subl`, `idea`, etc. |
+| `--no-auth` | off | Disable the per-session auth token. Only use on a trusted host. |
+
+#### Examples
+
+```bash
+# Run against the current project
+neuralmind serve .
+
+# Custom editor for the "open in editor" button
+neuralmind serve . --editor "code -n"
+
+# Pick a different port and skip the browser
+neuralmind serve . --port 9000 --no-browser
+
+# Skip auth for a kiosk / trusted local host
+neuralmind serve . --no-auth
+```
+
+#### Notes
+
+- Read-only over HTTP. Edits to nodes/synapses still go through the
+  regular CLI and MCP tools; the UI only inspects.
+- The `/api/open` endpoint launches `$EDITOR` against an allowlist
+  pre-computed from the graph's `source_file` set, so a tampered
+  client can't trick the server into opening arbitrary paths.
+- Vanilla-JS frontend, stdlib-only HTTP server, no CDN. Safe to run
+  behind a firewall.
+
+---
+
 ## Exit Codes
 
 | Code | Meaning |

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -6,15 +6,33 @@ Welcome — this wiki is the in-depth reference. For the fastest orientation, us
 
 ## What's New
 
-**v0.4.0 — Brain-like synapse layer.** NeuralMind now runs as a second
-brain alongside the LLM: a persistent SQLite-backed weighted graph that
-learns associations between code nodes from co-activation, decays unused
-edges, and answers via spreading activation. Includes the `neuralmind watch`
-daemon, three new Claude Code lifecycle hooks (SessionStart, UserPromptSubmit,
-PreCompact), and a memory exporter that surfaces learned associations to
-Claude Code's auto-memory system. See the [release notes](../blob/main/RELEASE_NOTES_v0.4.0.md)
-or the [Architecture](Architecture#synapse-layer-v04) and [Learning Guide](Learning-Guide#v04-synapse-layer)
-sections.
+**v0.5.4 — Graph view (`neuralmind serve`).** A local,
+dependency-free, Obsidian-style force-directed graph over the same
+index your agent queries. Code nodes coloured by community;
+structural edges and Hebbian synapses drawn together; backlinks,
+synaptic neighbours, semantic quick-switch, and one-click
+open-in-editor. Per-session access token bound to 127.0.0.1 by
+default. Builds on v0.5.0's bundled MCP server and v0.4.0's
+brain-like synapse layer — no migration needed.
+
+**Coming next.** A Phase B sequence of small graph-view UX wins —
+[replay-last-query overlay (#105)](https://github.com/dfrostar/neuralmind/pull/105),
+[edge tooltips + min-weight synapse slider (#106)](https://github.com/dfrostar/neuralmind/pull/106),
+pin UX, and a `Cmd/Ctrl-K` quick-switch shortcut — followed by
+Phase C: a live activity feed of synapse co-activations so you can
+watch the brain learning in real time. Full plan in the
+[ROADMAP](../blob/main/ROADMAP.md).
+
+**v0.4.0 — Brain-like synapse layer.** NeuralMind runs as a second
+brain alongside the LLM: a persistent SQLite-backed weighted graph
+that learns associations between code nodes from co-activation,
+decays unused edges, and answers via spreading activation. Includes
+the `neuralmind watch` daemon, three Claude Code lifecycle hooks
+(SessionStart, UserPromptSubmit, PreCompact), and a memory exporter
+that surfaces learned associations to Claude Code's auto-memory
+system. See the [release notes](../blob/main/RELEASE_NOTES_v0.4.0.md)
+or the [Architecture](Architecture#synapse-layer-v04) and
+[Learning Guide](Learning-Guide#v04-synapse-layer) sections.
 
 ## Quick Links
 


### PR DESCRIPTION
## Summary

Refreshes the user-facing landing surfaces so they reflect the actual development plan instead of months-old drift. No code changes.

### What was stale (initial pass)

| Surface | Said | Reality |
|---|---|---|
| `ROADMAP.md` "Now" | v0.5.0-era business-case docs that all shipped | Graph view (v0.5.4) + Phase B is the live thread |
| `docs/index.html` status tiles | "v0.4.0 Current / v0.5.0 Next" | v0.5.4 current, v0.5.5 next |
| `docs/wiki/Home.md` "What's New" | v0.4.0 brain-like synapse layer | v0.5.4 graph view (auto-mirrors to the public Wiki via `sync-wiki.yml`) |
| `README.md` "What's New" h2 | Led with v0.4.0; graph-view section had no "coming next" pointer | v0.5.4 entry + Phase B teaser linking to #105/#106 |
| `docs/about.html` | Already said v0.5.4; Phase B bullet read as aspirational | Reads as in-flight now that the PRs exist |

### What was stale (second pass, after review feedback + audit)

| Surface | Said | Reality |
|---|---|---|
| `ROADMAP.md` replay overlay path | `~/.neuralmind/memory/query_events.jsonl` (Copilot caught this on this PR) | `<project>/.neuralmind/recent_queries.jsonl` — corrected |
| `docs/wiki/CLI-Reference.md` | Had entries for build / query / wakeup / search / benchmark / stats / learn / skeleton / install-hooks / init-hook / watch — but **no `serve` command** despite shipping in v0.5.4 | Added full reference with args, flags (`--port` / `--no-browser` / `--editor` / `--no-auth`), examples, and security notes |
| `docs/index.html` + `docs/about.html` `<meta name="keywords">` | Pre-dated the graph view and the synapse layer entirely | Extended both with: graph view, neuralmind serve, Obsidian-style code graph, force-directed graph, MCP server, Hebbian learning, synapse layer, code visualization |

### Shape of the new ROADMAP

Three explicit headers so future drift is obvious at a glance:

- **Graph view — Phase B (small UX wins)** — replay overlay (#105), edge tooltips + min-weight slider (#106), pin UX, Cmd-K quick-switch
- **Graph view — Phase C (the next bigger lift)** — live activity feed of synapse co-activations
- **Shipped recently** — moves done items into a recognizable graveyard so "Now" stays current

## Out of MCP scope from this session — left for the maintainer

These need a human (no MCP tool exposes them in this scope):

1. **GitHub repo About-box description.** Current: *"Adaptive Neural Knowledge System — 40-70x token reduction for AI code understanding"*. Suggested rewrite:
   > Local-first semantic code intelligence for AI coding agents. 40-70× token reduction on code questions, brain-like synapse layer that learns from co-activation, and an Obsidian-style graph view (`neuralmind serve`). MCP server + PostToolUse compression for Claude Code, Cursor, Cline, Continue.

2. **GitHub repo topics** ("about" chips). Currently 10: `ai`, `ai-coding`, `chromadb`, `code-understanding`, `context-window`, `knowledge-graph`, `llm`, `mcp`, `semantic-search`, `token-reduction`. Suggested additions: `graph-view`, `code-visualization`, `synapse`, `hebbian-learning`, `obsidian`, `force-directed-graph`, `code-graph`.

3. **GitHub Projects board.** `has_projects: true` on the repo but no MCP tool surfaces project boards in this scope, so I couldn't audit or update what's there.

4. **`pyproject.toml` `keywords` list.** Intentionally untouched — adding new keywords to v0.5.4 mid-release-please dispatch would complicate the publish flow. Suggested additions (apply post-v0.5.4 release, will land in v0.5.5+): `graph-view`, `code-graph`, `obsidian-style`, `synapse-layer`, `hebbian-learning`, `code-visualization`, `force-directed-graph`, `neuralmind-serve`.

## Test plan

- [x] `git diff --stat` shows only the 6 doc files touched across the three commits.
- [x] All cross-links in the edited blocks point at existing files / valid PR URLs.
- [x] Copilot's first review comment on `ROADMAP.md:21` (path drift) addressed in commit 2.
- [ ] Visual check on the rendered GitHub Pages once this merges and Pages rebuilds.
- [ ] Wiki sync workflow runs on merge and the public Wiki Home + CLI-Reference pages update.

https://claude.ai/code/session_012ETGqFvnHc93J3ToqawKbU