### PR TITLE
feat(serve): Cmd/Ctrl-K and '/' jump to search, Esc clears

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ tests/benchmark/multi_model.json
 tests/benchmark/multi_model.md
 tests/fixtures/sample_project/graphify-out/
 tests/fixtures/sample_project/.neuralmind/
+/graphify-out/
 
 # Per-project synapse layer artifacts (generated, not source)
 .neuralmind/synapses.db

--- a/neuralmind/web/app.js
+++ b/neuralmind/web/app.js
@@ -662,6 +662,27 @@
     }
   }
 
+  /* ---------- keyboard shortcuts ---------- */
+
+  // Cmd/Ctrl-K from anywhere, '/' when no field is focused → jump to
+  // the search box (select existing text so re-typing overwrites).
+  // Esc inside the search box clears it and returns focus to the page.
+  window.addEventListener("keydown", (ev) => {
+    const t = ev.target;
+    const inField =
+      t && (t.tagName === "INPUT" || t.tagName === "TEXTAREA" || t.isContentEditable);
+    const cmdK = (ev.metaKey || ev.ctrlKey) && (ev.key === "k" || ev.key === "K");
+    if (cmdK || (ev.key === "/" && !inField)) {
+      ev.preventDefault();
+      searchInput.focus();
+      searchInput.select();
+    } else if (ev.key === "Escape" && t === searchInput) {
+      searchInput.value = "";
+      searchInput.dispatchEvent(new Event("input"));
+      searchInput.blur();
+    }
+  });
+
   /* ---------- open in editor ---------- */
 
   async function openInEditor(node, statusEl, btn) {

--- a/neuralmind/web/index.html
+++ b/neuralmind/web/index.html
@@ -15,7 +15,7 @@
       </header>
 
       <section class="panel">
-        <input id="search" type="search" placeholder="Quick switch — semantic search…" autocomplete="off" />
+        <input id="search" type="search" placeholder="Quick switch (⌘K or /) — semantic search…" autocomplete="off" />
         <ul id="search-results"></ul>
       </section>
 


### PR DESCRIPTION
## Summary

The semantic search box is the fastest way around a NeuralMind graph, but reaching it required a mouse click. Adds the conventional keystrokes:

- **Cmd/Ctrl-K** from anywhere → focuses `#search` and selects existing text (re-typing overwrites).
- **`/`** when no input field is focused → same behavior, matching GitHub / Vim / Slack. Typed `/` inside any text input still goes into the input.
- **Esc** inside the search box → clears the value (drops `searchHitIds` and aborts any in-flight fetch via the existing `input` handler) and blurs back to the page.

Placeholder updated to `Quick switch (⌘K or /) — semantic search…` so the shortcut is discoverable without docs.

Branched off `origin/main`, independent of PR #108.

## Test plan

- [x] `ruff check` + `black --check` clean
- [x] `test_server.py` + `test_graph_view.py` pass
- [x] Headless smoke against `sample_project`:
  - Cmd-K from canvas → focus moves to `#search`
  - Ctrl-K (non-Mac variant) → same
  - `/` from canvas → focus moves to `#search`
  - `/` typed while search focused → goes into the input (not hijacked)
  - Esc with `auth` in the box → value cleared, focus on BODY
  - Zero JS console errors
- [ ] Manual UI check on a real project (recommended)

https://claude.ai/code/session_01JupPy4oAsoTJ9gw1VUs9Vg

---
_Generated by [Claude Code](https://claude.ai/code/session_01JupPy4oAsoTJ9gw1VUs9Vg)_