### PR TITLE
feat(serve): cross-process activity stream via JSONL bridge

### DIFF
--- a/neuralmind/cli.py
+++ b/neuralmind/cli.py
@@ -387,10 +387,38 @@ def cmd_watch(args):
         if not quiet:
             print(f"  warning: build skipped ({exc}); watcher will still record edits.")
 
+    # Bridge synapse + file events into the project's JSONL log so that
+    # a separate `neuralmind serve` process picks them up and renders
+    # pulse rings on the canvas in real time. Best-effort: a missing
+    # `.neuralmind/` dir or NEURALMIND_EVENT_LOG=0 just leaves the
+    # daemon silent on the cross-process channel.
+    try:
+        from neuralmind.event_bus import configure_event_log
+        from neuralmind.event_log import (
+            EventLogWriter,
+            default_log_path,
+            event_log_enabled,
+        )
+
+        if event_log_enabled():
+            log_path = default_log_path(path)
+            log_path.parent.mkdir(parents=True, exist_ok=True)
+            configure_event_log(EventLogWriter(log_path))
+    except Exception:
+        pass
+
     activations_total = 0
 
     def on_batch(paths: list[str]) -> None:
         nonlocal activations_total
+        # Surface the raw file edits to the cross-process bridge first
+        # so the server can echo them even if no synapse pair fires.
+        try:
+            from neuralmind.event_bus import publish as _publish
+
+            _publish("file", {"paths": list(paths), "count": len(paths)})
+        except Exception:
+            pass
         try:
             pairs = mind.activate_files(paths)
         except Exception:

--- a/neuralmind/event_bus.py
+++ b/neuralmind/event_bus.py
@@ -1,25 +1,37 @@
 """
 event_bus.py — Process-local pub/sub for live activity events.
 
-``publish()`` is O(1) when nothing is subscribed, so wiring emit-points
-into ``SynapseStore.reinforce`` and the file watcher doesn't pay a tax
-during normal headless use. The graph-view SSE endpoint subscribes when
-a browser connects; tests subscribe explicitly.
+``publish()`` is O(1) when nothing is subscribed and no JSONL writer is
+configured, so wiring emit-points into ``SynapseStore.reinforce`` and
+the file watcher doesn't pay a tax during normal headless use. The
+graph-view SSE endpoint subscribes when a browser connects; tests
+subscribe explicitly.
 
 Each subscription owns a bounded queue — if a slow consumer falls
 behind, oldest events are dropped at the producer side and a
 ``dropped`` counter is incremented on the subscription, so the
 producer is never blocked on the bus.
+
+When a JSONL writer is attached via :func:`configure_event_log`, every
+published event is also appended to disk so a separate process (e.g.
+``neuralmind watch``) can carry events to the graph-view server. Events
+carry a ``_pid`` field so the server's tailer can ignore lines it wrote
+itself.
 """
 
 from __future__ import annotations
 
+import os
 import threading
 import time
 from queue import Empty, Full, Queue
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from .event_log import EventLogWriter
 
 DEFAULT_QUEUE_SIZE = 256
+_PID = os.getpid()
 
 
 class Subscription:
@@ -64,12 +76,13 @@ class Subscription:
 
 
 class EventBus:
-    """Thread-safe fan-out. ``publish`` with no subscribers is O(1)."""
+    """Thread-safe fan-out. ``publish`` is O(1) when idle."""
 
     def __init__(self, max_queue: int = DEFAULT_QUEUE_SIZE):
         self._lock = threading.Lock()
         self._subs: list[Subscription] = []
         self.max_queue = max_queue
+        self._log_writer: EventLogWriter | None = None
 
     def subscribe(self) -> Subscription:
         sub = Subscription(self, maxsize=self.max_queue)
@@ -84,15 +97,52 @@ class EventBus:
             except ValueError:
                 pass
 
