### PR TITLE
feat(serve): visible pin glyph, Pin/Unpin button, Unpin-all

### DIFF
--- a/neuralmind/web/app.js
+++ b/neuralmind/web/app.js
@@ -316,6 +316,18 @@
         ctx.arc(n.x, n.y, r + 5 + 6 * pulse, 0, Math.PI * 2);
         ctx.stroke();
       }
+      if (n.pinned) {
+        // Pin glyph: small warm dot at top-right, zoom-stable.
+        const off = r * 0.72;
+        const pr = 2.4 / t.k;
+        ctx.beginPath();
+        ctx.arc(n.x + off, n.y - off, pr, 0, Math.PI * 2);
+        ctx.fillStyle = "#e0a458";
+        ctx.fill();
+        ctx.lineWidth = 0.8 / t.k;
+        ctx.strokeStyle = "#1a1b1e";
+        ctx.stroke();
+      }
       if (state.showLabels || n === focus || n === state.selected) {
         ctx.globalAlpha = dim ? 0.4 : 1;
         ctx.fillStyle = "#d6d7da";
@@ -641,6 +653,22 @@
       `  ·  community ${node.community}  ·  ${node.file_type}`;
     panel.append(title, sub);
 
+    const pinBtn = document.createElement("button");
+    pinBtn.type = "button";
+    pinBtn.className = "open-btn";
+    const refreshPinLabel = () => {
+      pinBtn.textContent = node.pinned ? "Unpin" : "Pin";
+    };
+    refreshPinLabel();
+    pinBtn.addEventListener("click", () => {
+      node.pinned = !node.pinned;
+      refreshPinLabel();
+      saveLayout();
+      if (!node.pinned) state.alpha = Math.max(state.alpha, 0.3);
+      wake();
+    });
+    panel.append(pinBtn);
+
     if (node.source_file) {
       const openBtn = document.createElement("button");
       openBtn.type = "button";
@@ -900,6 +928,22 @@
       n.y = canvas.clientHeight / 2 + (Math.random() - 0.5) * canvas.clientHeight * 0.8;
     }
     state.alpha = 1;
+    if (state.selected) renderDetail(state.selected);
+    wake();
+  });
+
+  document.getElementById("unpin-all").addEventListener("click", () => {
+    let any = false;
+    for (const n of state.nodes) {
+      if (n.pinned) {
+        n.pinned = false;
+        any = true;
+      }
+    }
+    if (!any) return;
+    saveLayout();
+    state.alpha = Math.max(state.alpha, 0.6);
+    if (state.selected) renderDetail(state.selected);
     wake();
   });
 

--- a/neuralmind/web/index.html
+++ b/neuralmind/web/index.html
@@ -48,7 +48,10 @@
           <span>Min synapse weight: <span id="weight-readout">0.05</span></span>
           <input type="range" id="synapse-min-weight" min="0" max="1" step="0.05" value="0.05" aria-label="Minimum synapse weight to display" />
         </label>
-        <button id="reset-layout" type="button" class="ghost">Reset saved layout</button>
+        <div class="button-row">
+          <button id="reset-layout" type="button" class="ghost">Reset saved layout</button>
+          <button id="unpin-all" type="button" class="ghost">Unpin all</button>
+        </div>
       </section>
 
       <section class="panel" id="detail-panel">

--- a/neuralmind/web/style.css
+++ b/neuralmind/web/style.css
@@ -150,6 +150,13 @@ button.ghost:disabled, .open-btn:disabled {
   cursor: not-allowed;
 }
 
+.button-row {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+.button-row > button { margin-top: 8px; }
+
 .open-status {
   display: block;
   margin-top: 6px;


### PR DESCRIPTION
## Summary

Drag-to-pin already worked silently — positions stuck on refresh, but the layout was invisible and there was no way to unpin from the UI without dragging again or nuking the whole saved layout. This makes the pinned set legible and gives users in-UI controls.

- **Pin glyph** — `draw()` paints a small warm-colored dot at the upper-right of every pinned node, sized in screen units so it stays legible at any zoom.
- **Pin / Unpin in the detail panel** — clicking the selected node now has a button that flips `node.pinned` and re-saves the layout.
- **"Unpin all"** — new sidebar button next to "Reset saved layout" releases every pin without throwing away node positions (whereas Reset wipes both).

All state still flows through the existing `LS_KEY(projectKey)` localStorage entry, so two repos with the same basename remain isolated.

## Test plan

- [x] `ruff check` + `black --check` clean
- [x] Relevant Python tests (`test_server.py`, `test_graph_view.py`) pass
- [x] Headless smoke against bundled `sample_project` fixture: Pin → Unpin → Pin → Unpin-all all mutate the saved layout correctly, with zero JS console errors
- [x] Pin glyph renders visibly on the selected node in canvas screenshot
- [ ] Manual UI check on a real project (recommended before merge)

https://claude.ai/code/session_01JupPy4oAsoTJ9gw1VUs9Vg

---
_Generated by [Claude Code](https://claude.ai/code/session_01JupPy4oAsoTJ9gw1VUs9Vg)_