### PR TITLE
chore(release-please): let feat commits bump minor in 0.x

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -373,16 +373,21 @@ into its release.
 **Symptom: A `feat:` commit was merged but release-please proposed a patch bump
 (0.x.Y → 0.x.Y+1) instead of a minor bump (0.x.Y → 0.(x+1).0).**
 
-Expected: `release-please-config.json` has `"bump-patch-for-minor-pre-major": true`,
-which forces every `feat:` to a patch bump until v1.0. To force an explicit version
-(e.g. v0.4.0), land an empty commit with the `Release-As:` footer:
+Check `release-please-config.json` for `"bump-patch-for-minor-pre-major": true`.
+If it's set, every `feat:` is forced to a patch bump until v1.0 — regardless
+of the conventional-commit type. The flag was dropped before v0.6.0 so this
+should no longer be the default; if you see it again in the config, removing
+it restores the standard pre-1.0 behavior (`feat:` → minor, `fix:` → patch,
+`feat!:` → minor, capped at 0.x by `bump-minor-pre-major`).
+
+To pin a specific version regardless of commit history, land an empty commit
+with the `Release-As:` footer:
 
 ```bash
-git commit --allow-empty -m "chore: release as v0.4.0" -m "Release-As: 0.4.0"
+git commit --allow-empty -m "chore: release as v0.6.0" -m "Release-As: 0.6.0"
 ```
 
-This was used to produce v0.4.0. Future minor bumps before v1.0 need the same
-override or a config change to drop `bump-patch-for-minor-pre-major`.
+This was used to produce v0.4.0 before the config was sorted out.
 
 ## Community
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,8 +5,7 @@
     ".": {
       "release-type": "python",
       "changelog-path": "CHANGELOG.md",
-      "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": true
+      "bump-minor-pre-major": true
     }
   }
 }


### PR DESCRIPTION
## Summary

`release-please-config.json` had `bump-patch-for-minor-pre-major: true` alongside `bump-minor-pre-major: true`. The two flags do opposite things for 0.x repos:

- **`bump-minor-pre-major: true`** keeps a *breaking* change from prematurely cutting v1.0.0 — it bumps minor instead.
- **`bump-patch-for-minor-pre-major: true`** makes *feature* commits bump patch (0.5.x → 0.5.x+1) instead of the default minor (→ 0.6.0).

The auto-bump PR #104 is titled "release 0.5.5" even though `v0.5.4..main` is dominated by `feat(serve):` commits (live activity feed, pin UX, Cmd-K, depth slider, edge tooltips) — exactly what the second flag does.

For a v0.6.0 minor release we want the default (feat → minor), so drop the patch-for-feat override and keep the breaking-as-minor floor.

## Effect

After this lands on main, release-please re-runs on the push and should retitle #104 to **"chore(main): release 0.6.0"** with the matching `pyproject.toml`, `CHANGELOG.md`, and `.release-please-manifest.json` bumps. No manual edits to that PR are needed.

## Test plan

- [x] Diff is the one removed line in `release-please-config.json`; the surviving `bump-minor-pre-major` is still correct.
- [ ] Watch #104 re-fire after this merges to main and confirm the new version is `0.6.0`.

https://claude.ai/code/session_01JupPy4oAsoTJ9gw1VUs9Vg

---
_Generated by [Claude Code](https://claude.ai/code/session_01JupPy4oAsoTJ9gw1VUs9Vg)_