+    def configure_event_log(self, writer: EventLogWriter | None) -> None:
+        """Attach (or clear with None) the JSONL writer used by ``publish``.
+
+        When a writer is set, every published event is appended to disk
+        as one JSON line so other processes can consume it. Setting it
+        to ``None`` disables the side channel without touching subs.
+        """
+        with self._lock:
+            self._log_writer = writer
+
     def publish(self, event_type: str, payload: dict[str, Any] | None = None) -> int:
-        """Fan an event out to every current subscriber. Returns recipient count."""
+        """Fan an event out to every current subscriber. Returns recipient count.
+
+        If a JSONL writer is configured the event is also appended to
+        disk, regardless of subscriber count — that's the whole point of
+        the cross-process bridge.
+        """
+        with self._lock:
+            subs = list(self._subs)
+            writer = self._log_writer
+        if not subs and writer is None:
+            return 0
+        event: dict[str, Any] = {"type": event_type, "ts": time.time(), "_pid": _PID}
+        if payload:
+            event.update(payload)
+        if writer is not None:
+            try:
+                writer.write(event)
+            except Exception:
+                # Bridge must never break a real synapse write.
+                pass
+        for sub in subs:
+            sub._offer(event)
+        return len(subs)
+
+    def _fanout_only(self, event: dict[str, Any]) -> int:
+        """Deliver a pre-built external event to in-process subscribers.
+
+        Used by the JSONL tailer to republish events that arrived from
+        another process. Skips the writer so it can't loop back into the
+        file we just read.
+        """
         with self._lock:
             subs = list(self._subs)
         if not subs:
             return 0
-        event: dict[str, Any] = {"type": event_type, "ts": time.time()}
-        if payload:
-            event.update(payload)
         for sub in subs:
             sub._offer(event)
         return len(subs)
@@ -119,3 +169,8 @@ def get_event_bus() -> EventBus:
 def publish(event_type: str, payload: dict[str, Any] | None = None) -> int:
     """Shortcut for ``get_event_bus().publish(...)`` — safe to call anywhere."""
     return get_event_bus().publish(event_type, payload)
+
+
+def configure_event_log(writer: EventLogWriter | None) -> None:
+    """Module-level shortcut for ``get_event_bus().configure_event_log(...)``."""
+    get_event_bus().configure_event_log(writer)

