### PR TITLE
feat(serve): live activity feed — SSE stream of synapse + file events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ tests/benchmark/multi_model.json
 tests/benchmark/multi_model.md
 tests/fixtures/sample_project/graphify-out/
 tests/fixtures/sample_project/.neuralmind/
+/graphify-out/
 
 # Per-project synapse layer artifacts (generated, not source)
 .neuralmind/synapses.db

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,9 +27,11 @@ and the file activity watcher.
 - `neuralmind/synapses.py` — SQLite-backed Hebbian synapse store
 - `neuralmind/synapse_memory.py` — markdown export to Claude Code memory
 - `neuralmind/watcher.py` — file activity → synapse co-activation
+- `neuralmind/event_bus.py` — process-local pub/sub for live activity events
+- `neuralmind/server.py` — local graph-view HTTP server + `/api/events` SSE
 - `neuralmind/hooks.py` — Claude Code hook registration + runtime
 - `neuralmind/mcp_server.py` — MCP tools for any agent
-- `neuralmind/cli.py` — `neuralmind {build,query,watch,install-hooks,…}`
+- `neuralmind/cli.py` — `neuralmind {build,query,watch,serve,install-hooks,…}`
 
 ## Local conventions
 

--- a/neuralmind/event_bus.py
+++ b/neuralmind/event_bus.py
@@ -1,0 +1,105 @@
+"""
+event_bus.py — Process-local pub/sub for live activity events.
+
+``publish()`` is O(1) when nothing is subscribed, so wiring emit-points
+into ``SynapseStore.reinforce`` and the file watcher doesn't pay a tax
+during normal headless use. The graph-view SSE endpoint subscribes when
+a browser connects; tests subscribe explicitly.
+
+Each subscription owns a bounded queue — if a slow consumer falls
+behind, oldest events are dropped at the producer side and a
+``dropped`` counter is incremented on the subscription, so the
+producer is never blocked on the bus.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from queue import Empty, Full, Queue
+from typing import Any
+
+DEFAULT_QUEUE_SIZE = 256
+
+
+class Subscription:
+    """A single subscriber's bounded queue. Use ``get()`` to consume."""
+
+    def __init__(self, bus: EventBus, maxsize: int = DEFAULT_QUEUE_SIZE):
+        self._queue: Queue[dict[str, Any]] = Queue(maxsize=maxsize)
+        self._bus = bus
+        self.dropped = 0
+
+    def get(self, timeout: float | None = None) -> dict[str, Any] | None:
+        """Block until an event arrives or ``timeout`` elapses. Returns None on timeout."""
+        try:
+            return self._queue.get(timeout=timeout)
+        except Empty:
+            return None
+
+    def close(self) -> None:
+        self._bus._unsubscribe(self)
+
+    def _offer(self, event: dict[str, Any]) -> None:
+        try:
+            self._queue.put_nowait(event)
+        except Full:
+            self.dropped += 1
+
+
+class EventBus:
+    """Thread-safe fan-out. ``publish`` with no subscribers is O(1)."""
+
+    def __init__(self, max_queue: int = DEFAULT_QUEUE_SIZE):
+        self._lock = threading.Lock()
+        self._subs: list[Subscription] = []
+        self.max_queue = max_queue
+
+    def subscribe(self) -> Subscription:
+        sub = Subscription(self, maxsize=self.max_queue)
+        with self._lock:
+            self._subs.append(sub)
+        return sub
+
+    def _unsubscribe(self, sub: Subscription) -> None:
+        with self._lock:
+            try:
+                self._subs.remove(sub)
+            except ValueError:
+                pass
+
+    def publish(self, event_type: str, payload: dict[str, Any] | None = None) -> int:
+        """Fan an event out to every current subscriber. Returns recipient count."""
+        with self._lock:
+            subs = list(self._subs)
+        if not subs:
+            return 0
+        event: dict[str, Any] = {"type": event_type, "ts": time.time()}
+        if payload:
+            event.update(payload)
+        for sub in subs:
+            sub._offer(event)
+        return len(subs)
+
+    def subscriber_count(self) -> int:
+        with self._lock:
+            return len(self._subs)
+
+
+_BUS: EventBus | None = None
+_BUS_LOCK = threading.Lock()
+
+
+def get_event_bus() -> EventBus:
+    """Return (and lazily create) the process-wide event bus."""
+    global _BUS
+    if _BUS is None:
+        with _BUS_LOCK:
+            if _BUS is None:
+                _BUS = EventBus()
+    return _BUS
+
+
+def publish(event_type: str, payload: dict[str, Any] | None = None) -> int:
+    """Shortcut for ``get_event_bus().publish(...)`` — safe to call anywhere."""
+    return get_event_bus().publish(event_type, payload)

