### PR TITLE
feat(serve): local-graph depth slider (1–3 hops)

### DIFF
--- a/neuralmind/web/app.js
+++ b/neuralmind/web/app.js
@@ -932,7 +932,12 @@
   const depthValue = document.getElementById("local-depth-value");
   const depthRow = depthInput.closest(".slider-row");
   function syncDepthEnabled() {
-    depthRow.classList.toggle("disabled", !state.localOnly);
+    const off = !state.localOnly;
+    depthRow.classList.toggle("disabled", off);
+    // Mirror the CSS state on the input itself so keyboard / screen-reader
+    // users see the same "inert" behavior the sighted UI shows. Without
+    // this the range is still focusable + adjustable while it looks dimmed.
+    depthInput.disabled = off;
   }
   depthInput.addEventListener("input", () => {
     state.localDepth = Math.max(1, Math.min(3, parseInt(depthInput.value, 10) || 1));

--- a/neuralmind/web/app.js
+++ b/neuralmind/web/app.js
@@ -33,6 +33,7 @@
     showSynapses: true,
     showStructural: true,
     localOnly: false,
+    localDepth: 1,
     soloCommunity: false,
     filterToSearch: false,
     showLabels: false,
@@ -203,13 +204,23 @@
     let set = null;
     if (state.localOnly && state.selected) {
       set = new Set([state.selected.id]);
-      for (const e of state.structuralEdges) {
-        if (e.s.id === state.selected.id) set.add(e.t.id);
-        if (e.t.id === state.selected.id) set.add(e.s.id);
-      }
-      for (const e of state.synapseEdges) {
-        if (e.s.id === state.selected.id) set.add(e.t.id);
-        if (e.t.id === state.selected.id) set.add(e.s.id);
+      let frontier = new Set([state.selected.id]);
+      const depth = Math.max(1, Math.min(3, state.localDepth | 0));
+      for (let hop = 0; hop < depth && frontier.size; hop++) {
+        const next = new Set();
+        const visit = (e) => {
+          if (frontier.has(e.s.id) && !set.has(e.t.id)) {
+            set.add(e.t.id);
+            next.add(e.t.id);
+          }
+          if (frontier.has(e.t.id) && !set.has(e.s.id)) {
+            set.add(e.s.id);
+            next.add(e.s.id);
+          }
+        };
+        for (const e of state.structuralEdges) visit(e);
+        for (const e of state.synapseEdges) visit(e);
+        frontier = next;
       }
     }
     if (state.soloCommunity && state.activeCommunity != null) {
@@ -916,6 +927,20 @@
     }
     wake();
   });
+
+  const depthInput = document.getElementById("local-depth");
+  const depthValue = document.getElementById("local-depth-value");
+  const depthRow = depthInput.closest(".slider-row");
+  function syncDepthEnabled() {
+    depthRow.classList.toggle("disabled", !state.localOnly);
+  }
+  depthInput.addEventListener("input", () => {
+    state.localDepth = Math.max(1, Math.min(3, parseInt(depthInput.value, 10) || 1));
+    depthValue.textContent = String(state.localDepth);
+    wake();
+  });
+  document.getElementById("toggle-local").addEventListener("change", syncDepthEnabled);
+  syncDepthEnabled();
 
   document.getElementById("reset-layout").addEventListener("click", () => {
     if (!state.projectKey) return;

--- a/neuralmind/web/index.html
+++ b/neuralmind/web/index.html
@@ -32,6 +32,11 @@
           <input type="checkbox" id="toggle-local" />
           Local graph (focus selection)
         </label>
+        <label class="slider-row" for="local-depth">
+          <span class="slider-label">Depth</span>
+          <input type="range" id="local-depth" min="1" max="3" step="1" value="1" />
+          <span id="local-depth-value" class="slider-value">1</span>
+        </label>
         <label class="toggle">
           <input type="checkbox" id="toggle-solo" />
           Solo selected community

--- a/neuralmind/web/style.css
+++ b/neuralmind/web/style.css
@@ -126,6 +126,31 @@ ul {
   font-variant-numeric: tabular-nums;
 }
 
+.slider-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 2px 0 4px 22px;
+}
+.slider-row.disabled { opacity: 0.4; }
+.slider-row.disabled input { pointer-events: none; }
+.slider-label {
+  color: var(--text-dim);
+  font-size: 11px;
+  min-width: 36px;
+}
+.slider-row input[type="range"] {
+  flex: 1;
+  accent-color: var(--accent);
+}
+.slider-value {
+  color: var(--text);
+  font-variant-numeric: tabular-nums;
+  font-size: 11px;
+  min-width: 14px;
+  text-align: right;
+}
+
 #tooltip .tt-edge {
   display: block;
   font-size: 11px;


### PR DESCRIPTION
## Summary

The "Local graph (focus selection)" toggle previously hid everything beyond the selected node's immediate neighbors — fine for tight files but useless when the interesting context is a couple of hops out.

Adds a 1–3 step slider beneath the toggle that controls the BFS radius across both structural and synaptic edges. Default stays at 1, so existing behavior is unchanged unless the user moves the slider.

- `visibleSet()` is now a tiny BFS frontier loop instead of a one-shot neighbor scan.
- The slider row greys out and stops responding to pointer events when the local-graph toggle is off, so it's a visible-but-inert hint rather than dead UI.

Frontend-only, no server changes, no new tests (pure UI tweak over existing graph data).

## Test plan

- [x] `node --check` on app.js passes
- [x] Headless smoke against `sample_project`: slider moves through 1/2/3, the live value label tracks, the row goes `.disabled` when local-graph is unchecked, zero JS errors
- [ ] Manual UI check — eyeball that depth 2 and 3 each reveal a strictly larger neighborhood than depth 1

Branched off `origin/main`, independent of PR #108 / #109 / #110.

https://claude.ai/code/session_01JupPy4oAsoTJ9gw1VUs9Vg

---
_Generated by [Claude Code](https://claude.ai/code/session_01JupPy4oAsoTJ9gw1VUs9Vg)_