--- a/neuralmind/event_log.py
+++ b/neuralmind/event_log.py
@@ -1,0 +1,196 @@
+"""
+event_log.py — JSONL bridge so live events cross process boundaries.
+
+The in-process ``event_bus`` only fans events out to subscribers inside
+the same Python process. That's enough for ``neuralmind serve``, but
+``neuralmind watch`` (or a hook-driven Claude Code session) runs in a
+separate process whose synapse reinforcements would never reach the
+graph view's canvas otherwise.
+
+This module solves that with a deliberately boring side channel:
+
+- :class:`EventLogWriter` appends each published event as one JSON line
+  to ``<project>/.neuralmind/events.jsonl``. Every event carries a
+  ``_pid`` so consumers can tell self-emissions apart from cross-process
+  ones.
+- :class:`EventLogTailer` is a background thread used by the server. It
+  seeks to end of file on start (no history replay), polls for new
+  lines, parses each one, and fires a callback. The callback in
+  ``server.py`` re-publishes external events on the local bus *without*
+  going back through the writer — that's what keeps it from looping.
+
+Both classes are best-effort: a flaky filesystem must never break a
+synapse write or the live feed.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+DEFAULT_POLL_INTERVAL = 0.5
+
+_MAX_LINE_BYTES = 64 * 1024  # Skip pathologically long lines.
+
+
+class EventLogWriter:
+    """Append JSON events to a line-delimited file. Thread-safe."""
+
+    def __init__(self, path: str | Path):
+        self.path = Path(path)
+        self._lock = threading.Lock()
+        self._broken = False
+
+    def write(self, event: dict[str, Any]) -> bool:
+        """Append one line. Returns True on success, False if swallowed.
+
+        Once a write fails we set ``_broken`` so subsequent writes don't
+        retry on every call — a single broken filesystem shouldn't
+        thrash the hot path. Recover by constructing a new writer.
+        """
+        if self._broken:
+            return False
+        try:
+            line = json.dumps(event, separators=(",", ":"), default=str)
+        except (TypeError, ValueError):
+            return False
+        encoded = (line + "\n").encode("utf-8")
+        with self._lock:
+            try:
+                self.path.parent.mkdir(parents=True, exist_ok=True)
+                with open(self.path, "ab") as fh:
+                    fh.write(encoded)
+                return True
+            except OSError:
+                self._broken = True
+                return False
+
+
+class EventLogTailer:
+    """Poll a JSONL event log and fire a callback for each new line.
+
+    On ``start()`` we seek to the current end of file — historical
+    events are deliberately not replayed. If the file is truncated,
+    rotated, or replaced (size shrinks or inode changes), we re-open
+    and resume from the new start.
+    """
+
+    def __init__(
+        self,
+        path: str | Path,
+        on_event: Callable[[dict[str, Any]], None],
+        poll_interval: float = DEFAULT_POLL_INTERVAL,
+    ):
+        self.path = Path(path)
+        self._on_event = on_event
+        self._poll_interval = poll_interval
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+
+    def start(self) -> None:
+        if self._thread is not None:
+            return
+        self._thread = threading.Thread(target=self._run, name="event-log-tailer", daemon=True)
+        self._thread.start()
+
+    def stop(self, timeout: float = 2.0) -> None:
+        self._stop.set()
+        thread = self._thread
+        if thread is not None and thread.is_alive():
+            thread.join(timeout=timeout)
+        self._thread = None
+
+    def _open_at_end(self):
+        try:
+            fh = open(self.path, "rb")
+        except FileNotFoundError:
+            return None, None
+        except OSError:
+            return None, None
+        try:
+            fh.seek(0, 2)  # to EOF
+            offset = fh.tell()
+            inode = self._stat_inode()
+        except OSError:
+            fh.close()
+            return None, None
+        return fh, (inode, offset)
+
+    def _stat_inode(self) -> int | None:
+        try:
+            return self.path.stat().st_ino
+        except OSError:
+            return None
+
+    def _run(self) -> None:
+        fh = None
+        inode: int | None = None
+        buf = b""
+        while not self._stop.is_set():
+            if fh is None:
+                fh, state = self._open_at_end()
+                if fh is None:
+                    if self._stop.wait(self._poll_interval):
+                        return
+                    continue
+                inode = state[0] if state else None
+                buf = b""
+            # Detect rotation/truncation: inode change or size shrink.
+            try:
+                cur_inode = self._stat_inode()
+                cur_size = self.path.stat().st_size
+                if cur_inode != inode or cur_size < fh.tell():
+                    fh.close()
+                    fh = None
+                    inode = None
+                    continue
+            except OSError:
+                fh.close()
+                fh = None
+                continue
+
+            chunk = fh.read(8192)
+            if chunk:
+                buf += chunk
+                while b"\n" in buf:
+                    line, buf = buf.split(b"\n", 1)
+                    if not line or len(line) > _MAX_LINE_BYTES:
+                        continue
+                    self._dispatch(line)
+                continue
+            if self._stop.wait(self._poll_interval):
+                break
+
+        if fh is not None:
+            try:
+                fh.close()
+            except OSError:
+                pass
+
+    def _dispatch(self, raw: bytes) -> None:
+        try:
+            event = json.loads(raw.decode("utf-8", errors="replace"))
+        except (ValueError, UnicodeDecodeError):
+            return
+        if not isinstance(event, dict):
+            return
+        try:
+            self._on_event(event)
+        except Exception:
+            # The callback must not be allowed to crash the tailer; the
+            # whole point is "best-effort live feed."
+            pass
+
+
+def default_log_path(project_path: str | Path) -> Path:
+    """Where the JSONL bridge lives for a given project."""
+    return Path(project_path) / ".neuralmind" / "events.jsonl"
+
+
+def event_log_enabled() -> bool:
+    """``NEURALMIND_EVENT_LOG=0`` disables the cross-process bridge."""
+    return os.environ.get("NEURALMIND_EVENT_LOG", "1") != "0"

--- a/neuralmind/server.py
+++ b/neuralmind/server.py
@@ -29,6 +29,12 @@ from urllib.parse import parse_qs, urlparse
 
 from .core import NeuralMind
 from .event_bus import get_event_bus
+from .event_log import (
+    EventLogTailer,
+    EventLogWriter,
+    default_log_path,
+    event_log_enabled,
+)
 
 WEB_DIR = Path(__file__).parent / "web"
 
@@ -473,6 +479,46 @@ def _ensure_graph_or_explain(project_path: Path) -> None:
     raise RuntimeError(msg)
 
 
+def _start_event_log_bridge(mind: NeuralMind):
+    """Wire the cross-process JSONL bridge for the running server.
+
+    Configures a writer on the in-process bus so any synapse / file
+    event published here also lands on disk, and spins up a tailer that
+    re-publishes events written by *other* processes (e.g. a separate
+    ``neuralmind watch`` daemon, or hook-driven Claude Code sessions).
+
+    Self-emitted lines are skipped by ``_pid`` so the tailer can't loop.
+    Returns ``(writer, tailer)`` or ``(None, None)`` when disabled.
+    """
+    if not event_log_enabled():
+        return None, None
+
+    log_path = default_log_path(mind.project_path)
+    try:
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+    except OSError:
+        return None, None
+
+    bus = get_event_bus()
+    writer = EventLogWriter(log_path)
+    bus.configure_event_log(writer)
+
+    self_pid = os.getpid()
+
+    def on_external(event: dict) -> None:
+        if event.get("_pid") == self_pid:
+            return
+        bus._fanout_only(event)
+
+    tailer = EventLogTailer(log_path, on_external)
+    try:
+        tailer.start()
+    except Exception:
+        bus.configure_event_log(None)
+        return None, None
+    return writer, tailer
+
+
 def _start_activity_watcher(mind: NeuralMind):
     """Spin up the file-activity watcher that feeds the live event stream.
 
