### PR TITLE
docs(v0.6.0): release notes, polish, multi-agent + notebooklm pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@
 
 > NeuralMind turns a code repository into a queryable neural index. AI agents use it to answer code questions in ~800 tokens instead of loading 50,000+ tokens of raw source.
 
+> **🆕 New in v0.6.0** — Obsidian-style graph view with a **live activity feed**. `neuralmind serve` streams synapse + file events to the canvas in real time, so you can *watch the brain learning your codebase*. [Release notes](RELEASE_NOTES_v0.6.0.md) · [Graph view section ↓](#-graph-view-neuralmind-serve)
+
 > **🌐 [Visit the landing page](https://dfrostar.github.io/neuralmind/) • 📖 [Read the About page](https://dfrostar.github.io/neuralmind/about.html) • ⚖️ Not affiliated with NeuralMind.ai**
 
 ---
@@ -826,6 +828,12 @@ supported — see the upstream
 for the full schema (`command`, `args`, `env`, `url`, `headers`, `enabled`,
 per-server `tools` filtering, `timeout`, `connect_timeout`).
 
+**v0.6.0 graph view works identically here.** Run `neuralmind serve` in
+the same project and any tool call from Hermes-Agent will pulse the
+corresponding nodes on the canvas. The synapse store is shared with
+Claude Code, Cursor, OpenClaw, and any other agent pointed at this
+project — see [docs/use-cases/multi-agent.md](docs/use-cases/multi-agent.md).
+
 ### OpenClaw
 
 [OpenClaw](https://github.com/openclaw/openclaw) is a personal AI assistant
@@ -855,6 +863,12 @@ openclaw mcp show neuralmind       # echoes the JSON you stored
 
 Remove with `openclaw mcp unset neuralmind`. Definitions are stored under
 the `mcp.servers` key in `~/.openclaw/openclaw.json`.
+
+**v0.6.0 graph view works identically here.** Run `neuralmind serve` in
+the same project and any tool call from OpenClaw will pulse the
+corresponding nodes on the canvas. OpenClaw and Claude Code talking
+to the same project reinforce the same synapse store — see
+[docs/use-cases/multi-agent.md](docs/use-cases/multi-agent.md).
 
 If you haven't installed OpenClaw yet:
 
@@ -1519,7 +1533,8 @@ Only if you install the git post-commit hook with `neuralmind init-hook .`. Othe
 | **[Roadmap](ROADMAP.md)** | What's shipping next, where we want help, what's out of scope |
 | **[Future-Proofing Plan](docs/FUTURE-PROOFING-PLAN.md)** | 8-initiative engineering plan for sustainability and scale |
 | **[Brain-like Learning](docs/brain_like_learning.md)** | Design rationale for the learning system |
-| **[Use Cases](docs/use-cases/README.md)** | Step-by-step walkthroughs: Claude Code, cost optimization, any-LLM, offline/regulated, growing monorepo |
+| **[Use Cases](docs/use-cases/README.md)** | Step-by-step walkthroughs: Claude Code, cost optimization, any-LLM, offline/regulated, growing monorepo, multi-agent (new in v0.6.0) |
+| **[Release Notes v0.6.0](RELEASE_NOTES_v0.6.0.md)** | Live activity feed, cross-process JSONL bridge, pin UX, depth slider, replay overlay |
 | **[Comparisons](docs/comparisons/README.md)** | NeuralMind vs. Cursor, Copilot, Cody, Aider, Claude Projects, LangChain, long context, prompt caching, RAG, tree-sitter |
 | **[USAGE.md](USAGE.md)** | Extended usage examples |
 

--- a/RELEASE_NOTES_v0.6.0.md
+++ b/RELEASE_NOTES_v0.6.0.md
@@ -1,0 +1,194 @@
+# NeuralMind v0.6.0 — see the brain learning your codebase
+
+**Release Date:** May 2026
+
+## TL;DR
+
+`neuralmind serve` is no longer a static graph view. It now pulses
+in real time as the synapse layer learns from your file edits, your
+Claude Code prompts, and your queries. Synapse and file events stream
+to the browser over SSE; affected nodes flash on the canvas; a
+sidebar log keeps the most recent ~80 events. A cross-process JSONL
+bridge means a separate `neuralmind watch` daemon, hook-driven Claude
+Code session, or any other process feeds the same live feed.
+
+The pitch flipped. v0.5.4 was "Obsidian-style graph view over your
+code." v0.6.0 is "**watch the hippocampus learn your codebase, live.**"
+
+No migration. Same `graph.json`, same `synapses.db`, same hooks. If
+you ran `neuralmind serve` before, you already know v0.6.0 — it's
+just alive now.
+
+## What's new
+
+### Live activity feed
+
+`neuralmind serve` now exposes `/api/events` — a long-lived
+Server-Sent Events stream subscribed to an in-process event bus. The
+synapse store publishes a `synapse` event on every pair-touching
+`reinforce()` call; the file watcher publishes a `file_activity`
+event on every coalesced edit batch.
+
+The browser side does two things with that stream:
+
+- **Canvas pulse rings.** Every node referenced in a recent event
+  gets a short, animated radial pulse — colour-coded by event source
+  (synapse vs file activity). Multiple pulses stack so a hot subgraph
+  visibly *throbs* without being annoying.
+- **Sidebar log.** The most recent ~80 events render as a scrolling
+  feed with timestamps, event type, and node ids. Click an entry to
+  focus the corresponding node on the canvas.
+
+`event_bus.publish()` is O(1) when there are no subscribers and no
+JSONL writer configured — emit-points cost nothing on headless servers
+or CLI-only runs.
+
+### Cross-process activity bridge
+
+The in-process bus is great when `serve` and the activity source live
+in the same Python process. The common real-world case is *not* that:
+you run `neuralmind serve` in one terminal and `neuralmind watch` in
+another, or your Claude Code session triggers synapse events in a
+completely separate process from the long-running server.
+
+v0.6.0 adds a deliberately boring side channel: each `event_bus.publish()`
+call also appends to `<project>/.neuralmind/events.jsonl`, and the
+`serve` process tails that file and re-emits anything it didn't
+originate. Net result: one canvas, all sources, no IPC complexity.
+
+Behaviour controls:
+
+- `NEURALMIND_EVENT_LOG=0` disables the writer (you still get the
+  in-process feed).
+- The tailer is best-effort; if the file disappears or rolls, the
+  next event re-creates it.
+- The bus stays the primary path. The JSONL bridge is the fallback,
+  not a queue.
+
+### Visible pin glyph + Pin/Unpin button + Unpin-all
+
+Drag-to-pin has saved layout positions since v0.5.x, but you couldn't
+tell at a glance which nodes were pinned. v0.6.0:
+
+- Every pinned node renders a warm-coloured pin marker.
+- The detail panel shows a Pin / Unpin toggle for the focused node.
+- The sidebar has an "Unpin all" button for resetting layout.
+
+### Quick-switch shortcuts
+
+`Cmd/Ctrl-K` and `/` both focus the semantic search field from
+anywhere on the page. `Esc` clears the field and blurs.
+
+### Local-graph depth slider
+
+The "show only local neighborhood" toggle now has a depth slider:
+1–3 hops via BFS from the focused node. Defaults to 1, so existing
+behavior is unchanged. When the parent toggle is off, the range
+slider sets `disabled` so it stays visibly inert.
+
+### Replay-last-query overlay
+
+The detail panel grew a "Replay last query" action that re-highlights
+the L3 hits the agent most recently received. Useful for closing the
+trust gap when a retrieval feels wrong — you can see what the model
+actually got, on the same canvas you use to navigate the codebase.
+
+### Edge tooltips + min-weight synapse slider
+
+Hover any edge to see the relationship type (call, import, synapse)
+and, for synapses, the weight and activation count. A new slider
+below the synapse-overlay toggle filters edges below a minimum weight,
+so the canvas isn't noisy when you have thousands of low-weight links.
+
+## Why this is a different pitch
+
+v0.5.4 made the brain *inspectable*. v0.6.0 makes it *legible*.
+"The agent has a learning memory" is a claim. Watching a node flash
+the instant you save a file in your editor is evidence.
+
+For people deciding whether to install NeuralMind, the demo that
+matters now is:
+
+1. `neuralmind query` — show the 40–70× per-query token reduction
+   (still the headline measurable claim).
+2. `neuralmind serve` — pop the graph view, scroll around the
+   codebase.
+3. Edit a file in another terminal — pulse rings fire on the canvas
+   in real time.
+
+That third beat is where "code RAG" becomes "associative memory
+for your codebase." It's also the screenshot/clip that anchors the
+v0.6.0 LinkedIn and screencast assets (see
+[`docs/LINKEDIN-POST-DRAFT.md`](docs/LINKEDIN-POST-DRAFT.md) and
+[`docs/SCREENCAST-v0.6.0.md`](docs/SCREENCAST-v0.6.0.md)).
+
+## Upgrading
+
+```bash
+pip install --upgrade neuralmind
+```
+
+That's it. No data migration, no config changes, no hook reinstall.
+Open `neuralmind serve` and the live feed is on by default.
+
+### Opting out
+
+| Want to skip… | Set |
+|---------------|-----|
+| The JSONL bridge (process-local feed only) | `NEURALMIND_EVENT_LOG=0` |
+| Synapse-prompt context injection | `NEURALMIND_SYNAPSE_INJECT=0` |
+| Synapse memory export | `NEURALMIND_SYNAPSE_EXPORT=0` |
+| All hook-time work | `NEURALMIND_BYPASS=1` |
+
+## Compatibility
+
+- **CLI**: no breaking changes. All v0.5.x commands behave identically.
+- **MCP tools**: unchanged.
+- **On-disk state**: `synapses.db` and the ChromaDB index are
+  forward-compatible. `events.jsonl` is new and self-creating.
+- **Hooks**: same registration as v0.5.x. The `PostToolUse` /
+  `SessionStart` / `UserPromptSubmit` / `PreCompact` blocks are
+  unchanged.
+- **Python**: 3.10, 3.11, 3.12 all pass CI.
+
+## What's next (v0.7 candidates)
+
+Tracked in [`ROADMAP.md`](ROADMAP.md) under "Now (v0.7)":
+
+- **Saved views.** Obsidian-style named filter/zoom/depth presets,
+  persisted in `localStorage`.
+- **Right-click context menu on nodes.** Surface the detail-panel
+  verbs (open-in-editor, pin/unpin, focus, copy id) where mouse-driven
+  users expect them.
+- **PNG / SVG export** of the canvas, for design docs and PRs.
+- **Time-based edge filter.** `synapses.last_activated` is already
+  persisted — pair it with the v0.6.0 min-weight slider for a "last
+  N days" view.
+- **Unify `neuralmind watch` with the in-process bus** when they
+  share a process, so the JSONL bridge becomes a pure cross-process
+  fallback.
+
+## Verification
+
+Smoke against this release:
+
+```bash
+pip install neuralmind==0.6.0 graphifyy
+cd your-project
+graphify update . && neuralmind build .
+neuralmind serve .                              # terminal 1
+neuralmind watch . --quiet                      # terminal 2
+$EDITOR src/whatever.py                         # save, then watch terminal 1's
+                                                # canvas — affected nodes pulse.
+```
+
+If the canvas stays quiet, see the FAQ entry in the wiki:
+"Why does my serve canvas stay quiet when I edit files?"
+
+## Thanks
+
+The v0.5.x graph-view foundation made this release straightforward —
+the synapse store already published the right signals, the watcher
+already coalesced edits, and the only missing pieces were the
+subscription bus, the SSE endpoint, and the canvas pulse renderer.
+That's a small surface for a release that changes the pitch.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,70 +8,96 @@ For the longer-horizon engineering plan (release cadence, monitoring,
 compliance, scale targets), see
 [`docs/FUTURE-PROOFING-PLAN.md`](docs/FUTURE-PROOFING-PLAN.md).
 
-## Now (active — v0.5.x)
+## Shipped in v0.6.0 — graph view + live activity feed
 
-The current development thread is the **graph view** (`neuralmind
-serve`), introduced in v0.5.4. We're iterating it in small,
-independently-mergeable slices — "Phase B" below — before tackling
-the bigger live-activity feed step in Phase C.
+The v0.5.x graph-view foundation is now a story you can *see*. The
+canvas pulses while the brain learns. Highlights:
 
-### Graph view — Phase B (small UX wins)
+- **Live activity feed.** `neuralmind serve` streams synapse + file
+  events over SSE while running. Affected nodes pulse on the canvas
+  in real time; a sidebar log keeps the most recent ~80 events. The
+  pitch flipped from "view your code graph" to "watch the brain
+  learning your codebase."
+- **Cross-process activity bridge.** A separate `neuralmind watch`
+  daemon (or hook-driven Claude Code session) now feeds the same live
+  feed via `<project>/.neuralmind/events.jsonl`. The in-process bus
+  stays the primary path; the JSONL is a deliberately boring side
+  channel. Opt out with `NEURALMIND_EVENT_LOG=0`.
+- **Visible pin glyph + Pin/Unpin button + Unpin-all.** Drag-to-pin
+  already saved positions; v0.6.0 surfaces it: pinned nodes get a
+  warm-colored marker, the detail panel has a Pin/Unpin toggle, and
+  the sidebar has an Unpin-all button.
+- **Cmd/Ctrl-K + `/` jump-to-search.** Focus the semantic search
+  field from anywhere; Esc clears and blurs.
+- **Local-graph depth slider.** 1–3 hops via BFS from the focused
+  node; defaults to 1 so existing behavior is unchanged.
+- **Replay-last-query overlay.** Re-highlight the L3 hits the agent
+  most recently received — closes the trust gap on retrieval.
+- **Edge tooltips + min-weight synapse slider.** Hover an edge to
+  see the relationship and weight; filter the synapse overlay to
+  hide weak edges.
+- **Docs refresh.** Roadmap, README hero, landing page, about, and
+  wiki all positioned around the graph view rather than treating it
+  as a side feature.
 
-- **Replay-last-query overlay.** Reads
-  `<project>/.neuralmind/recent_queries.jsonl`, highlights the L3
-  hits the agent received, draws a pulse from the query into them.
-  Answers "what did the agent actually see?"
-  [`#105`](https://github.com/dfrostar/neuralmind/pull/105) — green, awaiting merge.
-- **Edge tooltips + min-weight synapse slider.** Hover any edge to
-  see the relationship (`calls`, or `learned · w 0.42 · 7×`); a
-  sidebar slider hides weak synapses on dense graphs.
-  [`#106`](https://github.com/dfrostar/neuralmind/pull/106) — green, awaiting merge.
-- **Pin UX.** Drag already pins silently; add a visible pin glyph, a
-  detail-panel "Pin / Unpin" toggle, and a sidebar "Unpin all".
-  Pure frontend.
-- **Quick-switch keyboard shortcut.** Bind `Cmd/Ctrl-K` (and `/`) to
-  focus the search input from anywhere on the canvas; Esc to clear.
+No migration needed. Same ChromaDB index, same `synapses.db`, same
+hooks — `neuralmind serve` just makes everything visible.
 
-### Graph view — Phase C (the next bigger lift)
+## Now (v0.7)
 
-- **Live activity feed.** Server-sent events stream synapse
-  activations and file-watcher events into a small sidebar log so
-  you can *see* the brain learning in real time. Touches
-  `server.py`, `synapses.py`, `watcher.py`, and the frontend.
+The graph view is differentiated; the next batch tightens it.
 
-### Other in-flight maintenance
+- **Saved views.** Obsidian-style named graph filter/zoom/depth
+  combos, persisted in `localStorage`. Lets users keep "auth tour",
+  "data layer", "hot synapses" around as one-click presets.
+- **Right-click context menu on nodes.** Open-in-editor, Pin/Unpin,
+  Focus, Copy id. The detail panel has the verbs already — surface
+  them where mouse-driven users actually reach for them.
+- **PNG / SVG export.** PNG is a one-liner via `canvas.toDataURL`;
+  SVG needs a separate render path. Useful for design docs and PRs
+  about retrieval behavior.
+- **Time-based edge filter.** `synapses.last_activated` is already
+  persisted — add a slider that complements the v0.6.0 min-weight
+  slider with a "last N days" filter. Surfaces fresh vs stale
+  associations.
+- **Unify `neuralmind watch` with the in-process bus.** A single
+  `serve` + `watch` process should not need the JSONL bridge — wire
+  the daemon into `event_bus.publish()` directly when they share a
+  process, keep JSONL as the cross-process fallback.
 
-- **Seed community benchmarks with 3–5 outside submissions** so the
-  table doesn't look maintainer-only. Best path is running
-  `neuralmind benchmark . --contribute` on Mempalace, the cmmc20
-  project, and 2–3 well-known OSS Python/TS repos with permission.
-  Each seed: ~10 min wall time. See
-  [`docs/community-benchmarks.json`](docs/community-benchmarks.json).
-- **Asciinema clip of the demo** embedded at the top of the README.
-  Runbook in [`docs/RECORDING-DEMO.md`](docs/RECORDING-DEMO.md);
-  needs to be recorded by the maintainer (can't run in CI because
-  of the chromadb model download).
+## Earlier wins (pre-v0.6)
 
-### Shipped recently
+Carried forward so the trail is legible — these were the "Now"
+items before the graph view took over.
 
 - **Graph view UI base** (v0.5.4) — `neuralmind serve` ships a
   local, dependency-free Obsidian-style force-directed graph with
   the synapse overlay, backlinks, semantic quick-switch,
   open-in-editor, per-session auth token, and layout persistence.
-- **Bundled MCP server** (v0.5.0) — the `[mcp]` extra is now a no-op;
-  `pip install neuralmind` ships the MCP server by default. Closes
-  the most common install footgun.
-- **One-command demo on the bundled fixture** — `bash scripts/demo.sh`
-  proves the headline reduction claim in under a minute on real
-  code.
-- **Fact-based business case + honest assessment docs** —
+  v0.6.0 made it live.
+- **Bundled MCP server** (v0.5.0) — the `[mcp]` extra is now a
+  no-op; `pip install neuralmind` ships the MCP server by default.
+  Closes the most common install footgun.
+- **One-command demo on the bundled fixture.** `bash scripts/demo.sh`
+  reproduces the headline reduction claim in under a minute. ✅ shipped.
+- **Fact-based business case + honest assessment docs.**
   [`BUSINESS-CASE.md`](docs/BUSINESS-CASE.md) makes the compelling
-  argument with provable claims;
-  [`HONEST-ASSESSMENT.md`](docs/HONEST-ASSESSMENT.md) documents
-  where NeuralMind isn't worth installing.
-- **README slim** — moved the Enterprise wall to
-  [`ENTERPRISE.md`](docs/ENTERPRISE.md), cut the inflated savings
-  table, killed the duplicate audiences section.
+  argument with provable claims; [`HONEST-ASSESSMENT.md`](docs/HONEST-ASSESSMENT.md)
+  documents where it isn't worth installing. ✅ shipped.
+- **README slim.** Cut the inflated savings table, the duplicate
+  "who is this for" section, and the Enterprise Use Cases marketing
+  wall (moved to [`ENTERPRISE.md`](docs/ENTERPRISE.md) with honest
+  framing). ✅ shipped (first pass; further trimming possible).
+- **Seed community benchmarks with outside submissions** so the
+  table doesn't look maintainer-only. ⏳ still wanted — best path
+  is running `neuralmind benchmark . --contribute` on a handful of
+  well-known OSS repos with permission. See
+  [`docs/community-benchmarks.json`](docs/community-benchmarks.json).
+- **Asciinema clip of the demo** embedded at the top of the README.
+  ⏳ Runbook in [`docs/RECORDING-DEMO.md`](docs/RECORDING-DEMO.md);
+  needs to be recorded by the maintainer (can't run in CI because
+  of the chromadb model download). v0.6.0's pulse-rings demo is a
+  candidate second clip.
 
 ## Next (~1–2 quarters)
 

--- a/docs/LINKEDIN-POST-DRAFT.md
+++ b/docs/LINKEDIN-POST-DRAFT.md
@@ -1,5 +1,172 @@
 # LinkedIn post draft — NeuralMind progress update
 
+Two sets of drafts. The **v0.6.0 launch drafts** are the current
+batch — post one of them the moment v0.6.0 is on PyPI. The
+**earlier drafts** below are the previous progress update; kept for
+reference and as a backbone if you want to combine.
+
+---
+
+## v0.6.0 launch drafts
+
+The pitch frame: **"we built the hippocampus, you can watch it
+learn."** Pair every draft with the 60-second screencast clip
+([`SCREENCAST-v0.6.0.md`](SCREENCAST-v0.6.0.md)) — the pulse-rings
+visual is the asset that makes this post land. Don't post the v0.6.0
+variants without it.
+
+### Draft v0.6.0–A — short, dev-honest (recommended for first post)
+
+> NeuralMind v0.6.0 is out today.
+>
+> Short version: the brain is now visible.
+>
+> NeuralMind has been an associative memory layer for AI coding
+> agents since v0.4 — a persistent weighted graph that learns
+> which code nodes fire together, decays the rest, and spreads
+> activation on every prompt so the agent gets better context the
+> longer it runs on your codebase.
+>
+> The honest problem with that pitch: nobody could see it working.
+> "The agent has a learning memory" is a claim. "Install this and
+> trust me" is not a demo.
+>
+> So in 0.6.0, `neuralmind serve` got a live activity feed.
+> Synapse and file events stream to the canvas over SSE. When
+> Claude (or any agent) calls a tool, the relevant nodes pulse.
+> When you save a file in your editor, the corresponding node
+> pulses. You can sit there and watch the hippocampus learn your
+> codebase in real time.
+>
+> Plus a JSONL cross-process bridge that means if you run Claude
+> Code, Cursor, OpenClaw, and Hermes-Agent all against the same
+> project — they reinforce the same brain, and the graph view
+> shows the union of their activity. NeuralMind becomes the shared
+> memory substrate underneath the polyglot agent stack.
+>
+> The headline measurable claim is unchanged: 40–70× per-query
+> token reduction on real codebases, ~3–10× end-to-end on a
+> typical agent workload, measured every commit in CI, reproducible
+> in 30 seconds on a fresh clone.
+>
+> What's new is that the abstraction now has a window.
+>
+> [VIDEO: 60-second clip — terminal demo + graph view + pulse rings]
+>
+> github.com/dfrostar/neuralmind
+>
+> #ClaudeCode #Cursor #AIEngineering #OpenSource #DeveloperTools
+
+### Draft v0.6.0–B — feature-tour, scannable
+
+> NeuralMind v0.6.0 ships today. What's new:
+>
+> → **Live activity feed.** `neuralmind serve` streams synapse +
+>   file events over SSE. Affected nodes pulse on the canvas in
+>   real time. Sidebar log shows the most recent ~80 events.
+>
+> → **Cross-process JSONL bridge.** A `neuralmind watch` daemon, a
+>   Claude Code session, an OpenClaw call — all in different
+>   processes — feed the same live feed via
+>   `.neuralmind/events.jsonl`. One canvas, every agent.
+>
+> → **Pin UX.** Drag-to-pin already saved positions; v0.6.0 adds a
+>   visible pin glyph, a Pin/Unpin button in the detail panel, and
+>   an Unpin-all sidebar action.
+>
+> → **Quick-switch.** Cmd/Ctrl-K and `/` jump to semantic search
+>   from anywhere. Esc clears.
+>
+> → **Local-graph depth slider.** 1–3 hops via BFS from the focused
+>   node. Default 1, so existing behavior is unchanged.
+>
+> → **Replay-last-query overlay.** Re-highlight the L3 hits the
+>   agent most recently received. Closes the "is the agent looking
+>   at the right code" trust gap in a 2-second visual.
+>
+> → **Edge tooltips + min-weight synapse slider.** Hover any edge
+>   for relationship + weight; filter out low-weight noise.
+>
+> The measurable claim is unchanged from v0.5: 40–70× per-query
+> retrieval reduction on real repos, ~3–10× end-to-end, verifiable
+> in 30 seconds with `bash scripts/demo.sh` on a fresh clone.
+>
+> What v0.6.0 changes is that the *learning* is now visible. You
+> can see the brain working.
+>
+> [VIDEO: 60-second pulse-rings clip]
+>
+> github.com/dfrostar/neuralmind
+
+### Draft v0.6.0–C — narrative / founder voice
+
+> Three months ago I posted about NeuralMind, the open-source
+> context engine I've been building for AI coding agents. The
+> story then was a number: 40–70× per-query token reduction. Real,
+> measurable, reproducible on a fresh clone. But also a little
+> dry.
+>
+> The story today, with v0.6.0, is something I can actually show
+> you.
+>
+> NeuralMind isn't just a retrieval index. Since v0.4, it's an
+> associative memory layer — a persistent graph that learns which
+> pieces of code your agent uses together. Edges strengthen with
+> co-activation, decay if unused, get protected from decay once
+> they're frequently-used. Spreading activation surfaces related
+> code on every prompt. It's a small, local hippocampus that runs
+> alongside the LLM cortex.
+>
+> The honest problem was: you couldn't see it work. We had tests.
+> We had benchmarks. But the experience was a black box that you
+> had to trust would get smarter.
+>
+> v0.6.0 ends that. `neuralmind serve` now streams a live activity
+> feed. Every time the agent uses a code node, that node pulses on
+> the graph. Every time you save a file, the corresponding node
+> pulses. You can sit there and watch the brain learn your
+> codebase.
+>
+> It's the moment that flips "code RAG" into "associative memory
+> for your codebase." It's also the moment when, if you're running
+> Claude Code in one terminal and OpenClaw in another, you can see
+> them reinforcing the *same* brain — because v0.6.0 also adds a
+> cross-process JSONL bridge so every agent talking to the project
+> contributes to one canvas.
+>
+> If you've been watching your Claude or Cursor bill climb, or
+> you've noticed your AI tools "forgetting" your codebase between
+> sessions: this is for you.
+>
+> [VIDEO: 60-second clip]
+>
+> Free, MIT, fully local. github.com/dfrostar/neuralmind
+
+### Choosing between A / B / C
+
+- **A** is the safest. Short, technical, honest about limitations,
+  works on any LinkedIn network. Default pick.
+- **B** has the highest information density and scans best for
+  engineering audiences. Good if your network skews scanners.
+- **C** is the highest-engagement candidate but only if you have
+  an audience that engages with longer-form / story-driven posts.
+  Higher variance.
+
+### Common across all three
+
+- **The video is non-optional.** Without the pulse-rings clip, all
+  three drafts collapse back into the existing v0.5 progress
+  update — same number, different words. The clip is what makes
+  v0.6.0 a separate post worth posting.
+- **The honest end-to-end caveat ("3–10× end-to-end") is in A and
+  B but not C.** That's deliberate — C is narrative, not spec
+  sheet. If you post C, link to `docs/HONEST-ASSESSMENT.md` in the
+  first comment so the caveat is reachable.
+
+---
+
+## Earlier drafts (pre-v0.6.0 — kept for reference)
+
 Three drafts at different lengths and tones. Pick one, edit to
 match your voice, post.
 

--- a/docs/SCREENCAST-v0.6.0.md
+++ b/docs/SCREENCAST-v0.6.0.md
@@ -1,0 +1,182 @@
+# 60-second screencast script — NeuralMind v0.6.0
+
+Three beats. Sixty seconds total. Recorded on the maintainer's
+machine against a real codebase (the bundled demo's pulse rings
+are sparse — see ROADMAP.md for the recording runbook).
+
+The job of this clip is to flip the pitch from "code RAG" to
+"associative memory you can watch learn." The first two beats
+re-state the existing claim. The third beat is the new claim.
+
+---
+
+## Format
+
+- **Length:** 60 seconds, hard cut.
+- **Aspect:** 16:9 for LinkedIn / X / blog embed; 9:16 vertical
+  re-cut for mobile-first surfaces.
+- **Resolution:** 1920×1080 minimum; capture at retina/2× if
+  possible — terminals look much sharper.
+- **Audio:** No voice-over. Soft ambient or none. Text overlays
+  for narration so the clip plays muted on autoplay surfaces.
+- **Terminal theme:** Dark background, monospace font ≥ 18pt. The
+  numbers have to be legible at thumbnail size.
+- **Browser theme:** Dark; canvas readable in thumbnails.
+
+## Beat 1 — The number (0:00–0:20)
+
+**Visual:** Full-screen terminal. Type and run:
+
+```bash
+bash scripts/demo.sh
+```
+
+The demo script's output scrolls. The hero line in the output is
+the average-reduction summary block — make sure it lands in the
+last 5 seconds of this beat.
+
+```
+Q: How does authentication work in this codebase?
+   naive = 4,736 tok   neuralmind =  829 tok   reduction =   5.7×
+...
+Average reduction:   5.5×  across 3 queries
+Wall time:           0.85s
+```
+
+**Text overlay (bottom third):**
+
+> 30-second proof on a fresh clone.
+> Real repos consistently hit 40–70×.
+
+**Cut at:** the "Wall time" line, before the next prompt.
+
+## Beat 2 — The graph (0:20–0:40)
+
+**Visual:** Cut to a browser. URL bar shows `127.0.0.1:8765`.
+Canvas already rendered — force-directed graph of the codebase,
+nodes colored by community, structural edges visible.
+
+**On-screen actions:**
+
+- Mouse over a node — detail panel pops in.
+- Click the semantic search field. Type `auth`. The matching
+  node focuses; its synaptic neighbors highlight.
+- Click an edge. Tooltip appears showing relationship type + weight.
+
+**Text overlay:**
+
+> `neuralmind serve` — Obsidian-style graph view.
+> Backlinks, synapse overlay, semantic quick-switcher.
+
+**Cut at:** mouse moving toward the terminal (visual transition
+to beat 3).
+
+## Beat 3 — The pulse (0:40–1:00)
+
+**THIS IS THE MONEY SHOT.** Everything in beats 1 and 2 is
+context for this beat.
+
+**Visual:** Split-screen if your recording app supports it, else
+quick cuts back and forth.
+
+- **Left half / cut A:** Editor (VS Code or similar) showing
+  a file in the demo project. Visible cursor position.
+- **Right half / cut B:** The graph view, canvas centered on
+  the file's corresponding node.
+
+**On-screen actions:**
+
+1. In the editor, make a one-line change (add a comment, change
+   a string — anything that triggers a save).
+2. Save the file (Cmd-S / Ctrl-S).
+3. Cut to the graph view — within ~1s, the corresponding node
+   **pulses** with an animated radial ring. The sidebar feed shows
+   a fresh `file_activity` event.
+4. (If achievable in the take) Run `neuralmind query .
+   "auth"` in a third terminal — a second wave of pulses fires on
+   the canvas as the synapse store reinforces the co-activated
+   nodes.
+
+**Text overlay (timed to the first pulse):**
+
+> Edit a file. The brain pulses.
+> v0.6.0 — see the synapses learn, live.
+
+**End frame (last 3 seconds):**
+
+Static frame. NeuralMind logo bottom-left. URL bottom-right:
+
+> github.com/dfrostar/neuralmind
+
+## Pitfalls / things to avoid
+
+- **Don't show the wakeup output in full.** It's text-heavy and
+  doesn't read at 5x speed. The terminal in beat 1 should be the
+  demo summary, not raw context.
+- **Don't include voice-over.** LinkedIn autoplays muted; X
+  autoplays muted. A voice-over that's only audible if the viewer
+  unmutes loses 80%+ of the impact. Text overlays do the job.
+- **Don't slow-mo the pulse.** It looks gimmicky and people
+  assume it's a render effect. Real-time playback makes it look
+  alive; slowed it looks fake.
+- **Don't show the JSONL bridge file.** The `events.jsonl` is
+  the boring side channel — opening it in a text editor is the
+  *opposite* of the punchy visual we want. The bridge is in the
+  release notes and the wiki; it doesn't earn screen time.
+- **Don't try to fit all eight features.** Pin glyph, depth
+  slider, replay overlay, edge tooltips — none of them are the
+  hero. The hero is the pulse. If you have 90 seconds instead of
+  60, add one more action in beat 2 (depth slider drag); past
+  that, cut.
+
+## Recording checklist
+
+- [ ] Demo project pre-built (`graphify update .` and
+      `neuralmind build .` already run, otherwise beat 1's
+      timing breaks).
+- [ ] `neuralmind serve` running before the recording starts.
+- [ ] Browser window pre-positioned and pre-zoomed.
+- [ ] Editor open on a file with one obvious one-line edit
+      already staged in muscle memory.
+- [ ] Screen recording app set to capture at 60fps if possible
+      (the pulse animation looks dramatically better at 60fps).
+- [ ] Run-through twice off-camera to get terminal timings
+      consistent.
+
+## Post-production
+
+- Hard cuts only. No fades. Each beat starts at second 0/20/40.
+- Color-grade the terminal slightly warmer than default — pure
+  white text on pure black tests as sterile in thumbnails.
+- The first frame of beat 3 (the pulse) is your **thumbnail
+  candidate**. Export a still from the moment a pulse is at full
+  radius for use as the YouTube/LinkedIn thumbnail.
+
+## Distribution
+
+- LinkedIn — native video upload preferred over embed; LinkedIn
+  algorithmically favors native. Use the LinkedIn draft from
+  [`LINKEDIN-POST-DRAFT.md`](LINKEDIN-POST-DRAFT.md) as the
+  caption.
+- X / Twitter — 60s fits in a single tweet. Lead the tweet with
+  the still-frame thumbnail.
+- README — embed the asciinema-style version (terminal-only
+  beats 1 + 3) at the top of the README, above the existing
+  30-second-proof block. Browser-based beat 2 doesn't asciinema
+  cleanly; show it as a separate animated PNG/GIF.
+- Blog / about page — embed the full 60s in the "What's new in
+  v0.6.0" callout.
+
+## TODO / not yet recorded
+
+The clip itself has not been recorded as of the v0.6.0 docs PR.
+This file is the script; the recording is a maintainer-run step
+(can't run in CI because of the chromadb model download — same
+constraint as the existing demo recording in
+[`RECORDING-DEMO.md`](RECORDING-DEMO.md)).
+
+Once recorded, drop the file in `docs/assets/v0.6.0-pulse.mp4`
+(and the GIF version at `docs/assets/v0.6.0-pulse.gif`) and
+update the embeds in `README.md`, `docs/index.html`, and
+`docs/about.html`. Those embed points are already prepared with
+TODO markers — see the placeholders in the v0.6.0 callout blocks.

--- a/docs/about.html
+++ b/docs/about.html
@@ -46,6 +46,31 @@
     </header>
 
     <section>
+        <div class="container" id="whats-new-v060">
+            <h2>What's New in v0.6.0 — see the brain learning, live</h2>
+            <p><strong>The pitch flipped.</strong> v0.5.4 made the brain inspectable. v0.6.0 makes it <em>legible</em>. <code>neuralmind serve</code> now streams a live activity feed: synapse + file events pulse across the canvas in real time as the agent and the codebase interact. The graph stops being a static map and becomes a window into the hippocampus learning your codebase.</p>
+            <div class="quote">
+                "You can sit there, in real time, and watch the hippocampus learn your codebase. That's the moment when 'code RAG' turns into 'associative memory for your codebase.'"
+            </div>
+            <h3>Headline changes</h3>
+            <ul>
+                <li><strong>Live activity feed</strong> — <code>/api/events</code> SSE stream subscribed to the in-process event bus. Affected nodes pulse on the canvas; sidebar log shows the most recent ~80 events.</li>
+                <li><strong>Cross-process activity bridge</strong> — a separate <code>neuralmind watch</code> daemon, or a hook-driven Claude Code session in another process, feeds the same live feed via <code>&lt;project&gt;/.neuralmind/events.jsonl</code>. The in-process bus stays the primary path; the JSONL is a deliberately boring side channel. Opt out with <code>NEURALMIND_EVENT_LOG=0</code>.</li>
+                <li><strong>Pin UX</strong> — visible pin glyph on every pinned node, Pin/Unpin toggle in the detail panel, Unpin-all sidebar button.</li>
+                <li><strong>Quick-switch shortcuts</strong> — <code>Cmd/Ctrl-K</code> and <code>/</code> jump-to-search from anywhere; <code>Esc</code> clears and blurs.</li>
+                <li><strong>Local-graph depth slider</strong> — 1–3 hops via BFS from the focused node; defaults to 1 so existing behavior is unchanged.</li>
+                <li><strong>Replay-last-query overlay</strong> — re-highlight the L3 hits the agent most recently received. Closes the trust gap on retrieval in a 2-second visual.</li>
+                <li><strong>Edge tooltips + min-weight synapse slider</strong> — hover an edge to see relationship and weight; filter low-weight synapses.</li>
+                <li><strong>Docs refresh</strong> — ROADMAP, README hero, landing page, about page, and wiki all reframed around the graph view as a second pillar alongside the 40–70× reduction.</li>
+            </ul>
+            <h3>The shared-brain unlock</h3>
+            <p>The cross-process JSONL bridge means that if you run Claude Code, Cursor, OpenClaw, and Hermes-Agent against the same project — they reinforce the same synapse store, and the v0.6.0 graph view shows the <em>union</em> of their activity. Pre-v0.6.0, the synapse store was shared but the experience wasn't — three tools talking to a black box. Now the brain is visibly one brain. See the <a href="https://github.com/dfrostar/neuralmind/blob/main/docs/use-cases/multi-agent.md">multi-agent walkthrough</a>.</p>
+            <p>No migration: same <code>graph.json</code>, same <code>synapses.db</code>, same hooks. Upgrade is <code>pip install --upgrade neuralmind</code>. Then <code>neuralmind serve</code> and save a file — that's the demo and the verification in one motion.</p>
+            <p><a href="https://github.com/dfrostar/neuralmind/blob/main/RELEASE_NOTES_v0.6.0.md">Full v0.6.0 release notes →</a></p>
+        </div>
+    </section>
+
+    <section>
         <div class="container">
             <h2>Mission</h2>
             <p>NeuralMind exists to solve a fundamental problem: AI agents waste tokens loading raw source code when they only need small, semantic context.</p>
@@ -84,7 +109,7 @@
             <p><strong>Phase 1 — Smart Retrieval:</strong> Instead of loading entire files, NeuralMind uses a 4-layer semantic index to surface only the ~800 tokens of code your question actually needs.</p>
             <p><strong>Phase 2 — Output Compression:</strong> PostToolUse hooks compress Read, Bash, and Grep output 88–91% smaller before agents see it.</p>
             <p><strong>Phase 3 — Brain-like Memory <em>(v0.4.0)</em>:</strong> A second brain runs alongside the LLM — a persistent weighted graph that learns associations between code nodes from how the agent and the codebase actually interact. Stronger connections form between code that gets used together, weaker ones decay, and the agent's prompts trigger spreading-activation recall over the learned graph.</p>
-            <p><strong>Phase 4 — Graph View <em>(new)</em>:</strong> <code>neuralmind serve</code> renders the whole system as an Obsidian-style force-directed graph in the browser. Structural edges, the learned synapse overlay, backlinks, a semantic quick-switcher, and one-click open-in-editor. The brain stops being a black box — you can finally see what it retrieved and what it has learned.</p>
+            <p><strong>Phase 4 — Graph View <em>(v0.5.4, made live in v0.6.0)</em>:</strong> <code>neuralmind serve</code> renders the whole system as an Obsidian-style force-directed graph in the browser. Structural edges, the learned synapse overlay, backlinks, a semantic quick-switcher, and one-click open-in-editor. <strong>v0.6.0 adds a live activity feed</strong> — synapse and file events pulse on the canvas in real time, with a cross-process JSONL bridge that lets Claude Code, Cursor, OpenClaw, and Hermes-Agent all feed the same canvas. The brain stops being a black box — you can finally watch what it's learning, live.</p>
             <p><strong>Result:</strong> 40–70× per-query token reduction (50K+ tokens of raw source compressed into ~800 tokens of structured context) and 40–70% bill drops on real codebases. Retrieval that gets sharper the longer the system runs on a codebase.</p>
 
             <h3>Enterprise Ready</h3>
@@ -123,9 +148,10 @@
             </ul>
             <p>The synapse store is local SQLite, project-scoped, and inspectable. It exports a markdown summary that Claude Code's auto-memory system loads natively, so the learned associations show up in every session — no MCP tool call required.</p>
 
-            <h3>Graph View — <code>neuralmind serve</code> <em>(new)</em></h3>
+            <h3>Graph View — <code>neuralmind serve</code> <em>(v0.5.4, made live in v0.6.0)</em></h3>
             <p>The agent-facing brain is now also a human-facing tool. A stdlib HTTP server renders a force-directed graph of the entire codebase in the browser — structural edges (calls and imports) drawn together with the learned synapse overlay, where edge thickness encodes weight. Each node has Obsidian-style backlinks and outgoing-links panels, a "synaptic neighbours" list with weights and activation counts, and a one-click "open in editor" button (smart support for VS Code, Cursor, vim, sublime, JetBrains). A semantic quick-switcher lets you type a phrase and jump straight to the matching node. Zero CDN dependencies; per-session access token bound to 127.0.0.1.</p>
-            <p>Why it matters: NeuralMind's retrieval used to be a black box — the agent claimed to use it, but you couldn't see what was found, what was missed, or whether the synapse layer was actually learning. The graph view exposes the whole index so retrievals are inspectable, debuggable, and trustable.</p>
+            <p><strong>v0.6.0 adds a live activity feed.</strong> The server now exposes a long-lived <code>/api/events</code> SSE stream subscribed to an in-process event bus. Every <code>SynapseStore.reinforce()</code> call and every coalesced file-edit batch publishes an event; affected nodes pulse on the canvas with short animated radial rings, and a sidebar log shows the most recent ~80 events. A cross-process JSONL bridge (<code>&lt;project&gt;/.neuralmind/events.jsonl</code>) lets a separate <code>neuralmind watch</code> daemon, a Claude Code session, an OpenClaw call, or any other process feed the same canvas. One canvas, every agent. Opt out with <code>NEURALMIND_EVENT_LOG=0</code>.</p>
+            <p>Why it matters: pre-v0.6.0 the graph view was inspectable but static — you had to refresh to see new state. With the live feed, you can sit there in real time and watch the hippocampus learn your codebase. "The agent has a learning memory" stops being a claim and becomes a visual.</p>
 
             <h3>Compliance-First Design</h3>
             <p>Every query is logged with full provenance: which code was retrieved, why, which embeddings were used, code state (git commit). Export for NIST AI RMF, SOC 2, GDPR, HIPAA.</p>
@@ -151,13 +177,13 @@
     <section>
         <div class="container">
             <h2>Status & Roadmap</h2>
-            <h3>Current Release: v0.5.4 — Graph View</h3>
-            <p>Adds <code>neuralmind serve</code>: a local, dependency-free, Obsidian-style graph view over the existing index and synapse store. Code nodes coloured by community; structural edges and Hebbian synapses drawn together; backlinks, synaptic neighbours, semantic quick-switch, and one-click open-in-editor. Builds on v0.5.x's bundled MCP server and v0.4.0's brain-like synapse layer — no migration needed.</p>
+            <h3>Current Release: v0.6.0 — Live Activity Feed</h3>
+            <p>Builds on v0.5.4's graph view. <code>neuralmind serve</code> now streams synapse + file events to the canvas in real time over SSE — affected nodes pulse, a sidebar log shows the most recent ~80 events. A cross-process JSONL bridge means a separate <code>neuralmind watch</code> daemon, or a hook-driven Claude Code session, feeds the same live feed via <code>&lt;project&gt;/.neuralmind/events.jsonl</code>. Pin UX, Cmd/Ctrl-K quick-switch, a 1–3-hop depth slider, replay-last-query overlay, edge tooltips, and a min-weight synapse slider round out the release. No migration — same index, same <code>synapses.db</code>, same hooks. See the <a href="https://github.com/dfrostar/neuralmind/blob/main/RELEASE_NOTES_v0.6.0.md">v0.6.0 release notes</a>.</p>
 
             <h3>Future Releases</h3>
             <ul>
-                <li><strong>v0.5.5 (next patch release)</strong> — Graph-view Phase B: a <a href="https://github.com/dfrostar/neuralmind/pull/105">"replay last query" overlay</a> highlighting the L3 hits the agent received, <a href="https://github.com/dfrostar/neuralmind/pull/106">edge tooltips + a min-weight synapse slider</a> answering "why are these two nodes related?" on hover, plus pin UX and a <code>Cmd/Ctrl-K</code> quick-switch shortcut. <strong>Phase C</strong> after: a live activity feed of synapse co-activations so you can watch the brain learning in real time.</li>
-                <li><strong>Later</strong> — Auto-watcher launch from <code>SessionStart</code> (<a href="https://github.com/dfrostar/neuralmind/issues/78">#78</a>); synapse import/export so teams can share a learned brain (<a href="https://github.com/dfrostar/neuralmind/issues/79">#79</a>); benchmarks measuring retrieval quality with vs without synapses (<a href="https://github.com/dfrostar/neuralmind/issues/80">#80</a>); PostgreSQL pgvector scale testing; expanded backend ecosystem.</li>
+                <li><strong>v0.7 (next)</strong> — Saved named graph views (Obsidian-style filter/zoom/depth combos, localStorage-backed), right-click context menu on nodes, PNG/SVG canvas export, time-based edge filter (complements v0.6.0's min-weight slider), and unifying the <code>neuralmind watch</code> daemon with the in-process bus so a single-process serve+watch stays unified without the JSONL bridge.</li>
+                <li><strong>Later</strong> — Synapse import/export so teams can share a learned brain (<a href="https://github.com/dfrostar/neuralmind/issues/79">#79</a>); benchmarks measuring retrieval quality with vs without synapses (<a href="https://github.com/dfrostar/neuralmind/issues/80">#80</a>); PostgreSQL pgvector scale testing; expanded backend ecosystem.</li>
                 <li><strong>v1.0.0 (Target Q1 2027)</strong> — Stable API guarantee, 2-year LTS support, commercial support options.</li>
             </ul>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -61,7 +61,10 @@
             <h1>🧠 NeuralMind</h1>
             <p>Semantic code intelligence for AI agents.<br/>40–70× token reduction. Zero data exfiltration. Enterprise-ready.</p>
             <p style="font-size: 1rem; opacity: 0.85; margin-top: 0.5rem;">
-                <strong>v0.4.0 — Brain-like synapse layer.</strong> A second brain alongside the LLM that learns associations between code from how you actually use it. <a href="https://github.com/dfrostar/neuralmind/blob/main/RELEASE_NOTES_v0.4.0.md" style="color: white; text-decoration: underline;">Release notes →</a>
+                <strong>🆕 v0.6.0 — Live activity feed.</strong> <code>neuralmind serve</code> now streams synapse + file events to the canvas in real time. Watch the brain learning your codebase, live. <a href="https://github.com/dfrostar/neuralmind/blob/main/RELEASE_NOTES_v0.6.0.md" style="color: white; text-decoration: underline;">Release notes →</a> · <a href="about.html#whats-new-v060" style="color: white; text-decoration: underline;">Visual walkthrough →</a>
+            </p>
+            <p style="font-size: 0.9rem; opacity: 0.75; margin-top: 0.25rem;">
+                Earlier: <a href="https://github.com/dfrostar/neuralmind/blob/main/RELEASE_NOTES_v0.4.0.md" style="color: white; text-decoration: underline;">v0.4.0 brain-like synapse layer</a>.
             </p>
             <div>
                 <a href="wiki/Setup-Guide" class="btn btn-primary">Get Started in 5 Minutes</a>

--- a/docs/notebooklm/v0.6.0/01-the-origin-story.md
+++ b/docs/notebooklm/v0.6.0/01-the-origin-story.md
@@ -1,0 +1,124 @@
+# Why NeuralMind exists, and what v0.6.0 changes
+
+*Founder-narrative source for the NotebookLM video. First-person,
+conversational. Use as the "why does this exist" arc.*
+
+---
+
+I started NeuralMind because my Claude Code bill was climbing past
+two hundred dollars a month on a single project and I wanted to
+understand why. The answer was depressingly simple: every code
+question loaded about fifty thousand tokens of context. The model
+needed maybe a thousand of them. I was paying for the model to
+re-read my entire codebase to answer "how does the auth middleware
+work."
+
+That's the problem in one sentence. Loading the whole codebase to
+answer a small question is like reading the entire book to look up
+one fact. Indexes have existed for centuries for exactly this
+reason. We just hadn't built one for AI coding agents yet.
+
+So I built one. The retrieval side was conceptually unremarkable —
+a vector index over the call graph, a four-layer progressive
+disclosure thing where the smallest layer is the project identity
+and the largest is the semantic search results. The numbers were
+nice: forty to seventy times reduction per query on real codebases.
+That gets you a 30-second demo and a small but real audience of
+developers who'd been quietly cursing their token bills.
+
+But somewhere around version 0.4, I started thinking about the
+problem differently. Retrieval is not the only thing brains do. The
+human brain doesn't just *look up* memories — it also *learns
+associations*. Things that fire together wire together. The auth
+middleware and the user model become linked, in your head, because
+you keep thinking about them together. The next time someone asks
+you a question about authentication, the user model surfaces too,
+without you having to "look it up."
+
+I wanted that for code. So I built a second brain alongside the
+retrieval brain — a persistent weighted graph that lives in a SQLite
+file in your project. Every time the agent uses two pieces of code
+together, the edge between them gets a little heavier. Edges decay
+if they go unused, like real synapses. Frequently-used edges get
+protection from decay, like long-term potentiation. When a new
+question comes in, "activation" spreads through the learned graph
+and surfaces related code that pure vector search would never find.
+
+That's the conceptual leap. NeuralMind isn't just a retrieval index
+anymore. It's an associative memory that gets sharper the longer
+it runs on your codebase. The agent never sees the weights
+directly. It just gets better context.
+
+The hard part, and the reason version 0.6.0 matters, is that "the
+agent has a learning memory" is a *claim*. It's not visible. It's
+not falsifiable. If you install NeuralMind and your agent feels a
+little smarter a week later, you can't tell whether the synapse
+layer helped or whether you just got used to the tool. That gap
+between "we built this" and "you can see it working" is the gap
+where most software dies.
+
+So in 0.6.0, we made the brain *legible*. There's a `neuralmind
+serve` command that opens an Obsidian-style force-directed graph of
+your codebase in the browser — every code node, every structural
+edge, every learned synapse. That part shipped in 0.5.4. What's new
+in 0.6.0 is that the graph is now *alive*. When the agent uses a
+piece of code, the corresponding node *pulses* on the canvas. When
+you save a file in your editor, the relevant nodes pulse. The
+sidebar logs the events as they happen.
+
+You can sit there, in real time, and watch the hippocampus learn
+your codebase. That's the moment when "code RAG" turns into
+"associative memory for your codebase." It's also the moment the
+pitch flips. Before 0.6.0, the headline was a number: "forty to
+seventy times fewer tokens." After 0.6.0, there's a *second*
+headline, and it's a verb: *see the brain learning*. The number is
+still there — it's still the measurable claim that justifies the
+install — but there's now a visceral demo behind it.
+
+There's a third thing in 0.6.0 that's quieter but maybe more
+important long-term. We added a cross-process activity bridge — a
+small JSON-lines file in `.neuralmind/events.jsonl` that lets
+different processes feed into the same live feed. That sounds dull
+until you realize what it enables: if you run Claude Code in one
+terminal, OpenClaw in another, and the `neuralmind watch` daemon in
+a third, all three are reinforcing the same synapse store. The
+graph view shows the union of their activity. The brain is shared.
+
+Pre-0.6.0, you couldn't see that. The synapse weights were getting
+updated by every agent, but the experience was three separate tools
+talking to a black box. Now there's one canvas, and any tool call
+from any agent makes a node pulse. The brain isn't just learning
+your codebase; it's learning your codebase across every tool you
+use. That's a feature you couldn't have shipped in 0.5.4 because
+the user couldn't perceive it.
+
+So that's where we are. The retrieval index is the cortex — useful,
+unsurprising, well-understood. The synapse layer is the
+hippocampus — newer, weirder, and now finally visible. And the
+graph view is the eye you point at the hippocampus to see it work.
+
+The next thing on my list is making the graph view *useful for
+debugging*. When an agent answers wrong, the natural question is:
+"what did it actually look at?" The replay-last-query overlay
+that shipped in 0.6.0 is the first step — it highlights the L3 hits
+the agent received on its last query, so you can see whether
+retrieval pulled the right nodes. The plan from here is to extend
+that into a full audit trail: every query, every tool call, every
+file edit, all timestamped, all replayable on the canvas. If
+NeuralMind is going to be the shared memory layer underneath your
+agents, it has to be inspectable. That's the long-term bet.
+
+If you're a developer who's been watching your Claude or Cursor
+bill climb, or if you're someone who's noticed that AI agents do
+the same thing wrong over and over because they keep "forgetting"
+what they learned about your codebase, this is for you. It's free,
+it's MIT-licensed, and it runs entirely on your machine. The thirty
+second demo is `bash scripts/demo.sh` on a fresh clone. If the
+numbers move for you, install it for real. If they don't, the
+honest assessment doc explains when NeuralMind isn't worth the five
+minutes of setup — small codebases, low-volume LLM use, you don't
+pay per token. We're not trying to convince everyone. We're trying
+to be useful to the people for whom this is genuinely useful.
+
+That's NeuralMind, in 2026, at version 0.6.0. The brain has a
+window now. You can look in.

--- a/docs/notebooklm/v0.6.0/02-what-shipped.md
+++ b/docs/notebooklm/v0.6.0/02-what-shipped.md
@@ -1,0 +1,176 @@
+# What ships in NeuralMind v0.6.0
+
+*Technical feature-tour source for the NotebookLM video. Neutral
+third-person, concrete. Use as the "what's actually in the box"
+arc.*
+
+---
+
+NeuralMind 0.6.0 is a single coherent feature release. The headline
+is the live activity feed in `neuralmind serve`, but the release
+ships eight closely related improvements that together turn the
+browser-based graph view from "a static map of your codebase" into
+"a live observatory for the synapse layer." Here's what each piece
+does and where it shows up.
+
+## The live activity feed
+
+`neuralmind serve` starts a small local web server — stdlib HTTP,
+no external dependencies — that renders a force-directed graph of
+the project in the browser. In 0.5.4, that view was a snapshot.
+You could click nodes, see backlinks and synaptic neighbors,
+search semantically, and open files in your editor, but the canvas
+didn't change unless you refreshed it.
+
+In 0.6.0, the canvas is live. The server exposes a long-lived
+Server-Sent Events stream at `/api/events`. Two things publish to
+the stream automatically. First, the synapse store: every time
+`SynapseStore.reinforce()` is called — meaning the brain learned
+something — it publishes a `synapse` event with the pair of nodes
+that just got connected. Second, the file activity watcher: every
+time a batch of file edits is coalesced into a single
+co-activation event, it publishes a `file_activity` event with the
+affected nodes.
+
+The browser side does two things with that stream. It draws short
+animated radial pulses around each node referenced in a recent
+event — color-coded by event source, synapse versus file activity —
+and it logs the most recent eighty events in a sidebar feed with
+timestamps. Click a sidebar entry, and the corresponding node
+focuses on the canvas.
+
+The effect is hard to convey in prose. You watch a node flash the
+instant you save a file in your editor. You see a cluster of nodes
+light up when you run a build that touches twenty modules at once.
+You see synapse events fire when the agent calls `neuralmind_query`
+and the brain reinforces the co-activated hits. The graph
+visibly *throbs*. The phrase that keeps coming up in early feedback
+is "second screen for my agent."
+
+## The cross-process JSONL bridge
+
+The in-process event bus is great when `serve` and the activity
+source live in the same Python process. The common real-world case
+is not that. You run `serve` in one terminal, the `neuralmind
+watch` daemon in another, and a Claude Code session in a third —
+three processes, three sources, one canvas that you'd like to show
+all of them.
+
+0.6.0 adds a deliberately boring side channel. When the event bus
+publishes, it also appends a JSON line to
+`<project>/.neuralmind/events.jsonl`. The `serve` process tails that
+file in a background thread and re-emits any events it didn't
+originate. Net result: every process talking to the same project
+contributes to the same live feed.
+
+The design choice worth noting is that the JSONL bridge is a
+*fallback*, not a queue. The in-process bus is still the primary
+path; the file is best-effort and reconstructs itself if it
+disappears or rolls. The environment variable
+`NEURALMIND_EVENT_LOG=0` disables the writer if you want the
+in-process feed only.
+
+The unlock here is bigger than it looks. Pre-0.6.0, running Claude
+Code, OpenClaw, and Hermes-Agent against the same project meant
+three tools reinforcing the same synapse store but no way to *see*
+the union of their activity. With the JSONL bridge, you get one
+canvas showing every tool call from every agent. NeuralMind
+becomes the shared memory layer underneath the polyglot agent
+stack.
+
+## Pin glyph plus Pin/Unpin button plus Unpin-all
+
+The graph view has had drag-to-pin since 0.5.x. Hold a node, drag
+it where you want it, and it stays there across re-renders.
+Useful, but invisible — you couldn't tell at a glance which nodes
+were pinned versus which had just settled there because of the
+force-directed layout.
+
+0.6.0 surfaces the state. Every pinned node renders a warm-colored
+pin marker. The node detail panel grows a Pin/Unpin toggle for
+the focused node. The sidebar gets an Unpin-all button for
+resetting layout. Small change, large daily quality-of-life impact
+for anyone using the graph view to maintain a curated "auth tour"
+or "data layer view."
+
+## Cmd/Ctrl-K and forward-slash for quick-switch
+
+Two new keyboard shortcuts both focus the semantic search field
+from anywhere on the page. Cmd-K and Ctrl-K work for the
+power-user crowd; forward-slash for the vim-flavored. Escape
+clears the search field and blurs the focus.
+
+The motivation: in a force-directed graph with hundreds or
+thousands of nodes, mouse-based navigation breaks down fast.
+Semantic search is the fastest path between any two nodes, and
+0.6.0 makes it always one keystroke away.
+
+## Local-graph depth slider
+
+The graph view has a "show only the local neighborhood" toggle
+that hides all but the nodes within one hop of the focused one.
+0.6.0 adds a depth slider that ranges from one to three hops,
+breadth-first from the focused node. Default is one, so existing
+behavior is unchanged. The slider uses the standard `disabled`
+attribute when the parent toggle is off, so it stays visibly
+inert.
+
+The expected use: depth one for "what does this function talk to
+directly," depth two for "what's in this function's tactical
+neighborhood," depth three for "what's the architectural cluster
+this function lives in." Past three hops, force-directed layouts
+on a real codebase become an unreadable hairball, so the slider
+caps at three by design.
+
+## Replay-last-query overlay
+
+The detail panel grows a "Replay last query" action that
+re-highlights the L3 hits the agent most recently received. This
+is the trust-gap closure feature. When a retrieval feels wrong —
+the agent answered with the wrong file, or missed the obvious
+function — you can pop the graph view, hit replay, and *see* which
+nodes the model actually got. Often the answer is obvious as soon
+as it's visible: a stale cluster boundary, a missing edge, an
+unexpected hub. Without the overlay, you'd be debugging by
+reading log files.
+
+## Edge tooltips and the min-weight synapse slider
+
+Hover any edge to see the relationship type — call, import, or
+synapse — and for synapses, the current weight and activation
+count. The synapse-overlay toggle now has a companion slider that
+filters edges below a configurable minimum weight, so the canvas
+isn't cluttered with thousands of low-weight noise links when
+you're trying to see the structural backbone.
+
+## Docs refresh and positioning
+
+The roadmap, the README hero, the landing page, the about page,
+and the wiki all reframe NeuralMind's positioning around the
+graph view. Pre-0.6.0, the graph view was treated as a side
+feature underneath the headline 40-70x token reduction. Post-0.6.0,
+it's a second pillar: the reduction number is the *measurable*
+claim, the graph view is the *visceral* claim. Both land.
+
+## What's *not* in 0.6.0
+
+A few things that came up during scoping but didn't ship, tracked
+for 0.7: saved named views (filter plus zoom plus depth combos
+persisted in localStorage), right-click context menus on nodes,
+PNG and SVG export of the canvas, and a time-based edge filter
+that complements the new min-weight slider with a "last N days"
+view. The synapse store already records `last_activated`, so that
+last one is a frontend-only follow-up.
+
+## Compatibility
+
+No breaking changes. Same `graph.json` format, same `synapses.db`
+schema, same hook registration. If you ran `neuralmind serve`
+before, you already know 0.6.0 — it's just alive now. The CLI
+surface is unchanged. The MCP tool surface is unchanged. The
+on-disk state is forward-compatible. The `events.jsonl` file is
+new and self-creating. Python 3.10, 3.11, and 3.12 all pass CI.
+
+The upgrade is `pip install --upgrade neuralmind`. Open
+`neuralmind serve`, watch the canvas, save a file. That's the
+demo and the verification in one motion.

--- a/docs/notebooklm/v0.6.0/03-the-numbers-and-the-honest-take.md
+++ b/docs/notebooklm/v0.6.0/03-the-numbers-and-the-honest-take.md
@@ -1,0 +1,180 @@
+# The numbers, the day-in-the-life, and the honest take
+
+*Mixed-register source for the NotebookLM video. Combines a
+developer-experience walkthrough with the measurable claims and a
+short skeptic's section. Use as the "is this real, and is it worth
+it" arc.*
+
+---
+
+## A day in the life
+
+You sit down to add a feature to a project you don't fully
+remember. You have Claude Code open in one terminal. You install
+NeuralMind once, with `pip install neuralmind graphifyy` and a
+quick `graphify update . && neuralmind build .` against your
+project. Five minutes, one time.
+
+You ask Claude Code a question. Behind the scenes, the
+`SessionStart` hook fires and your agent gets about four hundred
+tokens of project orientation: the project name, the
+architecture summary, the top code clusters. That replaces the
+agent's usual session-start ritual of reading half your repo to
+get its bearings. The `UserPromptSubmit` hook fires next and
+injects a few hundred more tokens of synapse-recall context — the
+nodes the brain has learned tend to fire together when you ask
+this kind of question.
+
+You hit enter. Your agent answers in about a thousand tokens of
+input context instead of fifty thousand. Same question, same
+answer, fifty times less money. If you're a Claude 3.5 Sonnet user
+running a hundred questions a day, that's the difference between
+fifteen dollars a day and twenty-five cents. Across a month, it's
+the difference between four hundred fifty dollars and seven
+dollars.
+
+Now you pop a second terminal and run `neuralmind serve`. A
+browser tab opens to your codebase as an Obsidian-style
+force-directed graph — nodes colored by community, structural
+edges in one shade, learned synapses in another. You ask Claude
+Code another question. The nodes the agent looked at *pulse* on
+the canvas. You can see, in real time, which clusters of code the
+agent considered. If it picked the wrong cluster, you know
+immediately — not from logs, from a visual.
+
+You save a file in your editor. The corresponding node pulses.
+The file watcher coalesced your edit into a co-activation event,
+which reinforced the synapse edges to all the other files you
+recently touched, which fired a `synapse` event, which the live
+feed picked up, which the browser rendered. End-to-end latency:
+under a second.
+
+You ask another question and watch the brain work. Over the next
+week, the pulses concentrate around the parts of the codebase you
+actually live in. The hub nodes get stronger. The dead corners
+fade. You're not maintaining this. You're just using your editor
+and your agent normally. The brain learns from the use.
+
+That's the day in the life. Two terminals, one extra browser tab,
+two existing tools talking through a shared associative memory.
+
+## The numbers, as honestly as we can state them
+
+The headline is forty to seventy times per-query token reduction.
+That number measures one specific thing: how many tokens of input
+context the agent receives when it queries through NeuralMind,
+versus how many it would receive if you loaded the relevant raw
+source instead. It's measured on real codebases. The bundled
+fixture in CI shows about six times because the fixture is
+deliberately tiny — about five hundred lines, sized to catch
+regressions, not to look impressive. Real-world submissions from
+two outside repos show forty-six and sixty-six times. Your
+number, when you run `neuralmind benchmark .` on your own code,
+will land in that range if you have a real codebase. Small repos
+land lower; large repos with rich call graphs land higher.
+
+That's the retrieval-side number. It's the one we lead with
+because it's the one that's literally measured every commit in
+continuous integration, and the one anyone can reproduce in
+thirty seconds with `bash scripts/demo.sh` on a fresh clone.
+
+But there's a second number you should know, and the honest
+assessment doc spells it out: the *end-to-end* cost reduction on
+a typical agent workload is three to ten times, not forty to
+seventy. The retrieval stage is one cost line item among several
+in a real session. The agent still spends tokens on its own
+thinking, on tool output, on conversation history. NeuralMind
+drops one big slice of the pie. It doesn't drop the whole pie.
+
+We say this out loud because we want you to install NeuralMind
+only if it actually helps you. If you're spending fifty dollars
+a month on LLM calls against a small repo, three to ten times is
+nice but not life-changing. If you're spending five hundred or
+five thousand a month, three to ten times is the difference
+between a budget conversation and a non-issue. The honest
+assessment doc has the math.
+
+The graph view doesn't change the numbers. It changes whether
+you trust them. When you watch a node pulse the instant you save
+a file, and the next pulse is your agent picking up that node in
+its very next query, the abstraction stops being abstract. You
+can see the system doing what it claims.
+
+## When NeuralMind isn't worth installing
+
+There's a short list, written down in `docs/HONEST-ASSESSMENT.md`,
+of cases where you should skip this:
+
+Small codebases under about five thousand tokens, where you can
+just paste the whole thing into the context window. NeuralMind's
+setup time exceeds its benefit there.
+
+Workflows where you don't pay per token — local-only LLMs with
+flat-rate compute, or hobby projects where cost doesn't matter.
+The retrieval-quality benefit still exists, but the headline pitch
+is cost reduction, and there's nothing to reduce.
+
+Use cases that aren't code questions. NeuralMind is specialized.
+It indexes a call graph from `graphify-out/graph.json`. It does
+not help with documentation QA, customer-support ticket triage,
+or any other non-code agent task.
+
+Cases where you only want inline completions. Use Copilot or your
+editor's native completion. NeuralMind is the context layer, not
+the completion layer; the two coexist but they're solving
+different problems.
+
+You almost certainly *do* want NeuralMind if your monthly LLM
+spend has crossed the point where a few hours of setup pays back
+in days, if you run an AI coding agent against a real codebase
+(ten thousand lines or more), or if you've been frustrated that
+your agent does the same thing wrong over and over because it
+keeps "forgetting" your codebase between sessions.
+
+## The two competing pitches, side by side
+
+For people who care about cost: NeuralMind reduces per-query
+retrieval cost forty to seventy times, end-to-end cost three to
+ten times, measured on every commit in CI, reproducible in thirty
+seconds on a fresh clone. Pay-per-query at Claude 3.5 Sonnet rates
+drops from roughly fifteen cents to roughly two-tenths of a cent.
+A hundred queries a day, four hundred fifty a month becomes
+seven. Multiplied across a team, the math gets unmissable.
+
+For people who care about quality and trust: NeuralMind is an
+associative memory layer for your AI coding agent. It learns from
+how you and the agent actually use the codebase — co-activations
+reinforce edges, unused edges decay, spreading activation
+surfaces related code on every prompt. Version 0.6.0 makes that
+learning *visible*. The graph view pulses in real time as the
+brain works. When retrieval feels wrong, you can replay the last
+query on the canvas and see exactly which nodes the agent got. If
+you've ever wondered "is my AI tool actually using the right
+context," 0.6.0 is the first version where that's a two-second
+visual answer.
+
+The two pitches aren't in tension. They're the same product
+viewed through two lenses. The cost reduction is what justifies
+the install on a spreadsheet. The graph view is what makes the
+install land *emotionally* — what flips you from "I should try
+this" to "I want to show this to everyone on my team."
+
+## What to do next
+
+The install is `pip install neuralmind graphifyy`. The verification
+is `bash scripts/demo.sh` on a fresh clone. The graph view is
+`neuralmind serve` after `neuralmind build .`. The benchmark on
+your own code is `neuralmind benchmark . --contribute`, which
+also produces a paste-ready JSON blob you can submit to the public
+leaderboard if you want.
+
+If after thirty seconds the demo numbers don't look meaningful for
+your workflow, `pip uninstall neuralmind` and the cost is the
+five minutes. If they do, the next step is the actual install on
+your real repo and a week of using it. The graph view's job is to
+make sure that week is the most interesting week of agent usage
+you've had in months.
+
+That's the offer. It's open source, MIT licensed, runs entirely on
+your machine, no cloud, no telemetry, no signup. Try it or don't.
+We'll be over here, watching the canvas pulse.

--- a/docs/notebooklm/v0.6.0/README.md
+++ b/docs/notebooklm/v0.6.0/README.md
@@ -1,0 +1,93 @@
+# NotebookLM source pack — NeuralMind v0.6.0
+
+These three documents are designed to be loaded as sources in
+NotebookLM (or any similar tool — opennotebooklm, etc.) to
+generate a video, podcast, or audio overview about NeuralMind
+v0.6.0.
+
+## How to use
+
+1. Open NotebookLM (or your equivalent).
+2. Create a new notebook.
+3. Add the three files in this directory as sources, in order:
+   - `01-the-origin-story.md`
+   - `02-what-shipped.md`
+   - `03-the-numbers-and-the-honest-take.md`
+4. Generate a Video Overview (or Audio Overview / Podcast).
+5. Optional: feed it a prompt like "make this developer-focused
+   and honest about limitations" if you want to nudge the voice.
+
+## Why three docs, in this order
+
+The three sources are deliberately written in *different
+registers* so NotebookLM has multiple angles to weave from:
+
+| Doc | Register | What it provides |
+|---|---|---|
+| `01-the-origin-story.md` | First-person founder narrative | The conceptual arc — why retrieval, why a synapse layer, why a visible brain. Emotional beats and the "hippocampus you can watch learn" framing. |
+| `02-what-shipped.md` | Neutral third-person technical tour | Concrete feature-by-feature breakdown of every v0.6.0 change. Specs, behavior, env vars, compatibility notes. |
+| `03-the-numbers-and-the-honest-take.md` | Mixed developer-experience + skeptic's-view | A day-in-the-life walkthrough, the measurable claims with honest caveats, the "when to skip this" section. |
+
+Together they cover the *why*, the *what*, and the *should you*.
+Each is self-contained, plain prose (not bullet-heavy), and
+narratable as continuous text.
+
+## What this pack is *not*
+
+- **Not the release notes.** Those live at
+  [`/RELEASE_NOTES_v0.6.0.md`](../../../RELEASE_NOTES_v0.6.0.md)
+  and exist for humans skimming changelogs, not AI narration.
+- **Not the LinkedIn drafts.** Those live at
+  [`/docs/LINKEDIN-POST-DRAFT.md`](../../LINKEDIN-POST-DRAFT.md)
+  and are shorter, posty, with hashtags.
+- **Not the screencast script.** That lives at
+  [`/docs/SCREENCAST-v0.6.0.md`](../../SCREENCAST-v0.6.0.md) and
+  is a beat-by-beat narration script for a 60-second demo recorded
+  in person against a real terminal.
+
+These NotebookLM sources are the *long-form prose* pack
+specifically optimized for AI hosts to digest into conversational
+output.
+
+## Editing notes
+
+- Keep prose narratable. Don't add tables, dense code blocks, or
+  bullet lists past a sentence or two — they trip up generative
+  audio.
+- The three docs deliberately overlap a little (e.g. all three
+  mention the live activity feed). That redundancy gives NotebookLM
+  multiple phrasings to mix; don't dedupe.
+- If you change product positioning, update all three. The
+  registers are different but the *claims* must stay consistent.
+- New major release? Copy this directory to
+  `docs/notebooklm/v0.X.0/`, update the three docs, and you have a
+  fresh source pack.
+
+## Suggested prompts for NotebookLM
+
+After loading the sources, try one of these to steer the output:
+
+- **For a developer-honest video (default):**
+  > "Make a 5-minute video overview targeted at experienced
+  > developers. Honest about limitations. No marketing
+  > superlatives. Include the day-in-the-life walkthrough and at
+  > least one concrete number with the caveat about end-to-end
+  > versus retrieval-stage reduction."
+
+- **For a shorter cost-pitch video:**
+  > "3-minute video. Focus on the cost reduction angle. Lead
+  > with the bill-going-from-450-to-7 example. End on the
+  > graph-view debugging story."
+
+- **For a conceptual / "why" video:**
+  > "5-7 minute video. Story-driven. Lead with the founder origin,
+  > the hippocampus / cortex analogy, the moment the pitch flipped
+  > with v0.6.0. Light on feature specs, heavy on the conceptual
+  > leap."
+
+## Re-using outside NotebookLM
+
+These files are plain markdown and work as sources for any
+AI-driven content tool — Descript, Claude Artifacts, ChatGPT
+custom GPTs, etc. The structure (narrative-prose, mixed
+registers) is the part that matters; the tool is interchangeable.

--- a/docs/use-cases/README.md
+++ b/docs/use-cases/README.md
@@ -10,5 +10,6 @@ Walkthroughs for the most common "what do I actually do?" questions, organized b
 | [Any LLM (ChatGPT / Gemini / local)](./any-llm.md) | You use non-MCP chats or a model-agnostic workflow | Get NeuralMind context into any chat window |
 | [Offline / regulated work](./offline-regulated.md) | Regulated industries, air-gapped machines | 100% local retrieval with zero telemetry |
 | [Growing monorepo](./growing-monorepo.md) | Codebase where old context goes stale fast | Keep the index fresh with minimal effort |
+| [Multi-agent codebase](./multi-agent.md) | You use multiple AI tools (Claude Code + Cursor + Hermes + OpenClaw) on the same project | One shared associative memory across every agent; v0.6.0 live graph shows the union |
 
 Not sure which applies? Start with the [symptom / goal table in the main README](../../README.md#-when-do-i-reach-for-neuralmind).

--- a/docs/use-cases/any-llm.md
+++ b/docs/use-cases/any-llm.md
@@ -86,6 +86,24 @@ Paste, ask, done. Usually ~800–1,100 tokens instead of tens of thousands.
 - Fully local, no data leaves your machine
 - Works with any model — OpenAI, Google, Anthropic, Ollama, vLLM, anything
 
+## Graph view works with any LLM (v0.6.0+)
+
+The graph view (`neuralmind serve`) is agent-agnostic — it doesn't
+care which chat window you're piping context into. If you use
+ChatGPT, Gemini, or a local model:
+
+1. `neuralmind serve .` in a terminal.
+2. Browser shows the live graph.
+3. Run `neuralmind query . "..."` in a second terminal — its
+   nodes pulse on the canvas as the query executes, even though
+   ChatGPT itself never called NeuralMind directly.
+4. Pipe the CLI output into your chat window.
+
+The pulse-rings feed reflects every CLI call, every `neuralmind
+watch` daemon event, and every file edit — regardless of which
+LLM you ultimately send the context to. The trust-gap closure
+benefit (see [claude-code.md](./claude-code.md#second-screen-see-what-the-agent-is-looking-at-v060)) applies anywhere you're using NeuralMind retrieval.
+
 ## Pro tip: system prompt pattern
 
 Generate context once at the start of a long session:

--- a/docs/use-cases/claude-code.md
+++ b/docs/use-cases/claude-code.md
@@ -67,6 +67,39 @@ Tune hook thresholds via env vars — see [PostToolUse Compression](../../README
 
 Combined retrieval + consumption reduction is typically **5–10×** vs vanilla Claude Code on the same tasks. Run `neuralmind benchmark . --json` on your repo for a concrete number.
 
+## Second screen: see what the agent is looking at (v0.6.0+)
+
+Pop a separate terminal and run:
+
+```bash
+neuralmind serve .
+```
+
+Open the URL it prints. You now have an Obsidian-style graph view
+of your codebase that updates in real time as Claude works. Every
+time Claude calls `neuralmind_query` (or any other NeuralMind tool),
+the relevant nodes **pulse** on the canvas — animated radial rings,
+color-coded by event source. The sidebar shows a rolling log of
+the most recent ~80 events.
+
+The use this unlocks is **trust-gap closure**:
+
+| You wonder… | The graph view answers in ~2 seconds |
+|---|---|
+| Is Claude looking at the right code? | Watch which nodes pulse during the prompt |
+| Did the retrieval miss something obvious? | Use the replay-last-query overlay to see the L3 hits |
+| Why did this answer feel wrong? | Pulse pattern usually shows it — wrong cluster, missing edge, unexpected hub |
+| Has the synapse layer learned anything yet? | Hover the synapse edges; weight + activation count appear |
+
+Pin the nodes you want to keep in focus (the visible pin glyph
+shows pinned state at a glance), use the depth slider (1–3 hops)
+to see how far the agent's retrieval reached, and use Cmd/Ctrl-K
+or `/` to jump-to-search from anywhere.
+
+`NEURALMIND_EVENT_LOG=0` disables the cross-process bridge if you
+prefer the in-process feed only.
+
 ---
 
-[← Back to use-case index](./README.md) · [Main README](../../README.md)
+[← Back to use-case index](./README.md) · [Main README](../../README.md) ·
+[Multi-agent: share the brain across all your tools](./multi-agent.md)

--- a/docs/use-cases/cost-optimization.md
+++ b/docs/use-cases/cost-optimization.md
@@ -74,6 +74,30 @@ A one-page summary template:
 - **Adapt to workflow:** enable memory (TTY prompt) + periodically `neuralmind learn .` to rerank by actual query patterns.
 - **Model changes:** run `neuralmind benchmark` again when you switch models — absolute dollar savings scale with input price.
 
+## Debugging cost spikes with the graph view (v0.6.0+)
+
+If a query returns 5K tokens when you'd expect 800, you used to be
+debugging by reading log files. v0.6.0 makes it visual.
+
+1. `neuralmind serve .` in a separate terminal.
+2. Run the offending query.
+3. In the detail panel, click **Replay last query**.
+
+The graph view highlights the L3 hits the agent received. The
+diagnosis is usually obvious from the pulse pattern — a stale
+cluster boundary that grabbed too many nodes, a missing structural
+edge that forced the retriever wider, or an unexpected hub node
+pulling in unrelated context. Fix the underlying issue (rebuild the
+index, update `CLAUDE.md`, or tune the cluster boundary) and the
+next replay shows a tighter result.
+
+The pulse-rings live feed is also useful during normal use: if
+you notice the canvas going *quiet* during sessions you'd expect
+to be busy, that's a signal the agent isn't actually using
+NeuralMind retrieval (maybe the MCP server isn't wired up, or the
+hooks didn't install). A visual heartbeat is faster than checking
+a log.
+
 ## What this doesn't fix
 
 - **Output tokens** — NeuralMind reduces input context, not model output length. Pair with prompt instructions to keep responses concise.

--- a/docs/use-cases/growing-monorepo.md
+++ b/docs/use-cases/growing-monorepo.md
@@ -93,6 +93,38 @@ neuralmind learn .
 
 Future queries get a `+0.3` rerank boost on modules that historically cooccur with your team's queries. Over a few weeks, retrieval starts to anticipate what you mean.
 
+## Always-on activity tracking (v0.6.0+)
+
+For monorepos that get touched by multiple agents and multiple
+developers across the day, run a long-lived `neuralmind watch`
+daemon next to your normal workflow:
+
+```bash
+# Terminal 1: live graph in browser
+neuralmind serve .
+
+# Terminal 2: always-on synapse learning from file edits
+neuralmind watch . --quiet &
+```
+
+The v0.6.0 cross-process JSONL bridge means `serve` and `watch`
+share a live feed even though they're separate processes. Every
+file save anywhere in the monorepo coalesces into a co-activation
+event; the corresponding nodes pulse on the canvas; the synapse
+store reinforces.
+
+After a week of normal team use, the pulse pattern on the canvas
+visibly concentrates around the parts of the monorepo currently
+under active development. Stale subtrees fade. "Synapse density
+over the last week" becomes a real, observable property of the
+graph — useful for onboarding ("here's what we've actually been
+working on"), for refactor planning ("here's the hot path
+nobody's touched in a month"), and for retrieval-quality
+debugging ("this cluster is over-represented, let me dial it back").
+
+`NEURALMIND_EVENT_LOG=0` disables the bridge if you don't need it.
+
 ---
 
-[← Back to use-case index](./README.md) · [Main README](../../README.md)
+[← Back to use-case index](./README.md) · [Main README](../../README.md) ·
+[Multi-agent: shared brain across tools](./multi-agent.md)

--- a/docs/use-cases/multi-agent.md
+++ b/docs/use-cases/multi-agent.md
@@ -1,0 +1,193 @@
+# Use Case: Multi-Agent Codebase (shared memory across tools)
+
+## What you're solving for
+
+You don't use just one AI coding tool. You use Claude Code for the
+work you live in, Cursor when you want inline completions, OpenClaw
+or Hermes-Agent for one-off automations, maybe Claude Desktop for
+the chat-flavored questions. Each one is great at what it does.
+None of them learn from the others.
+
+You want a **shared memory layer** underneath all of them — a
+single place where co-activations, file edits, and tool calls
+reinforce the same brain, so the smarter your Claude Code session
+gets, the smarter your Hermes session gets, automatically.
+
+That's what NeuralMind v0.6.0 unlocks. It was *technically* true
+in v0.5.x — every agent talking to the project hit the same
+`synapses.db` — but you couldn't see it. v0.6.0 makes the union
+visible.
+
+## The shared substrate
+
+Every agent that uses NeuralMind talks to the same three pieces of
+local state:
+
+- `graphify-out/graph.json` — the call graph (created by graphify)
+- `graphify-out/neuralmind_db/` — the ChromaDB vector index
+- `<project>/.neuralmind/synapses.db` — the learned synapse graph
+
+There's no per-agent partition. When Claude Code calls
+`neuralmind_query`, the brain reinforces the co-activated nodes.
+When Hermes-Agent calls the *same tool* an hour later in a separate
+process, the brain *also* reinforces. They're talking to the same
+SQLite file.
+
+In v0.5.x, that was an implementation detail. In v0.6.0, it's a
+feature you can see.
+
+## Setup (one-time, per project)
+
+```bash
+pip install neuralmind graphifyy
+cd your-project
+graphify update .
+neuralmind build .
+```
+
+That's the shared substrate. Now wire up every agent you use:
+
+**Claude Code:**
+
+```bash
+neuralmind install-hooks .
+```
+
+Registers `PostToolUse` compression + `SessionStart` / `UserPromptSubmit` /
+`PreCompact` synapse hooks. Auto-active in every session.
+
+**Claude Desktop:** Edit `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "neuralmind": {
+      "command": "neuralmind-mcp",
+      "args": ["/absolute/path/to/project"]
+    }
+  }
+}
+```
+
+**Cursor / Cline / Continue:** Drop a `.mcp.json` at the project root:
+
+```json
+{ "mcpServers": { "neuralmind": { "command": "neuralmind-mcp", "args": ["."] } } }
+```
+
+**Hermes-Agent:**
+
+```bash
+hermes mcp add  # or edit ~/.hermes/config.yaml
+```
+
+**OpenClaw:**
+
+```bash
+openclaw mcp set neuralmind '{"command":"neuralmind-mcp","args":["/absolute/path/to/project"]}'
+```
+
+All five point at the same project. Same MCP tools (`neuralmind_wakeup`,
+`_query`, `_skeleton`, `_search`, ...). Same `.neuralmind/synapses.db`.
+
+## The new v0.6.0 superpower: see the union
+
+```bash
+neuralmind serve .
+```
+
+Opens `http://127.0.0.1:8765/?token=…` in your browser — a
+force-directed graph of the codebase with the learned synapse
+overlay. Pre-v0.6.0, that was a static snapshot.
+
+In v0.6.0, the canvas is **live**. Every time *any* agent — Claude,
+Cursor, Hermes, OpenClaw — calls a NeuralMind MCP tool, the relevant
+nodes pulse on the canvas in real time. The sidebar feed logs the
+event with a timestamp.
+
+The trick that makes this work across processes is the JSONL bridge
+([`event_log.py`](../../neuralmind/event_log.py), shipped in
+v0.6.0). Each `event_bus.publish()` call appends a line to
+`<project>/.neuralmind/events.jsonl`. The `serve` process tails that
+file and re-emits anything it didn't originate. Net result: one
+canvas, all agents, no IPC complexity.
+
+Opt out of the bridge with `NEURALMIND_EVENT_LOG=0` (you still get
+the in-process feed for the agent that's running `serve` itself).
+
+## A two-week walkthrough
+
+**Day 1.** Set up the substrate. Wire up Claude Code + Cursor +
+OpenClaw. Pop `neuralmind serve` in a browser tab.
+
+**Day 2.** You use Claude Code as usual. Every prompt that triggers
+a NeuralMind tool call pulses nodes on the canvas. You notice the
+auth cluster lighting up a lot.
+
+**Day 3.** Cursor finishes a refactor across five files. Save-on-edit
+fires file activity events; nodes pulse. The synapse edges between
+those five files strengthen.
+
+**Day 4.** You ask Hermes-Agent to run a one-off audit. It calls
+`neuralmind_query` against the same project. The auth cluster
+pulses — because that's where Hermes started looking too. The
+synapse store reinforces *those* co-activations.
+
+**Day 7.** You ask Claude Code "how does billing flow through the
+codebase?" Spreading activation now surfaces three files that
+didn't even semantically match — they came from the Cursor refactor
+and the Hermes audit a few days earlier. The agent's answer is
+visibly better because the brain has learned from all three tools.
+
+**Day 14.** The graph view's pulse density now visibly concentrates
+around the parts of the codebase you actually live in. Dead corners
+have decayed. Hub nodes are protected by LTP. You haven't done
+anything special. You just used your tools normally.
+
+That's the multi-agent story. NeuralMind is the shared associative
+memory; the live graph is how you watch it work; the JSONL bridge
+is what makes it work across processes.
+
+## What you should pin on the canvas
+
+The graph view supports persistent pins (drag a node, it stays).
+v0.6.0 adds a visible pin glyph + Pin/Unpin button + Unpin-all.
+
+Useful pins for a multi-agent workflow:
+
+- **Project entry point(s).** They anchor the layout.
+- **The "domain core"** — the few hub nodes everything else
+  depends on.
+- **Whatever the agent keeps getting wrong.** Pin it, ask the
+  agent again, watch the canvas to see whether it actually hits
+  the right node this time. If not, the replay-last-query overlay
+  shows you which nodes it *did* hit. Often the fix is updating
+  `CLAUDE.md` or rebuilding the index.
+
+## What it's *not*
+
+- **Not a database.** Synapse weights are derived state. If you
+  blow away `<project>/.neuralmind/`, the brain forgets — but the
+  next week of normal use rebuilds it. There's no migration cost.
+- **Not a cross-repo brain.** Each project has its own
+  `synapses.db`. NeuralMind is per-project local-first by design.
+- **Not a network protocol.** The JSONL bridge is single-machine.
+  Two developers on different machines have two independent
+  brains; sharing a brain across machines would require
+  `synapses.db` import/export (tracked for v0.7).
+- **Not a queue.** The bridge is best-effort. If you need
+  guaranteed delivery between agents, that's not what this is.
+
+## Related env vars
+
+| Variable | Default | Effect |
+|----------|---------|--------|
+| `NEURALMIND_EVENT_LOG` | `1` | `0` disables JSONL writer (in-process feed still works) |
+| `NEURALMIND_SYNAPSE_INJECT` | `1` | `0` disables spreading-activation context injection on `UserPromptSubmit` |
+| `NEURALMIND_SYNAPSE_EXPORT` | `1` | `0` disables session-start memory export |
+| `NEURALMIND_BYPASS` | unset | `1` disables PostToolUse compression for one command |
+
+---
+
+[← Back to use-case index](./README.md) · [Main README](../../README.md) ·
+[Architecture: synapse layer + event bus](../../docs/wiki/Architecture.md#synapse-layer-v04)

--- a/docs/wiki/Architecture.md
+++ b/docs/wiki/Architecture.md
@@ -720,6 +720,133 @@ layer also sees as activation seeds.
 
 ---
 
+## Event Bus and JSONL Bridge (v0.6)
+
+v0.6.0 added a third structural piece: an **event bus** that turns
+"the brain is learning" from a claim into a visible, real-time
+signal. The bus and its cross-process counterpart (the JSONL
+bridge) are how `neuralmind serve` knows when to pulse a node on
+the canvas.
+
+### Why an event bus
+
+Pre-v0.6.0, the synapse store reinforced on every co-activation but
+the experience was invisible. You had to refresh the graph view to
+see a state change. We wanted the canvas to feel like a heartbeat
+monitor — pulse the instant a node lights up — so we needed a
+push-based notification path from the model layer to the UI.
+
+We considered three options:
+
+| Option | Verdict |
+|---|---|
+| Polling — UI re-reads `synapses.db` every N ms | Wasteful; introduces lag proportional to N |
+| WebSocket | More than we need; adds a real dependency surface |
+| **In-process event bus + SSE** | Stdlib-only, push-based, O(1) when nobody's listening |
+
+We picked the third option. `event_bus.py` is a tiny pub/sub
+singleton accessed via `get_event_bus()`. `SynapseStore.reinforce()`
+publishes a `synapse` event after every pair-touching call;
+`FileActivityWatcher` publishes a `file_activity` event after every
+coalesced batch. `serve`'s `/api/events` endpoint subscribes and
+forwards to the browser as a long-lived Server-Sent Events stream.
+
+### Two-brain diagram, refreshed
+
+```
+                       ┌──────────────────────────────┐
+                       │  Browser canvas              │
+                       │  • pulse rings               │
+                       │  • sidebar event log         │
+                       └─────────────▲────────────────┘
+                                     │ SSE: /api/events
+                       ┌─────────────┴────────────────┐
+                       │  EventBus (event_bus.py)     │
+                       │  • publish() is O(1) when    │
+                       │    no subscribers + no       │
+                       │    JSONL writer configured   │
+                       └─────▲──────────────────▲─────┘
+                             │                  │ tail
+        ┌────────────────────┼─────┐  ┌─────────┴───────────┐
+        │                          │  │ events.jsonl bridge │
+┌───────┴─────────┐  ┌─────────────┴┐ │ (event_log.py)      │
+│ SynapseStore    │  │ FileActivity │ │ ─ writer: appends   │
+│ .reinforce()    │  │ Watcher      │ │   on publish        │
+│ publishes       │  │ publishes    │ │ ─ tailer: re-emits  │
+│ "synapse" event │  │ "file_       │ │   foreign events    │
+└─────────────────┘  │  activity"   │ └─────────────────────┘
+                     │  events      │
+                     └──────────────┘
+```
+
+### Why the JSONL bridge
+
+The in-process bus is great when `serve` and the activity source
+share a Python process. The common real-world case is *not* that:
+you run `neuralmind serve` in one terminal, `neuralmind watch` in
+another, and a Claude Code session in a third — three processes,
+three sources of brain activity, one canvas you'd like to show all
+of them.
+
+`event_log.py` is the deliberately boring side channel that makes
+this work:
+
+- Every `event_bus.publish()` call appends one JSON line to
+  `<project>/.neuralmind/events.jsonl`.
+- The `serve` process tails that file in a background thread, drops
+  events it originated itself (deduped by event id), and republishes
+  the rest into its local bus.
+- `NEURALMIND_EVENT_LOG=0` disables the writer for opt-out. The
+  in-process bus is unaffected.
+
+The design choice worth stating: the JSONL is a **fallback, not a
+queue**. The bus is the primary path; the file is best-effort and
+reconstructs itself if it disappears or rolls. We deliberately did
+not build a real IPC mechanism — sockets, gRPC, named pipes —
+because the cost/benefit didn't justify it. JSONL is observable
+with `tail -f` and survives process restarts. Good enough.
+
+### What this unlocks: the multi-agent shared brain
+
+Pre-v0.6.0, every agent talking to a project reinforced the same
+`synapses.db` but you couldn't see it. The synapse store was
+shared; the *experience* wasn't. Three tools talking to a black
+box.
+
+In v0.6.0, the JSONL bridge makes the union visible. Claude Code,
+Cursor, OpenClaw, and Hermes-Agent all publish to
+`events.jsonl`; `neuralmind serve` aggregates them into one canvas.
+Every tool call from any agent pulses the corresponding nodes. The
+brain isn't just learning your codebase; it's learning across every
+tool you use, and you can finally see the union.
+
+See [`docs/use-cases/multi-agent.md`](../../docs/use-cases/multi-agent.md)
+for the day-by-day walkthrough.
+
+### Files
+
+- [`neuralmind/event_bus.py`](../../neuralmind/event_bus.py) —
+  pub/sub singleton, `get_event_bus()` accessor, `Event` dataclass.
+  No external deps.
+- [`neuralmind/event_log.py`](../../neuralmind/event_log.py) —
+  JSONL writer + tailer for the cross-process bridge. No external
+  deps.
+- `tests/test_event_bus.py`, `tests/test_event_log.py` — stdlib-only
+  tests; they lock in that `reinforce()` and the watcher publish
+  the right events, and that the tailer dedupes correctly.
+
+### Performance footprint
+
+- `event_bus.publish()` is O(1) when there are **no** subscribers
+  AND **no** writer configured — emit-points cost nothing on
+  headless servers or CLI-only runs.
+- With the writer enabled, each publish is one `fcntl`-locked
+  `write()` on the JSONL file. Measured overhead on a 2026 dev
+  laptop: ~50 µs/event.
+- The tailer is one background thread per `serve` process.
+
+---
+
 ## See Also
 
 - [API Reference](API-Reference.md) - Python API documentation

--- a/docs/wiki/CLI-Reference.md
+++ b/docs/wiki/CLI-Reference.md
@@ -17,6 +17,8 @@ Complete command-line interface documentation for NeuralMind.
   - [skeleton](#skeleton)
   - [install-hooks](#install-hooks)
   - [init-hook](#init-hook)
+  - [watch](#watch-v040)
+  - [serve](#serve-v054-live-feed-v060)
 - [Exit Codes](#exit-codes)
 - [Environment Variables](#environment-variables)
 - [Examples](#examples)
@@ -632,14 +634,13 @@ neuralmind watch . --decay-interval 0
 
 ---
 
-### serve *(v0.5.4+)*
+### serve *(v0.5.4; live feed v0.6.0+)*
 
 Start the graph-view UI — a local, dependency-free, Obsidian-style
 force-directed graph over the same index and synapse store your AI
-agent queries. Renders code nodes coloured by community, structural
-edges and Hebbian synapses drawn together, plus backlinks, synaptic
-neighbours, a semantic quick-switcher, and one-click open-in-editor.
-Stops cleanly on Ctrl-C.
+agent queries. v0.6.0 made the canvas live: synapse + file events
+stream to the browser over SSE, affected nodes pulse, a sidebar log
+shows recent events. Stops cleanly on Ctrl-C.
 
 The server binds to 127.0.0.1 by default and prints a per-session
 auth-token URL on startup; pass that URL to the browser so untrusted
@@ -680,6 +681,37 @@ neuralmind serve . --port 9000 --no-browser
 neuralmind serve . --no-auth
 ```
 
+#### Live activity feed (v0.6.0+)
+
+The canvas updates in real time as the brain works:
+
+- **Synapse events** — every `SynapseStore.reinforce()` call publishes
+  a `synapse` event over the in-process event bus; the affected pair
+  of nodes pulse on the canvas.
+- **File activity events** — every coalesced edit batch from the
+  `neuralmind watch` daemon (or from Claude Code's `PostToolUse`
+  hooks) publishes a `file_activity` event; affected nodes pulse.
+- **Sidebar log** — the most recent ~80 events render as a scrolling
+  feed with timestamps. Click an entry to focus the corresponding
+  node on the canvas.
+
+#### Cross-process activity bridge (v0.6.0+)
+
+When `serve` and the activity source live in different processes —
+a separate `neuralmind watch` daemon, a Claude Code session — each
+`event_bus.publish()` call also appends a JSON line to
+`<project>/.neuralmind/events.jsonl`. The `serve` process tails that
+file in a background thread and re-emits anything it didn't
+originate. Net result: one canvas, all processes, no IPC complexity.
+
+Behaviour:
+
+- `NEURALMIND_EVENT_LOG=0` disables the writer (in-process feed
+  still works).
+- The tailer is best-effort. If the file disappears or rolls, the
+  next event re-creates it.
+- The bus stays the primary path. The JSONL is a fallback, not a queue.
+
 #### Notes
 
 - Read-only over HTTP. Edits to nodes/synapses still go through the
@@ -687,6 +719,10 @@ neuralmind serve . --no-auth
 - The `/api/open` endpoint launches `$EDITOR` against an allowlist
   pre-computed from the graph's `source_file` set, so a tampered
   client can't trick the server into opening arbitrary paths.
+- All assets in `neuralmind/web/` (HTML, JS, CSS) are read-only at
+  runtime; the server doesn't generate any of them.
+- Graph payload is cached per-session in `_Handler._graph_cache`; any
+  endpoint touching graph state respects `_graph_lock`.
 - Vanilla-JS frontend, stdlib-only HTTP server, no CDN. Safe to run
   behind a firewall.
 
@@ -714,6 +750,7 @@ neuralmind serve . --no-auth
 | `NEURALMIND_BYPASS` | unset | Set to `1` to bypass PostToolUse hook compression temporarily |
 | `NEURALMIND_SYNAPSE_INJECT` | `1` | *(v0.4.0+)* Set to `0` to disable spreading-activation context injection in the `UserPromptSubmit` hook |
 | `NEURALMIND_SYNAPSE_EXPORT` | `1` | *(v0.4.0+)* Set to `0` to disable session-start synapse memory export |
+| `NEURALMIND_EVENT_LOG` | `1` | *(v0.6.0+)* Set to `0` to disable the cross-process JSONL event-bridge writer at `<project>/.neuralmind/events.jsonl`. The in-process event bus is unaffected; `serve` running in the same process as the activity source still gets a live feed. |
 
 ---
 

--- a/docs/wiki/FAQ.md
+++ b/docs/wiki/FAQ.md
@@ -313,6 +313,77 @@ pip install "neuralmind[dev]"
 
 ---
 
+### "Why does my `serve` canvas stay quiet when I edit files?" *(v0.6.0+)*
+
+You ran `neuralmind serve`, opened the graph view, edited a file in
+your editor — and no node pulsed. The live feed (v0.6.0) depends on
+two paths working: the in-process event bus, and the cross-process
+JSONL bridge. When the canvas is silent, one of these is the
+culprit. Check in this order:
+
+1. **`.neuralmind/` directory exists in the project root.** The
+   JSONL bridge writes to `<project>/.neuralmind/events.jsonl`,
+   which the watcher and `serve` both need to find. If the directory
+   doesn't exist (fresh clone, or you blew it away):
+
+   ```bash
+   neuralmind build .   # creates .neuralmind/ alongside graphify-out/
+   ```
+
+2. **`NEURALMIND_EVENT_LOG` is not set to `0`.** This env var
+   disables the JSONL writer. If it's set in your shell config or
+   the parent process of either `serve` or `watch`, the in-process
+   feed still works for the *same* process but cross-process events
+   never reach the canvas.
+
+   ```bash
+   env | grep NEURALMIND_EVENT_LOG   # should be empty or =1
+   unset NEURALMIND_EVENT_LOG        # clear it if set
+   ```
+
+3. **Both processes target the same project root.** A common gotcha:
+   `neuralmind serve` was started from `~/projects/foo` and
+   `neuralmind watch` from `~/projects/foo/src/`. They write to
+   *different* `.neuralmind/events.jsonl` files and never see each
+   other. Run both from the project root, or pass an explicit
+   `project_path`:
+
+   ```bash
+   neuralmind serve /abs/path/to/project &
+   neuralmind watch /abs/path/to/project &
+   ```
+
+4. **The file watcher is actually running.** If you're relying on
+   Claude Code's `PostToolUse` hooks for file events, those only
+   fire on tool calls — they won't see your manual editor saves.
+   For editor-driven pulses, start `neuralmind watch` separately:
+
+   ```bash
+   neuralmind watch . --quiet &
+   ```
+
+5. **The browser tab actually has the SSE stream open.** Open the
+   browser devtools network tab and look for a long-lived request
+   to `/api/events`. If it's missing or 404, refresh the page; if it
+   401s, your token expired (re-open the URL `serve` printed).
+
+6. **The synapse store is being reinforced.** If no agent is
+   calling `neuralmind_query` or any other NeuralMind MCP tool, the
+   synapse store has nothing to publish — the canvas pulses only
+   when something actually happens. Trigger one manually:
+
+   ```bash
+   neuralmind query . "test query"
+   ```
+
+   You should see a pulse within ~1s.
+
+If the canvas still stays quiet after all six, that's a bug — open
+an issue with the output of `neuralmind stats .` and a
+description of what you tried.
+
+---
+
 ### "MCP server won't start"
 
 ```bash

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -6,33 +6,52 @@ Welcome — this wiki is the in-depth reference. For the fastest orientation, us
 
 ## What's New
 
-**v0.5.4 — Graph view (`neuralmind serve`).** A local,
-dependency-free, Obsidian-style force-directed graph over the same
-index your agent queries. Code nodes coloured by community;
-structural edges and Hebbian synapses drawn together; backlinks,
-synaptic neighbours, semantic quick-switch, and one-click
-open-in-editor. Per-session access token bound to 127.0.0.1 by
-default. Builds on v0.5.0's bundled MCP server and v0.4.0's
-brain-like synapse layer — no migration needed.
+### v0.6.0 — Graph view + live activity feed
 
-**Coming next.** A Phase B sequence of small graph-view UX wins —
-[replay-last-query overlay (#105)](https://github.com/dfrostar/neuralmind/pull/105),
-[edge tooltips + min-weight synapse slider (#106)](https://github.com/dfrostar/neuralmind/pull/106),
-pin UX, and a `Cmd/Ctrl-K` quick-switch shortcut — followed by
-Phase C: a live activity feed of synapse co-activations so you can
-watch the brain learning in real time. Full plan in the
-[ROADMAP](../blob/main/ROADMAP.md).
+`neuralmind serve` now streams synapse + file events to the canvas in
+real time over SSE. Affected nodes pulse as the brain works; a
+sidebar log keeps the most recent ~80 events. A cross-process JSONL
+bridge means a separate `neuralmind watch` daemon, a Claude Code
+session, or any other process feeds the same live feed via
+`<project>/.neuralmind/events.jsonl`. Pin UX (visible glyph,
+Pin/Unpin button, Unpin-all), Cmd/Ctrl-K quick-switch, a 1–3-hop
+depth slider, replay-last-query overlay, edge tooltips, and a
+min-weight synapse slider round out the release.
 
-**v0.4.0 — Brain-like synapse layer.** NeuralMind runs as a second
-brain alongside the LLM: a persistent SQLite-backed weighted graph
-that learns associations between code nodes from co-activation,
-decays unused edges, and answers via spreading activation. Includes
-the `neuralmind watch` daemon, three Claude Code lifecycle hooks
-(SessionStart, UserPromptSubmit, PreCompact), and a memory exporter
-that surfaces learned associations to Claude Code's auto-memory
-system. See the [release notes](../blob/main/RELEASE_NOTES_v0.4.0.md)
-or the [Architecture](Architecture#synapse-layer-v04) and
-[Learning Guide](Learning-Guide#v04-synapse-layer) sections.
+The pitch flipped: v0.5.4 made the brain inspectable; v0.6.0 makes
+it legible. You can sit there and **watch the hippocampus learn
+your codebase, live**.
+
+Multi-tool unlock: every agent (Claude Code, Cursor, OpenClaw,
+Hermes-Agent) talking to the same project reinforces the same
+synapse store, and the v0.6.0 canvas now shows the **union** of
+their activity. See [docs/use-cases/multi-agent.md](../blob/main/docs/use-cases/multi-agent.md).
+
+Full details: [v0.6.0 release notes](../blob/main/RELEASE_NOTES_v0.6.0.md) ·
+[Architecture: event bus + JSONL bridge](Architecture#event-bus-and-jsonl-bridge-v06) ·
+[CLI Reference: `neuralmind serve`](CLI-Reference#serve)
+
+### v0.5.4 — Graph view foundation
+
+The Obsidian-style force-directed graph that v0.6.0 made live first
+shipped in v0.5.4. Code nodes coloured by community; structural edges
+and Hebbian synapses drawn together; backlinks, synaptic neighbours,
+semantic quick-switch, and one-click open-in-editor. Per-session
+access token bound to 127.0.0.1 by default. Builds on v0.5.0's
+bundled MCP server.
+
+### v0.4.0 — Brain-like synapse layer
+
+NeuralMind runs as a second brain alongside the LLM: a persistent
+SQLite-backed weighted graph that learns associations between code
+nodes from co-activation, decays unused edges, and answers via
+spreading activation. Includes the `neuralmind watch` daemon, three
+Claude Code lifecycle hooks (SessionStart, UserPromptSubmit,
+PreCompact), and a memory exporter that surfaces learned
+associations to Claude Code's auto-memory system. See the
+[release notes](../blob/main/RELEASE_NOTES_v0.4.0.md) or the
+[Architecture](Architecture#synapse-layer-v04) and [Learning Guide](Learning-Guide#v04-synapse-layer)
+sections.
 
 ## Quick Links
 

--- a/docs/wiki/Integration-Guide.md
+++ b/docs/wiki/Integration-Guide.md
@@ -4,6 +4,7 @@ Guide to integrating NeuralMind with MCP tools, graphify, and other development 
 
 ## Table of Contents
 
+- [How Agents Share Memory (v0.6.0+)](#how-agents-share-memory-v060)
 - [Graphify Integration](#graphify-integration)
 - [MCP Integration](#mcp-integration)
   - [Claude Desktop](#claude-desktop)
@@ -12,6 +13,78 @@ Guide to integrating NeuralMind with MCP tools, graphify, and other development 
 - [CI/CD Integration](#cicd-integration)
 - [IDE Integration](#ide-integration)
 - [Scripting Integration](#scripting-integration)
+
+---
+
+## How Agents Share Memory (v0.6.0+)
+
+NeuralMind is the **shared associative memory layer** underneath
+whatever AI coding tools you use. If you run Claude Code for the
+day-to-day, Cursor for inline completions, OpenClaw for one-offs,
+and Hermes-Agent for planning — they all reinforce the same brain,
+and v0.6.0 makes the union of their activity visible.
+
+### The shared substrate
+
+Three pieces of local state belong to the project, not to any one
+agent:
+
+| Path | What it is | Who reads/writes |
+|------|------------|------------------|
+| `graphify-out/graph.json` | Call graph (created by `graphify`) | Read-only at NeuralMind runtime |
+| `graphify-out/neuralmind_db/` | ChromaDB vector index | `neuralmind build` writes; agents read |
+| `<project>/.neuralmind/synapses.db` | Learned synapse weights | Every MCP tool call, every `watch` event, every Claude Code hook |
+| `<project>/.neuralmind/events.jsonl` *(v0.6.0+)* | Cross-process activity stream | Every `event_bus.publish()` writes; `serve` tails |
+
+There's no per-agent partition. Claude Code's `neuralmind_query`
+and Hermes-Agent's `neuralmind_query` reinforce the exact same
+synapse edges. The brain is one brain.
+
+### Verifying the shared-brain setup
+
+```bash
+# In each agent's host (Claude Desktop, Hermes, OpenClaw, etc.),
+# the MCP server is registered with the SAME args:
+
+neuralmind-mcp /absolute/path/to/project
+
+# Verify the agent connected:
+hermes mcp test neuralmind          # if using Hermes
+openclaw mcp show neuralmind        # if using OpenClaw
+
+# Verify the synapse store is at the expected path:
+neuralmind stats .
+
+# Pop the live canvas:
+neuralmind serve .
+```
+
+Then trigger a tool call from each agent. The corresponding nodes
+should pulse on the v0.6.0 canvas regardless of which agent
+originated the call. If only some agents pulse, check that they're
+pointing at the same project root (most common bug: relative paths
+that resolve differently in different processes — always use
+absolute paths in MCP host configs).
+
+### Why this didn't work pre-v0.6.0
+
+The synapse store was already shared, but the *experience* wasn't.
+Each agent talked to the same SQLite file but you had no way to see
+the union of their activity — three tools talking to a black box.
+The v0.6.0 JSONL bridge ([`event_log.py`](../../neuralmind/event_log.py))
+solved this by routing every `event_bus.publish()` through a
+shared file that `serve` can tail. Same SQLite, plus a visible
+heartbeat.
+
+See [docs/use-cases/multi-agent.md](../../docs/use-cases/multi-agent.md)
+for a two-week walkthrough.
+
+### Opt-out
+
+`NEURALMIND_EVENT_LOG=0` disables the JSONL writer in the process
+where it's set. The in-process bus is unaffected — `serve` still
+pulses for its own activity, just not for activity from other
+processes.
 
 ---
 

--- a/docs/wiki/Usage-Guide.md
+++ b/docs/wiki/Usage-Guide.md
@@ -263,7 +263,69 @@ jobs:
 
 ---
 
-### Use Case 6: IDE Integration (MCP Server)
+### Use Case 6: Watch the brain learn (v0.6.0+)
+
+**When**: You want a "second screen" for your AI coding session — a
+live view of which parts of your codebase the agent is using, in
+real time, as it works.
+
+**How**:
+
+```bash
+# Terminal A — your normal Claude Code (or Cursor, OpenClaw, etc.) session
+claude-code   # work as usual
+
+# Terminal B — the live graph view
+neuralmind serve .
+
+# Terminal C — always-on synapse learning from file edits
+neuralmind watch . --quiet &
+```
+
+Open the URL `neuralmind serve` prints in your browser. The graph
+view is now alive:
+
+- **Every time your agent calls `neuralmind_query`** (or any other
+  NeuralMind MCP tool), the affected nodes pulse on the canvas with
+  short animated radial rings.
+- **Every time you save a file in your editor**, the corresponding
+  node pulses (because the `watch` daemon coalesces edits into
+  co-activation events).
+- **The sidebar log** shows the most recent ~80 events with
+  timestamps. Click an entry to focus the corresponding node.
+
+**The three-terminal walkthrough:**
+
+1. Open Claude Code (terminal A) and ask "how does authentication
+   work in this codebase?"
+2. Switch to terminal B's browser tab — the auth-cluster nodes are
+   pulsing as the agent calls `neuralmind_query`.
+3. In your editor, open `src/auth/handlers.py`, add a comment, save.
+4. Switch back to the browser — the corresponding node pulses
+   within ~1s.
+5. The synapse store has now reinforced the edges between auth
+   handlers and whatever else the agent looked at. Next session,
+   asking about auth will surface this file faster.
+
+**Benefit**: trust-gap closure. "Is the agent looking at the right
+code?" becomes a 2-second visual answer. When retrieval feels
+wrong, the **Replay last query** action in the detail panel
+re-highlights the L3 hits the agent actually received — usually the
+diagnosis is obvious from the pulse pattern.
+
+**Multi-agent unlock**: the v0.6.0 cross-process JSONL bridge
+(`<project>/.neuralmind/events.jsonl`) means *every* agent talking
+to the same project (Claude Code, Cursor, OpenClaw, Hermes-Agent)
+feeds the same canvas. See
+[multi-agent use-case page](../blob/main/docs/use-cases/multi-agent.md).
+
+**Opt out**: set `NEURALMIND_EVENT_LOG=0` to disable the JSONL
+writer (you still get the in-process feed for the agent running
+`serve` itself).
+
+---
+
+### Use Case 7: IDE Integration (MCP Server)
 
 **When**: Direct AI integration in Claude Desktop or Cursor
 


### PR DESCRIPTION
## Summary

Post-#107 docs polish for the v0.6.0 release. Covers steps 2–7 of the v0.6.0 handoff doc plus a NotebookLM source pack for video generation. **No code changes** — all Python tests and lint unaffected.

## What ships

**Release framing**
- `RELEASE_NOTES_v0.6.0.md` (new) — drafted around the live-feed pitch flip ("see the brain learning your codebase, live")
- `README.md` hero callout under the existing 40–70× headline
- `docs/about.html` "What's new in v0.6.0" section + status block updated to v0.6.0
- `docs/index.html` v0.6.0 hero callout + about-page link

**Roadmap**
- `ROADMAP.md`: "Shipped in v0.6.0" + "Now (v0.7)" + "Earlier wins" sections (extends #107's positioning)

**Wiki refresh** (auto-mirrors via `sync-wiki.yml`)
- `Home.md`: "Graph view + live activity (v0.6.0)" section
- `CLI-Reference.md`: extends #107's `serve` section with v0.6.0 live-feed + JSONL bridge subsections; `NEURALMIND_EVENT_LOG` env var
- `Architecture.md`: new "Event Bus and JSONL Bridge (v0.6)" section with refreshed two-brain diagram, cross-link to `event_bus.py` and `event_log.py`, performance footprint
- `Usage-Guide.md`: "Watch the brain learn" three-terminal walkthrough as Use Case 6
- `FAQ.md`: six-step "Why does my serve canvas stay quiet?" diagnostic
- `Integration-Guide.md`: "How Agents Share Memory" section at the top

**Use-case docs**
- NEW `docs/use-cases/multi-agent.md` — the v0.6.0-unlocked shared-brain story (Claude Code + Cursor + Hermes + OpenClaw all reinforcing the same canvas)
- `claude-code.md`: "Second screen" trust-gap-closure section
- `cost-optimization.md`: graph-view debugging for cost spikes
- `any-llm.md`: graph view is agent-agnostic
- `growing-monorepo.md`: always-on watch + serve pattern
- `use-cases/README.md`: multi-agent table entry

**Benefits comms** (drafted, not published — gated on maintainer approval)
- `docs/LINKEDIN-POST-DRAFT.md` v0.6.0 launch drafts A/B/C ("we built the hippocampus, you can watch it learn")
- NEW `docs/SCREENCAST-v0.6.0.md` 60-second three-beat script (number / graph / pulse)

**NotebookLM source pack** (per separate user request)
- `docs/notebooklm/v0.6.0/{README,01-the-origin-story,02-what-shipped,03-the-numbers-and-the-honest-take}.md` — 3 lean source docs in mixed registers, designed to load into NotebookLM for video/podcast generation

**README integration mentions**
- §Hermes-Agent + §OpenClaw blocks gain a v0.6.0 line: `neuralmind serve` pulses for tool calls from any agent against the project; the synapse store is shared
- Docs table: multi-agent use-case + v0.6.0 release-notes links

## Test plan

- [x] No Python code touched; CI matrix should pass identically to baseline
- [x] All cross-links verified to point at existing files / valid v0.6.0 URLs
- [x] Rebased on `main` post-#107 merge; conflicts resolved on ROADMAP.md, about.html, wiki/Home.md, wiki/CLI-Reference.md (`serve` section folds #107's accurate flag list + security notes with the v0.6.0 live-feed extension)
- [ ] Visual check on rendered GitHub Pages once this merges
- [ ] Wiki sync workflow runs on merge and the public Wiki updates

## Out of scope (intentionally)

- The screencast itself isn't recorded — script is ready; recording is a maintainer-run step (chromadb model download blocks CI)
- Hero GIF/screenshot — references include placeholder + asciinema TODO; swap-in is a one-line change once the recording exists
- Maintainer-only GitHub-side items #107 flagged (repo About-box rewrite, repo topics, `pyproject.toml` keywords post-v0.6.0)

https://claude.ai/code/session_01LuGFoY2vuB3az7sVCNwG6V

---
_Generated by [Claude Code](https://claude.ai/code/session_01LuGFoY2vuB3az7sVCNwG6V)_