--- a/neuralmind/event_bus.py
+++ b/neuralmind/event_bus.py
@@ -28,6 +28,7 @@ class Subscription:
     def __init__(self, bus: EventBus, maxsize: int = DEFAULT_QUEUE_SIZE):
         self._queue: Queue[dict[str, Any]] = Queue(maxsize=maxsize)
         self._bus = bus
+        self._drop_lock = threading.Lock()
         self.dropped = 0
 
     def get(self, timeout: float | None = None) -> dict[str, Any] | None:
@@ -41,9 +42,24 @@ class Subscription:
         self._bus._unsubscribe(self)
 
     def _offer(self, event: dict[str, Any]) -> None:
+        # Live feeds care more about fresh state than complete history, so when
+        # a slow consumer fills the queue we drop the oldest item before
+        # enqueuing the new one. Concurrent producers can race on the
+        # get-then-put sequence; we just retry once, then count the drop.
+        try:
+            self._queue.put_nowait(event)
+            return
+        except Full:
+            pass
+        try:
+            self._queue.get_nowait()
+        except Empty:
+            pass
         try:
             self._queue.put_nowait(event)
         except Full:
+            pass
+        with self._drop_lock:
             self.dropped += 1
 
 

--- a/neuralmind/server.py
+++ b/neuralmind/server.py
@@ -530,9 +530,11 @@ def serve(
     _Handler.allowed_open_paths = _compute_allowed_open_paths(mind)
     _Handler._graph_cache = None
 
-    watcher = _start_activity_watcher(mind)
-
+    # Bind the listening socket first so a port-in-use failure doesn't
+    # leak a running watcher thread; only spin the watcher up once we
+    # know the server is going to run.
     httpd = ThreadingHTTPServer((host, port), _Handler)
+    watcher = _start_activity_watcher(mind)
     base = f"http://{host}:{port}/"
     landing = f"{base}?token={token}" if token else base
     stats = mind.graph_data()["stats"]

--- a/neuralmind/server.py
+++ b/neuralmind/server.py
@@ -22,13 +22,18 @@ import shlex
 import shutil
 import subprocess
 import threading
+import time
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from urllib.parse import parse_qs, urlparse
 
 from .core import NeuralMind
+from .event_bus import get_event_bus
 
 WEB_DIR = Path(__file__).parent / "web"
+
+SSE_HEARTBEAT_SECONDS = 20.0
+SSE_POLL_INTERVAL = 1.0
 
 _CONTENT_TYPES = {
     ".html": "text/html; charset=utf-8",
@@ -310,8 +315,55 @@ class _Handler(BaseHTTPRequestHandler):
                 {"query": query, "results": _search(type(self).mind, query)},
                 set_cookie=new_cookie,
             )
+        elif route == "/api/events":
+            self._stream_events(new_cookie)
         else:
             self.send_error(404)
+
+    def _stream_events(self, new_cookie: str | None) -> None:
+        """Stream live synapse + file events as Server-Sent Events.
+
+        Long-lived response. Subscribes to the process-wide event bus,
+        emits each event as ``data: {...}\\n\\n``, and sends a comment
+        heartbeat periodically so idle connections aren't reaped by
+        proxies / load balancers.
+        """
+        self.send_response(200)
+        self.send_header("Content-Type", "text/event-stream; charset=utf-8")
+        self.send_header("Cache-Control", "no-cache")
+        self.send_header("Connection", "keep-alive")
+        # Tell nginx / other reverse proxies not to buffer the stream.
+        self.send_header("X-Accel-Buffering", "no")
+        if new_cookie:
+            self.send_header(
+                "Set-Cookie",
+                f"{_AUTH_COOKIE}={new_cookie}; Path=/; HttpOnly; SameSite=Strict",
+            )
+        self.end_headers()
+
+        bus = get_event_bus()
+        sub = bus.subscribe()
+        try:
+            self._sse_send({"type": "hello", "ts": time.time()})
+            last_heartbeat = time.time()
+            while True:
+                event = sub.get(timeout=SSE_POLL_INTERVAL)
+                if event is not None:
+                    self._sse_send(event)
+                now = time.time()
+                if now - last_heartbeat >= SSE_HEARTBEAT_SECONDS:
+                    self.wfile.write(b": hb\n\n")
+                    self.wfile.flush()
+                    last_heartbeat = now
+        except (BrokenPipeError, ConnectionResetError, OSError):
+            pass
+        finally:
+            sub.close()
+
+    def _sse_send(self, event: dict) -> None:
+        payload = "data: " + json.dumps(event) + "\n\n"
+        self.wfile.write(payload.encode("utf-8"))
+        self.wfile.flush()
 
     def do_POST(self) -> None:  # noqa: N802 - http.server API
         parsed = urlparse(self.path)
@@ -421,6 +473,39 @@ def _ensure_graph_or_explain(project_path: Path) -> None:
     raise RuntimeError(msg)
 
 
+def _start_activity_watcher(mind: NeuralMind):
+    """Spin up the file-activity watcher that feeds the live event stream.
+
+    Returns the watcher (so ``serve()`` can stop it on shutdown) or
+    ``None`` if the watcher could not start — the graph view still works
+    without it, the stream is just quiet.
+    """
+    try:
+        from .watcher import FileActivityWatcher
+    except Exception:
+        return None
+
+    bus = get_event_bus()
+
+    def on_batch(paths: list[str]) -> None:
+        # Surface the raw file edit immediately so the UI can log it
+        # even when nothing maps to a graph node.
+        bus.publish("file", {"paths": list(paths), "count": len(paths)})
+        # Reinforce synapses for any nodes in those files — that call
+        # itself publishes a "synapse" event when pairs were touched.
+        try:
+            mind.activate_files(paths)
+        except Exception:
+            pass
+
+    try:
+        watcher = FileActivityWatcher(str(mind.project_path), on_batch)
+        watcher.start()
+        return watcher
+    except Exception:
+        return None
+
+
 def serve(
     project_path: str,
     host: str = "127.0.0.1",
@@ -444,6 +529,8 @@ def serve(
     _Handler.editor = editor or os.environ.get("EDITOR") or os.environ.get("VISUAL")
     _Handler.allowed_open_paths = _compute_allowed_open_paths(mind)
     _Handler._graph_cache = None
+
+    watcher = _start_activity_watcher(mind)
 
     httpd = ThreadingHTTPServer((host, port), _Handler)
     base = f"http://{host}:{port}/"
@@ -475,4 +562,9 @@ def serve(
     except KeyboardInterrupt:
         print("\nStopping NeuralMind graph view.")
     finally:
+        if watcher is not None:
+            try:
+                watcher.stop()
+            except Exception:
+                pass
         httpd.server_close()

--- a/neuralmind/synapses.py
+++ b/neuralmind/synapses.py
@@ -158,6 +158,22 @@ class SynapseStore:
                 conn.execute("ROLLBACK")
                 raise
 
+        if pairs:
+            # Best-effort: never let the graph-view stream break a real write.
+            try:
+                from .event_bus import publish as _publish
+
+                _publish(
+                    "synapse",
+                    {
+                        "nodes": list(ids),
+                        "pair_count": len(pairs),
+                        "strength": float(strength),
+                    },
+                )
+            except Exception:
+                pass
+
         return len(pairs)
 
     def decay(self, now: float | None = None) -> dict:

--- a/neuralmind/web/app.js
+++ b/neuralmind/web/app.js
@@ -298,6 +298,15 @@
         ctx.strokeStyle = "#fff";
         ctx.stroke();
       }
+      const pulse = pulseAmount(n.id);
+      if (pulse > 0) {
+        ctx.globalAlpha = pulse * 0.8;
+        ctx.lineWidth = 2 / t.k;
+        ctx.strokeStyle = "#e0a458";
+        ctx.beginPath();
+        ctx.arc(n.x, n.y, r + 5 + 6 * pulse, 0, Math.PI * 2);
+        ctx.stroke();
+      }
       if (state.showLabels || n === focus || n === state.selected) {
         ctx.globalAlpha = dim ? 0.4 : 1;
         ctx.fillStyle = "#d6d7da";
@@ -309,13 +318,13 @@
   }
 
   // Pause the render loop when the layout is idle so we don't spin at
-  // 60fps drawing the same static graph forever. Interactions call wake()
-  // to kick it back on.
+  // 60fps drawing the same static graph forever. Interactions and
+  // incoming activity pulses call wake() to kick it back on.
   let paused = false;
   function tick() {
     simulate();
     draw();
-    if (state.alpha < 0.005 && !dragNode) {
+    if (state.alpha < 0.005 && !dragNode && pulses.size === 0) {
       paused = true;
     } else {
       requestAnimationFrame(tick);
@@ -751,10 +760,123 @@
     wake();
   });
 
+  /* ---------- live activity stream ---------- */
+
+  // nodeId → pulse-end timestamp (performance.now() units). The render
+  // loop reads pulseAmount(id) ∈ [0,1] each frame; entries are evicted
+  // once expired so an idle graph can pause animation.
+  const PULSE_MS = 1400;
+  const pulses = new Map();
+  function pulseAmount(id) {
+    const exp = pulses.get(id);
+    if (!exp) return 0;
+    const now = performance.now();
+    if (exp <= now) {
+      pulses.delete(id);
+      return 0;
+    }
+    return (exp - now) / PULSE_MS;
+  }
+  function triggerPulses(ids) {
+    if (!Array.isArray(ids) || !ids.length) return;
+    const exp = performance.now() + PULSE_MS;
+    let any = false;
+    for (const id of ids) {
+      if (state.nodeById.has(id)) {
+        pulses.set(id, exp);
+        any = true;
+      }
+    }
+    if (any) wake();
+  }
+
+  const eventLog = document.getElementById("event-log");
+  const eventStatus = document.getElementById("activity-status");
+  const MAX_LOG_ROWS = 80;
+
+  function formatEventTime(ts) {
+    const d = ts ? new Date(ts * 1000) : new Date();
+    const pad = (n) => String(n).padStart(2, "0");
+    return `${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
+  }
+
+  function describeEvent(ev) {
+    if (ev.type === "synapse") {
+      const n = ev.nodes ? ev.nodes.length : 0;
+      const p = ev.pair_count || 0;
+      return `synapse · ${p} pair${p === 1 ? "" : "s"} on ${n} node${n === 1 ? "" : "s"}`;
+    }
+    if (ev.type === "file") {
+      const c = ev.count || (ev.paths ? ev.paths.length : 0);
+      const first = ev.paths && ev.paths[0] ? shortPath(ev.paths[0]) : "";
+      return c <= 1 && first
+        ? `file · ${first}`
+        : `file · ${c} edit${c === 1 ? "" : "s"}` + (first ? ` (${first}…)` : "");
+    }
+    if (ev.type === "hello") return "stream connected";
+    return ev.type;
+  }
+
+  function shortPath(p) {
+    const parts = String(p).split("/");
+    return parts.length <= 2 ? p : parts.slice(-2).join("/");
+  }
+
+  function appendEvent(ev) {
+    const li = document.createElement("li");
+    li.className = "event-row fresh event-" + (ev.type || "system");
+    const time = document.createElement("span");
+    time.className = "event-time";
+    time.textContent = formatEventTime(ev.ts);
+    const label = document.createElement("span");
+    label.className = "event-label";
+    label.textContent = describeEvent(ev);
+    li.append(time, label);
+    eventLog.prepend(li);
+    while (eventLog.children.length > MAX_LOG_ROWS) {
+      eventLog.removeChild(eventLog.lastChild);
+    }
+    // Fade the "fresh" highlight after a beat so newer rows still stand out.
+    setTimeout(() => li.classList.remove("fresh"), 1200);
+  }
+
+  function startEventStream() {
+    if (typeof EventSource === "undefined") {
+      eventStatus.classList.add("dead");
+      eventStatus.title = "Live stream not supported in this browser";
+      return;
+    }
+    const es = new EventSource("/api/events");
+    es.onopen = () => {
+      eventStatus.classList.add("live");
+      eventStatus.classList.remove("dead");
+      eventStatus.title = "Live stream connected";
+    };
+    es.onerror = () => {
+      // EventSource auto-reconnects; just mark the status until then.
+      eventStatus.classList.remove("live");
+      eventStatus.classList.add("dead");
+      eventStatus.title = "Live stream disconnected; will retry";
+    };
+    es.onmessage = (m) => {
+      let ev;
+      try {
+        ev = JSON.parse(m.data);
+      } catch {
+        return;
+      }
+      appendEvent(ev);
+      if (ev.type === "synapse" && Array.isArray(ev.nodes)) {
+        triggerPulses(ev.nodes);
+      }
+    };
+  }
+
   /* ---------- boot ---------- */
 
   resize();
   load().catch((e) => {
     loading.textContent = "Failed to load graph: " + e;
   });
+  startEventStream();
 })();

--- a/neuralmind/web/app.js
+++ b/neuralmind/web/app.js
@@ -321,7 +321,18 @@
   // 60fps drawing the same static graph forever. Interactions and
   // incoming activity pulses call wake() to kick it back on.
   let paused = false;
+  function sweepPulses() {
+    // Evict expired entries even for hidden nodes, otherwise filters
+    // (local-graph, solo-community, search) could leave the pulse map
+    // permanently non-empty and the render loop would never re-pause.
+    if (!pulses.size) return;
+    const now = performance.now();
+    for (const [id, exp] of pulses) {
+      if (exp <= now) pulses.delete(id);
+    }
+  }
   function tick() {
+    sweepPulses();
     simulate();
     draw();
     if (state.alpha < 0.005 && !dragNode && pulses.size === 0) {
@@ -840,23 +851,27 @@
     setTimeout(() => li.classList.remove("fresh"), 1200);
   }
 
+  function setStreamStatus(kind, message) {
+    eventStatus.classList.toggle("live", kind === "live");
+    eventStatus.classList.toggle("dead", kind === "dead");
+    eventStatus.title = message;
+    // Update the screen-reader announcement too so the live/disconnected
+    // state isn't conveyed by color alone.
+    eventStatus.setAttribute("aria-label", message);
+  }
+
   function startEventStream() {
     if (typeof EventSource === "undefined") {
-      eventStatus.classList.add("dead");
-      eventStatus.title = "Live stream not supported in this browser";
+      setStreamStatus("dead", "Live stream not supported in this browser");
       return;
     }
     const es = new EventSource("/api/events");
     es.onopen = () => {
-      eventStatus.classList.add("live");
-      eventStatus.classList.remove("dead");
-      eventStatus.title = "Live stream connected";
+      setStreamStatus("live", "Live stream connected");
     };
     es.onerror = () => {
       // EventSource auto-reconnects; just mark the status until then.
-      eventStatus.classList.remove("live");
-      eventStatus.classList.add("dead");
-      eventStatus.title = "Live stream disconnected; will retry";
+      setStreamStatus("dead", "Live stream disconnected; will retry");
     };
     es.onmessage = (m) => {
       let ev;

--- a/neuralmind/web/index.html
+++ b/neuralmind/web/index.html
@@ -57,6 +57,14 @@
         <ul id="community-list"></ul>
       </section>
 
+      <section class="panel" id="activity-panel">
+        <h2>
+          Activity
+          <span id="activity-status" class="activity-status" title="Live stream status">·</span>
+        </h2>
+        <ul id="event-log" aria-live="polite"></ul>
+      </section>
+
       <footer id="stats"></footer>
     </aside>
 

--- a/neuralmind/web/index.html
+++ b/neuralmind/web/index.html
@@ -60,7 +60,14 @@
       <section class="panel" id="activity-panel">
         <h2>
           Activity
-          <span id="activity-status" class="activity-status" title="Live stream status">·</span>
+          <span
+            id="activity-status"
+            class="activity-status"
+            role="status"
+            aria-live="polite"
+            aria-label="Live stream status: connecting"
+            title="Live stream status: connecting"
+          >·</span>
         </h2>
         <ul id="event-log" aria-live="polite"></ul>
       </section>

--- a/neuralmind/web/style.css
+++ b/neuralmind/web/style.css
@@ -182,6 +182,56 @@ button.ghost:disabled, .open-btn:disabled {
   line-height: 1.6;
 }
 
+#activity-panel h2 { display: flex; align-items: center; gap: 6px; }
+.activity-status {
+  display: inline-block;
+  width: 8px; height: 8px;
+  border-radius: 50%;
+  background: var(--text-dim);
+  text-indent: -9999px;
+  overflow: hidden;
+  flex-shrink: 0;
+}
+.activity-status.live { background: #5fb37a; }
+.activity-status.dead { background: #d9694f; }
+
+#event-log {
+  max-height: 220px;
+  overflow-y: auto;
+  margin-top: 4px;
+  font-size: 11px;
+  line-height: 1.5;
+}
+#event-log:empty::after {
+  content: "Waiting for synapse / file events…";
+  color: var(--text-dim);
+  font-size: 11px;
+}
+.event-row {
+  display: flex;
+  gap: 6px;
+  padding: 3px 6px;
+  border-radius: 4px;
+  cursor: default;
+  align-items: baseline;
+}
+.event-row.fresh { background: rgba(224, 164, 88, 0.10); }
+.event-time {
+  color: var(--text-dim);
+  font-variant-numeric: tabular-nums;
+  flex-shrink: 0;
+  font-size: 10px;
+}
+.event-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 1;
+}
+.event-synapse .event-label { color: var(--synapse); }
+.event-file .event-label { color: var(--text); }
+.event-hello .event-label, .event-system .event-label { color: var(--text-dim); }
+
 #canvas-wrap {
   flex: 1;
   position: relative;

--- a/tests/test_event_bus.py
+++ b/tests/test_event_bus.py
@@ -1,0 +1,119 @@
+"""Pub/sub semantics for the live activity event bus."""
+
+from __future__ import annotations
+
+import threading
+import time
+
+from neuralmind.event_bus import EventBus, get_event_bus, publish
+
+
+def test_publish_with_no_subscribers_is_cheap_noop():
+    bus = EventBus()
+    # No throw, returns 0 recipients, doesn't allocate a queue we can't drain.
+    assert bus.publish("nothing", {"k": 1}) == 0
+    assert bus.subscriber_count() == 0
+
+
+def test_single_subscriber_receives_event_in_order():
+    bus = EventBus()
+    sub = bus.subscribe()
+    try:
+        bus.publish("a", {"n": 1})
+        bus.publish("b", {"n": 2})
+        ev1 = sub.get(timeout=0.5)
+        ev2 = sub.get(timeout=0.5)
+        assert ev1["type"] == "a" and ev1["n"] == 1
+        assert ev2["type"] == "b" and ev2["n"] == 2
+        # Each event carries its own timestamp.
+        assert ev1["ts"] <= ev2["ts"]
+    finally:
+        sub.close()
+
+
+def test_multiple_subscribers_each_get_their_own_copy():
+    bus = EventBus()
+    a = bus.subscribe()
+    b = bus.subscribe()
+    try:
+        assert bus.publish("ping", {}) == 2
+        assert a.get(timeout=0.5)["type"] == "ping"
+        assert b.get(timeout=0.5)["type"] == "ping"
+    finally:
+        a.close()
+        b.close()
+
+
+def test_close_unsubscribes():
+    bus = EventBus()
+    sub = bus.subscribe()
+    assert bus.subscriber_count() == 1
+    sub.close()
+    assert bus.subscriber_count() == 0
+    # Subsequent publish has no recipients.
+    assert bus.publish("x") == 0
+
+
+def test_full_queue_drops_events_without_blocking_producer():
+    bus = EventBus(max_queue=3)
+    sub = bus.subscribe()
+    try:
+        for i in range(10):
+            bus.publish("burst", {"i": i})
+        # First three filled the queue; remaining seven were dropped at the source.
+        assert sub.dropped == 7
+        drained = []
+        for _ in range(3):
+            drained.append(sub.get(timeout=0.5))
+        assert [e["i"] for e in drained] == [0, 1, 2]
+    finally:
+        sub.close()
+
+
+def test_module_level_helpers_share_singleton_bus():
+    # First call materializes it; second call returns the same instance.
+    bus = get_event_bus()
+    assert get_event_bus() is bus
+    sub = bus.subscribe()
+    try:
+        publish("hello", {"v": 7})
+        ev = sub.get(timeout=0.5)
+        assert ev["type"] == "hello"
+        assert ev["v"] == 7
+    finally:
+        sub.close()
+
+
+def test_concurrent_publish_and_subscribe_stays_consistent():
+    bus = EventBus()
+    received: list[dict] = []
+    sub = bus.subscribe()
+
+    def drain():
+        for _ in range(50):
+            ev = sub.get(timeout=1.0)
+            if ev is None:
+                break
+            received.append(ev)
+
+    consumer = threading.Thread(target=drain)
+    consumer.start()
+
+    def producer():
+        for i in range(25):
+            bus.publish("p", {"i": i})
+
+    producers = [threading.Thread(target=producer) for _ in range(2)]
+    for t in producers:
+        t.start()
+    for t in producers:
+        t.join()
+    # Drain queue: give the consumer a moment.
+    time.sleep(0.1)
+    consumer.join(timeout=2.0)
+    sub.close()
+
+    # 2 producers × 25 events = 50; the consumer may pick up fewer if the
+    # drain finishes early, but every received event should be well-formed.
+    assert all(ev["type"] == "p" for ev in received)
+    assert all("ts" in ev for ev in received)

--- a/tests/test_event_bus.py
+++ b/tests/test_event_bus.py
@@ -54,18 +54,20 @@ def test_close_unsubscribes():
     assert bus.publish("x") == 0
 
 
-def test_full_queue_drops_events_without_blocking_producer():
+def test_full_queue_drops_oldest_so_subscribers_see_freshest():
     bus = EventBus(max_queue=3)
     sub = bus.subscribe()
     try:
         for i in range(10):
             bus.publish("burst", {"i": i})
-        # First three filled the queue; remaining seven were dropped at the source.
+        # Live-feed semantics: when a slow subscriber falls behind, the bus
+        # evicts oldest events so the queue always reflects the most recent
+        # activity. Three slots survive (i=7,8,9), seven were dropped.
         assert sub.dropped == 7
         drained = []
         for _ in range(3):
             drained.append(sub.get(timeout=0.5))
-        assert [e["i"] for e in drained] == [0, 1, 2]
+        assert [e["i"] for e in drained] == [7, 8, 9]
     finally:
         sub.close()
 
@@ -117,3 +119,41 @@ def test_concurrent_publish_and_subscribe_stays_consistent():
     # drain finishes early, but every received event should be well-formed.
     assert all(ev["type"] == "p" for ev in received)
     assert all("ts" in ev for ev in received)
+
+
+def test_synapse_store_reinforce_publishes_event(tmp_path):
+    """SynapseStore.reinforce() should fan-out a `synapse` event with the
+    triggering node ids and pair count. Locks in the wiring so the live
+    activity feed can't silently regress to a quiet bus.
+    """
+    from neuralmind.synapses import SynapseStore
+
+    store = SynapseStore(tmp_path / "syn.db")
+    bus = get_event_bus()
+    sub = bus.subscribe()
+    try:
+        pairs = store.reinforce(["alpha", "beta", "gamma"], strength=1.0)
+        assert pairs == 3
+
+        ev = sub.get(timeout=1.0)
+        assert ev is not None
+        assert ev["type"] == "synapse"
+        assert ev["pair_count"] == 3
+        assert sorted(ev["nodes"]) == ["alpha", "beta", "gamma"]
+        assert ev["strength"] == 1.0
+    finally:
+        sub.close()
+
+
+def test_synapse_store_reinforce_swallows_publish_errors(tmp_path, monkeypatch):
+    """A flaky event bus must not break the underlying database write."""
+    from neuralmind import event_bus as bus_mod
+    from neuralmind.synapses import SynapseStore
+
+    def boom(*_a, **_kw):
+        raise RuntimeError("bus exploded")
+
+    monkeypatch.setattr(bus_mod, "publish", boom)
+    store = SynapseStore(tmp_path / "syn2.db")
+    # Should not raise — reinforce returns the pair count regardless.
+    assert store.reinforce(["x", "y"], strength=1.0) == 1

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,15 +1,22 @@
-"""Tests for the local graph-view server (auth, editor open, first-run)."""
+"""Tests for the local graph-view server (auth, editor open, first-run, SSE)."""
 
 from __future__ import annotations
 
+import http.client
+import json
+import threading
+import time
+from http.server import ThreadingHTTPServer
 from types import SimpleNamespace
 
 import pytest
 
+from neuralmind.event_bus import publish
 from neuralmind.server import (
     _compute_allowed_open_paths,
     _editor_command,
     _ensure_graph_or_explain,
+    _Handler,
     _resolve_open_target,
 )
 
@@ -122,6 +129,67 @@ def test_resolve_open_target_no_source_file(tmp_path):
     path, line, reason = _resolve_open_target(mind, "n1")
     assert path is None
     assert reason == "node has no source file"
+
+
+def _run_handler_server():
+    """Spin up a ThreadingHTTPServer bound to ephemeral port; returns (server, thread, port)."""
+    # SSE handler reads from the event bus and ignores `mind` / open paths,
+    # so a minimal stub keeps the handler attributes well-formed for class init.
+    _Handler.mind = None
+    _Handler.auth_token = None
+    _Handler.editor = None
+    _Handler.allowed_open_paths = set()
+    _Handler._graph_cache = None
+
+    httpd = ThreadingHTTPServer(("127.0.0.1", 0), _Handler)
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+    return httpd, thread, httpd.server_address[1]
+
+
+def test_sse_endpoint_streams_published_events():
+    httpd, thread, port = _run_handler_server()
+    try:
+        conn = http.client.HTTPConnection("127.0.0.1", port, timeout=5)
+        conn.request("GET", "/api/events")
+        resp = conn.getresponse()
+        assert resp.status == 200
+        assert resp.getheader("Content-Type", "").startswith("text/event-stream")
+
+        # Give the handler a tick to subscribe before we publish.
+        for _ in range(40):
+            time.sleep(0.025)
+            from neuralmind.event_bus import get_event_bus
+
+            if get_event_bus().subscriber_count() >= 1:
+                break
+        publish("synapse", {"nodes": ["a", "b"], "pair_count": 1, "strength": 1.0})
+
+        deadline = time.time() + 5.0
+        events: list[dict] = []
+        buf = b""
+        while time.time() < deadline and len(events) < 2:
+            chunk = resp.fp.readline()
+            if not chunk:
+                break
+            buf += chunk
+            if buf.endswith(b"\n"):
+                for line in buf.splitlines():
+                    if line.startswith(b"data: "):
+                        try:
+                            events.append(json.loads(line[6:].decode("utf-8")))
+                        except ValueError:
+                            pass
+                buf = b""
+
+        types = [e["type"] for e in events]
+        assert "hello" in types
+        assert any(e.get("type") == "synapse" and e.get("pair_count") == 1 for e in events)
+        conn.close()
+    finally:
+        httpd.shutdown()
+        thread.join(timeout=2.0)
+        httpd.server_close()
 
 
 def test_allowed_open_paths_only_includes_in_project_files(tmp_path):


### PR DESCRIPTION
## Summary

Turns the static graph view into a watchable one. While `neuralmind serve` is running, edits in the project tree flow through a new in-process event bus and out to the browser as Server-Sent Events. The pitch flips from *"view your code graph"* to **"see the brain learning your codebase, live"**.

### What ships

- **`neuralmind/event_bus.py`** — thread-safe fan-out pub/sub. `publish()` with no subscribers is O(1), so wiring emit-points doesn't tax headless callers. Each subscription owns a bounded queue; slow consumers drop oldest events instead of blocking producers (with a `dropped` counter on the subscription for visibility).
- **`SynapseStore.reinforce()`** publishes a `synapse` event whenever a Hebbian update touches at least one pair. Payload: `{nodes, pair_count, strength}`. Best-effort — never breaks a real write if the bus is unhappy.
- **`server.py`** starts a `FileActivityWatcher` for the serve lifetime; each debounced batch publishes a `file` event and feeds `mind.activate_files(paths)`, which chains a `synapse` event in turn.
- **`GET /api/events`** — long-lived SSE endpoint, authed by the existing cookie/token. Emits each bus event as `data: {...}\n\n` and sends a heartbeat comment every 20s so proxies don't kill idle streams.

### Frontend

- New **Activity** panel in the sidebar with a status dot (live / disconnected) and a scrolling log of the most recent ~80 events. Empty-state copy reads *"Waiting for synapse / file events…"*.
- `EventSource` client auto-reconnects on transient failures.
- On every `synapse` event, the affected nodes briefly **pulse with a warm-colored ring** on the canvas. The render loop wakes up for the pulse duration and re-pauses when the graph is idle — no idle CPU.

### Tests

- `tests/test_event_bus.py` (7 tests) covers ordering, multi-subscriber fan-out, drop-on-full-queue, close-unsubscribes, the singleton helper, and concurrent producers + consumer.
- `tests/test_server.py` gains an end-to-end SSE integration test that spins up a real `ThreadingHTTPServer`, opens an HTTP client against `/api/events`, publishes from another thread, and asserts both the `hello` frame and the streamed event arrive on the wire.

## Test plan

- [x] `ruff check` + `black --check` clean
- [x] Full test suite: 371 pass (3 pre-existing tiktoken-env errors, unrelated)
- [x] Headless end-to-end against bundled `sample_project`: touched a watched file, both `file` and `synapse` events arrived in the SSE stream, canvas pulse rings visible on the `auth_handlers_*` cluster, no JS console errors
- [ ] Manual UI check on a real project (recommended): leave `neuralmind serve` running, edit code, watch the brain react

## Known scope

In-process event bus — events fire only for activity originating within the `neuralmind serve` process (its own watcher, the synapse store touches it drives). Activity from a separate `neuralmind watch` or from Claude Code hooks running in another process won't show up until we add cross-process IPC. That's a deliberate follow-up.

https://claude.ai/code/session_01JupPy4oAsoTJ9gw1VUs9Vg

---
_Generated by [Claude Code](https://claude.ai/code/session_01JupPy4oAsoTJ9gw1VUs9Vg)_