@@ -534,6 +580,7 @@ def serve(
     # leak a running watcher thread; only spin the watcher up once we
     # know the server is going to run.
     httpd = ThreadingHTTPServer((host, port), _Handler)
+    log_writer, log_tailer = _start_event_log_bridge(mind)
     watcher = _start_activity_watcher(mind)
     base = f"http://{host}:{port}/"
     landing = f"{base}?token={token}" if token else base
@@ -569,4 +616,11 @@ def serve(
                 watcher.stop()
             except Exception:
                 pass
+        if log_tailer is not None:
+            try:
+                log_tailer.stop()
+            except Exception:
+                pass
+        if log_writer is not None:
+            get_event_bus().configure_event_log(None)
         httpd.server_close()

--- a/tests/test_event_log.py
+++ b/tests/test_event_log.py
@@ -1,0 +1,367 @@
+"""JSONL bridge — writer + tailer + cross-process bus integration."""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+import time
+from pathlib import Path
+
+from neuralmind.event_bus import EventBus, get_event_bus
+from neuralmind.event_log import (
+    EventLogTailer,
+    EventLogWriter,
+    default_log_path,
+    event_log_enabled,
+)
+
+
+def _read_lines(path: Path) -> list[dict]:
+    if not path.exists():
+        return []
+    out: list[dict] = []
+    for raw in path.read_bytes().splitlines():
+        if not raw:
+            continue
+        out.append(json.loads(raw.decode("utf-8")))
+    return out
+
+
+def test_writer_appends_one_json_line_per_call(tmp_path):
+    log = tmp_path / "events.jsonl"
+    w = EventLogWriter(log)
+    assert w.write({"type": "a", "ts": 1.0}) is True
+    assert w.write({"type": "b", "ts": 2.0, "nodes": ["x", "y"]}) is True
+
+    lines = _read_lines(log)
+    assert [ev["type"] for ev in lines] == ["a", "b"]
+    assert lines[1]["nodes"] == ["x", "y"]
+
+
+def test_writer_creates_parent_directory_lazily(tmp_path):
+    nested = tmp_path / "deep" / "nest" / "events.jsonl"
+    assert not nested.parent.exists()
+    w = EventLogWriter(nested)
+    assert w.write({"type": "ok"}) is True
+    assert nested.is_file()
+
+
+def test_writer_concurrent_writes_dont_interleave_bytes(tmp_path):
+    log = tmp_path / "events.jsonl"
+    w = EventLogWriter(log)
+
+    def burst(tid: int) -> None:
+        for i in range(50):
+            w.write({"type": "p", "tid": tid, "i": i})
+
+    threads = [threading.Thread(target=burst, args=(t,)) for t in range(4)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    lines = _read_lines(log)
+    # 4 * 50 = 200 lines, all well-formed JSON.
+    assert len(lines) == 200
+    assert all(ev["type"] == "p" for ev in lines)
+
+
+def test_writer_swallows_unserializable_payload(tmp_path):
+    """Non-JSON payloads are dropped, not raised — bridge is best-effort."""
+    log = tmp_path / "events.jsonl"
+    w = EventLogWriter(log)
+
+    class Weird:
+        pass
+
+    # ``default=str`` in the writer means even Weird() stringifies, so
+    # write succeeds. We assert the success + parseable line.
+    assert w.write({"type": "x", "blob": Weird()}) is True
+    lines = _read_lines(log)
+    assert lines[0]["type"] == "x"
+    assert isinstance(lines[0]["blob"], str)
+
+
+def test_tailer_picks_up_new_lines_after_start(tmp_path):
+    log = tmp_path / "events.jsonl"
+    log.touch()
+    received: list[dict] = []
+    done = threading.Event()
+
+    def on_event(ev: dict) -> None:
+        received.append(ev)
+        if len(received) >= 3:
+            done.set()
+
+    tailer = EventLogTailer(log, on_event, poll_interval=0.05)
+    tailer.start()
+    try:
+        time.sleep(0.15)  # let the tailer seek-to-end
+        w = EventLogWriter(log)
+        for i in range(3):
+            w.write({"type": "burst", "i": i})
+        assert done.wait(timeout=2.0), f"only got {received}"
+    finally:
+        tailer.stop(timeout=2.0)
+
+    assert [ev["i"] for ev in received] == [0, 1, 2]
+
+
+def test_tailer_seeks_to_end_so_history_is_not_replayed(tmp_path):
+    log = tmp_path / "events.jsonl"
+    w = EventLogWriter(log)
+    for i in range(5):
+        w.write({"type": "old", "i": i})
+
+    received: list[dict] = []
+    tailer = EventLogTailer(log, received.append, poll_interval=0.05)
+    tailer.start()
+    try:
+        time.sleep(0.25)
+        # New event after start should arrive; the 5 historical ones must not.
+        w.write({"type": "new", "i": 99})
+        deadline = time.time() + 2.0
+        while time.time() < deadline and not received:
+            time.sleep(0.05)
+    finally:
+        tailer.stop(timeout=2.0)
+
+    assert received and received[0]["type"] == "new"
+    assert all(ev["type"] == "new" for ev in received)
+
+
+def test_tailer_skips_malformed_lines(tmp_path):
+    log = tmp_path / "events.jsonl"
+    log.touch()
+    received: list[dict] = []
+
+    tailer = EventLogTailer(log, received.append, poll_interval=0.05)
+    tailer.start()
+    try:
+        time.sleep(0.15)
+        with open(log, "ab") as fh:
+            fh.write(b"not json at all\n")
+            fh.write(b'{"type": "good", "i": 1}\n')
+            fh.write(b"{broken\n")
+            fh.write(b'{"type": "good", "i": 2}\n')
+        deadline = time.time() + 2.0
+        while time.time() < deadline and len(received) < 2:
+            time.sleep(0.05)
+    finally:
+        tailer.stop(timeout=2.0)
+
+    assert [ev.get("i") for ev in received] == [1, 2]
+
+
+def test_tailer_recovers_from_rotation(tmp_path):
+    """logrotate-style rename + new file: inode changes, tailer resumes."""
+    log = tmp_path / "events.jsonl"
+    log.touch()
+    received: list[dict] = []
+    tailer = EventLogTailer(log, received.append, poll_interval=0.05)
+    tailer.start()
+    try:
+        time.sleep(0.15)
+        w_pre = EventLogWriter(log)
+        w_pre.write({"type": "pre"})
+        # Give the tailer a chance to read "pre" before we rotate.
+        deadline = time.time() + 2.0
+        while time.time() < deadline and not any(ev["type"] == "pre" for ev in received):
+            time.sleep(0.05)
+        # logrotate-style: rename existing file, replace with a fresh inode.
+        rotated = tmp_path / "events.jsonl.1"
+        log.rename(rotated)
+        log.touch()
+        # Tailer notices inode change and re-opens at end of new (empty) file.
+        time.sleep(0.2)
+        w_post = EventLogWriter(log)
+        w_post.write({"type": "post"})
+        deadline = time.time() + 3.0
+        while time.time() < deadline and not any(ev["type"] == "post" for ev in received):
+            time.sleep(0.05)
+    finally:
+        tailer.stop(timeout=2.0)
+
+    types = [ev["type"] for ev in received]
+    assert "pre" in types
+    assert "post" in types
+
+
+def test_tailer_callback_exception_does_not_kill_thread(tmp_path):
+    log = tmp_path / "events.jsonl"
+    log.touch()
+    received: list[dict] = []
+
+    def on_event(ev: dict) -> None:
+        if ev.get("i") == 0:
+            raise RuntimeError("boom")
+        received.append(ev)
+
+    tailer = EventLogTailer(log, on_event, poll_interval=0.05)
+    tailer.start()
+    try:
+        time.sleep(0.15)
+        w = EventLogWriter(log)
+        w.write({"type": "x", "i": 0})  # callback raises
+        w.write({"type": "x", "i": 1})  # but thread keeps going
+        deadline = time.time() + 2.0
+        while time.time() < deadline and not received:
+            time.sleep(0.05)
+    finally:
+        tailer.stop(timeout=2.0)
+
+    assert received and received[0]["i"] == 1
+
+
+def test_bus_publish_writes_to_log_when_writer_configured(tmp_path):
+    log = tmp_path / "events.jsonl"
+    bus = EventBus()
+    bus.configure_event_log(EventLogWriter(log))
+    bus.publish("synapse", {"nodes": ["a", "b"], "pair_count": 1})
+    bus.publish("file", {"count": 2})
+
+    lines = _read_lines(log)
+    assert [ev["type"] for ev in lines] == ["synapse", "file"]
+    # Every event must carry pid so a cross-process consumer can dedupe.
+    assert all(ev["_pid"] == os.getpid() for ev in lines)
+    assert all("ts" in ev for ev in lines)
+
+
+def test_bus_publish_writes_to_log_even_without_subscribers(tmp_path):
+    """Disk side channel is the whole point of the bridge — it must
+    fire when no in-process subscribers exist, otherwise a headless
+    ``neuralmind watch`` daemon would never persist anything."""
+    log = tmp_path / "events.jsonl"
+    bus = EventBus()
+    bus.configure_event_log(EventLogWriter(log))
+    assert bus.subscriber_count() == 0
+    bus.publish("synapse", {"pair_count": 3})
+    assert _read_lines(log)[0]["pair_count"] == 3
+
+
+def test_bus_fanout_only_skips_writer(tmp_path):
+    """Tailer republish path must not write back to the same file it
+    just read — that would loop forever."""
+    log = tmp_path / "events.jsonl"
+    bus = EventBus()
+    bus.configure_event_log(EventLogWriter(log))
+    sub = bus.subscribe()
+    try:
+        bus._fanout_only({"type": "external", "_pid": 99999, "ts": 1.0})
+        ev = sub.get(timeout=0.5)
+        assert ev is not None and ev["type"] == "external"
+        assert _read_lines(log) == []
+    finally:
+        sub.close()
+
+
+def test_bus_publish_idle_when_no_writer_and_no_subscribers():
+    """No fan-out, no writer, no event allocation. Keeps ``reinforce``
+    cheap during normal headless use."""
+    bus = EventBus()
+    assert bus.publish("x") == 0
+    assert bus.publish("y", {"k": 1}) == 0
+
+
+def test_clearing_writer_disables_the_side_channel(tmp_path):
+    log = tmp_path / "events.jsonl"
+    bus = EventBus()
+    bus.configure_event_log(EventLogWriter(log))
+    bus.publish("first", {})
+    bus.configure_event_log(None)
+    bus.publish("second", {})
+    types = [ev["type"] for ev in _read_lines(log)]
+    assert types == ["first"]
+
+
+def test_publish_does_not_raise_when_writer_errors(monkeypatch, tmp_path):
+    """A broken filesystem must never break a synapse write."""
+    log = tmp_path / "events.jsonl"
+    writer = EventLogWriter(log)
+
+    def boom(_ev: dict) -> bool:
+        raise OSError("disk gone")
+
+    monkeypatch.setattr(writer, "write", boom)
+    bus = EventBus()
+    bus.configure_event_log(writer)
+    bus.publish("synapse", {"pair_count": 1})  # must not raise
+
+
+def test_event_log_enabled_respects_env_var(monkeypatch):
+    monkeypatch.delenv("NEURALMIND_EVENT_LOG", raising=False)
+    assert event_log_enabled() is True
+    monkeypatch.setenv("NEURALMIND_EVENT_LOG", "0")
+    assert event_log_enabled() is False
+    monkeypatch.setenv("NEURALMIND_EVENT_LOG", "1")
+    assert event_log_enabled() is True
+
+
+def test_default_log_path_is_under_dot_neuralmind(tmp_path):
+    p = default_log_path(tmp_path)
+    assert p == tmp_path / ".neuralmind" / "events.jsonl"
+
+
+def test_cross_process_handoff_via_jsonl(tmp_path):
+    """End-to-end: writer process appends, reader process tails and
+    republishes locally. This is the contract the graph view depends
+    on — a ``neuralmind watch`` daemon's events must reach the server's
+    in-process bus without going through any IPC machinery beyond the
+    JSONL file."""
+    log = tmp_path / "events.jsonl"
+    log.touch()
+
+    # "Server" side: tailer republishes onto a local bus.
+    server_bus = EventBus()
+
+    def on_external(event: dict) -> None:
+        if event.get("_pid") == os.getpid():
+            # Real server filters self-events; this test forces a
+            # foreign pid below so this branch is never taken here.
+            return
+        server_bus._fanout_only(event)
+
+    tailer = EventLogTailer(log, on_external, poll_interval=0.05)
+    tailer.start()
+    sub = server_bus.subscribe()
+    try:
+        time.sleep(0.15)
+
+        # "Watcher" side: writes a synapse event with a foreign pid so
+        # the tailer's pid filter doesn't skip it.
+        writer = EventLogWriter(log)
+        writer.write(
+            {
+                "type": "synapse",
+                "ts": time.time(),
+                "_pid": os.getpid() + 1,
+                "nodes": ["alpha", "beta"],
+                "pair_count": 1,
+            }
+        )
+
+        ev = sub.get(timeout=2.0)
+        assert ev is not None
+        assert ev["type"] == "synapse"
+        assert ev["nodes"] == ["alpha", "beta"]
+    finally:
+        sub.close()
+        tailer.stop(timeout=2.0)
+
+
+def test_module_level_configure_event_log_targets_singleton(tmp_path):
+    """``configure_event_log`` exposed at module level must wire the
+    same singleton bus that ``publish()`` uses, otherwise emit-points
+    that import ``publish`` would silently bypass the writer."""
+    from neuralmind.event_bus import configure_event_log, publish
+
+    log = tmp_path / "events.jsonl"
+    bus = get_event_bus()
+    configure_event_log(EventLogWriter(log))
+    try:
+        publish("synapse", {"pair_count": 7})
+        lines = _read_lines(log)
+        assert lines and lines[0]["pair_count"] == 7
+    finally:
+        configure_event_log(None)


### PR DESCRIPTION
## Summary

Phase D #1 of the live-feed roadmap — closes the cross-process gap left
by #110. The in-process `event_bus` only fans events out to subscribers
in the same Python process, so a separate `neuralmind watch` daemon (or
a hook-driven Claude Code session) writes synapses to SQLite just fine
but never reaches the graph view's canvas. This PR adds a deliberately
boring side channel: `<project>/.neuralmind/events.jsonl`.

- `event_log.EventLogWriter` appends each published event as one JSON
  line. Thread-safe, lazy `mkdir -p`, best-effort: a flaky filesystem
  can never break a real synapse write.
- `event_log.EventLogTailer` is a daemon thread `neuralmind serve`
  starts. Seeks to end of file on start (no history replay), polls for
  new lines, handles logrotate-style rename + new file via the inode,
  and dispatches parsed events. Malformed lines are skipped; callback
  exceptions don't kill the thread.
- `EventBus.configure_event_log` wires the writer onto the bus.
  `publish()` now stamps every event with `_pid` and mirrors to disk
  after fanout. `_fanout_only()` is the tailer's republish path — it
  delivers to in-process subscribers *without* writing back to the
  file, so the bridge can't loop.
- `neuralmind serve` configures the writer and starts the tailer so a
  browser sees events emitted by any other process in the same project.
- `neuralmind watch` configures the writer too, so the daemon's
  `activate_files` reinforcements land on disk for the server to pick
  up.
- `NEURALMIND_EVENT_LOG=0` opts out.

> Stacked on `claude/live-activity-feed` (#110). GitHub will
> auto-retarget this PR to `main` once #110 merges.

## Test plan

19 new stdlib-only tests in `test_event_log.py`. Full suite:
**389 passed, 7 fixture-skipped**. `ruff check` + `black --check` both
clean.

- [x] Writer atomics — append order, lazy `mkdir -p`, concurrent-thread
      byte safety (4 threads × 50 writes = 200 well-formed lines),
      unserializable payload survival
- [x] Tailer behavior — seek-to-end on start (no history replay), new
      lines dispatched, malformed lines skipped, logrotate-style rename
      recovery via inode check, callback exception isolation
- [x] Bus + writer integration — every published event carries `_pid` +
      `ts`, writer fires even with zero subscribers (whole point of the
      cross-process bridge), `_fanout_only` republish skips the writer
      (no loop), clearing writer disables side channel, writer error
      never propagates to the synapse write path
- [x] End-to-end — simulated cross-process handoff through a temp
      JSONL: foreign-pid event written, server-side tailer picks it up,
      local bus republishes to subscriber
- [x] Env gate — `NEURALMIND_EVENT_LOG=0` disables; default `1` enables

https://claude.ai/code/session_01YWK6fxhS8JZFLYHYybKyRm

---
_Generated by [Claude Code](https://claude.ai/code/session_01YWK6fxhS8JZFLYHYybKyRm)_