### PR TITLE
docs(release): rename v0.6.1 → v0.7.0 to match release-please

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 > NeuralMind turns a code repository into a queryable neural index. AI agents use it to answer code questions in ~800 tokens instead of loading 50,000+ tokens of raw source.
 
-> **🆕 New in v0.6.1** — **Install anywhere.** Five install paths now in the README: `pip`, `pipx`, `uv`, Docker, and source. Same package every path; smoke-test verified. [Release notes](RELEASE_NOTES_v0.6.1.md) · [Install matrix ↓](#install--pick-your-path)
+> **🆕 New in v0.7.0** — **Install anywhere.** Five install paths now in the README: `pip`, `pipx`, `uv`, Docker, and source. Same package every path; smoke-test verified. [Release notes](RELEASE_NOTES_v0.7.0.md) · [Install matrix ↓](#install--pick-your-path)
 >
 > **v0.6.0** — Obsidian-style graph view with a **live activity feed**. `neuralmind serve` streams synapse + file events to the canvas in real time, so you can *watch the brain learning your codebase*. [Release notes](RELEASE_NOTES_v0.6.0.md) · [Graph view section ↓](#-graph-view-neuralmind-serve)
 
@@ -1615,7 +1615,7 @@ Only if you install the git post-commit hook with `neuralmind init-hook .`. Othe
 | **[Future-Proofing Plan](docs/FUTURE-PROOFING-PLAN.md)** | 8-initiative engineering plan for sustainability and scale |
 | **[Brain-like Learning](docs/brain_like_learning.md)** | Design rationale for the learning system |
 | **[Use Cases](docs/use-cases/README.md)** | Step-by-step walkthroughs: Claude Code, cost optimization, any-LLM, offline/regulated, growing monorepo, multi-agent (new in v0.6.0) |
-| **[Release Notes v0.6.1](RELEASE_NOTES_v0.6.1.md)** | Install anywhere — `pip` / `pipx` / `uv` / Docker / source, Dockerfile, event-log rotation fix |
+| **[Release Notes v0.7.0](RELEASE_NOTES_v0.7.0.md)** | Install anywhere — `pip` / `pipx` / `uv` / Docker / source, Dockerfile, event-log rotation fix |
 | **[Release Notes v0.6.0](RELEASE_NOTES_v0.6.0.md)** | Live activity feed, cross-process JSONL bridge, pin UX, depth slider, replay overlay |
 | **[Comparisons](docs/comparisons/README.md)** | NeuralMind vs. Cursor, Copilot, Cody, Aider, Claude Projects, LangChain, long context, prompt caching, RAG, tree-sitter |
 | **[USAGE.md](USAGE.md)** | Extended usage examples |

--- a/RELEASE_NOTES_v0.6.0.md
+++ b/RELEASE_NOTES_v0.6.0.md
@@ -151,9 +151,14 @@ Open `neuralmind serve` and the live feed is on by default.
   unchanged.
 - **Python**: 3.10, 3.11, 3.12 all pass CI.
 
-## What's next (v0.7 candidates)
+## What's next (graph-view follow-ups)
 
-Tracked in [`ROADMAP.md`](ROADMAP.md) under "Now (v0.7)":
+> Note (updated post-v0.7.0): v0.7.0 ended up being the "Install
+> Anywhere" release; v0.8 is "Always-On". The graph-view backlog
+> below moved to ROADMAP's [`Graph-view backlog (v0.8 or later)`](ROADMAP.md#graph-view-backlog-v08-or-later)
+> section.
+
+Originally tracked in [`ROADMAP.md`](ROADMAP.md) under "Now (v0.7)":
 
 - **Saved views.** Obsidian-style named filter/zoom/depth presets,
   persisted in `localStorage`.

--- a/RELEASE_NOTES_v0.7.0.md
+++ b/RELEASE_NOTES_v0.7.0.md
@@ -1,4 +1,4 @@
-# NeuralMind v0.6.1 — install anywhere
+# NeuralMind v0.7.0 — install anywhere
 
 **Release Date:** May 2026
 
@@ -11,7 +11,7 @@ repo root, a PyPI keyword refresh, a P2 fix in the JSONL event log,
 and a closed test-coverage gap on `/api/queries`.
 
 No new product features. The brain is the same brain. v0.6.0 made
-it visible; v0.6.1 makes it reachable.
+it visible; v0.7.0 makes it reachable.
 
 No migration. Same `graph.json`, same `synapses.db`, same hooks. If
 you're on v0.6.0 and your install path is fine, upgrading is
@@ -102,7 +102,7 @@ addressed in this release.
 ### `test(server)`: `/api/queries` regression coverage — #116
 
 The replay-last-query route added in PR #105 was hand-tested for
-happy-path / clamping / bad-input. v0.6.1 adds the no-`?n=` →
+happy-path / clamping / bad-input. v0.7.0 adds the no-`?n=` →
 default 20 case explicitly so the documented default can't drift on
 a future query-string parsing change.
 
@@ -121,16 +121,16 @@ Smoke against this release on each install path:
 
 ```bash
 # pip
-pip install neuralmind==0.6.1 graphifyy
+pip install neuralmind==0.7.0 graphifyy
 neuralmind --help
 
 # pipx
-pipx install neuralmind==0.6.1
+pipx install neuralmind==0.7.0
 pipx inject neuralmind graphifyy
 neuralmind --help
 
 # uv
-uv pip install neuralmind==0.6.1 graphifyy
+uv pip install neuralmind==0.7.0 graphifyy
 neuralmind --help
 
 # Docker
@@ -151,19 +151,19 @@ persistence trade-offs).
 
 ## What's next
 
-v0.7 — **Always-On.** systemd / launchd templates, a `/healthz`
+v0.8 — **Always-On.** systemd / launchd templates, a `/healthz`
 endpoint for `neuralmind serve`, Aider MCP integration, Windows
 Task Scheduler doc polish. Tracking issue: [#119](https://github.com/dfrostar/neuralmind/issues/119).
 
-v0.7.x — **Enterprise-Ready.** GHCR / Docker Hub auto-build,
+v0.8.x — **Enterprise-Ready.** GHCR / Docker Hub auto-build,
 air-gapped install doc, SBOM publication on tagged releases, a
 consolidated compliance one-pager. Tracking issue: [#120](https://github.com/dfrostar/neuralmind/issues/120).
 
 ## Thanks
 
-Most of the v0.6.1 work was surface-area: bringing existing
+Most of the v0.7.0 work was surface-area: bringing existing
 documentation up to "five install paths" consistency, drafting a
 container image that matches the rest of the project's
 local-first / non-root / no-network-at-runtime conventions, and
 landing the two deferred review-feedback patches the v0.6.0 merge
-train held back. Small release. Sets up the v0.7 always-on story.
+train held back. Small release. Sets up the v0.8 always-on story.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,7 +8,7 @@ For the longer-horizon engineering plan (release cadence, monitoring,
 compliance, scale targets), see
 [`docs/FUTURE-PROOFING-PLAN.md`](docs/FUTURE-PROOFING-PLAN.md).
 
-## Shipped in v0.6.1 — install anywhere
+## Shipped in v0.7.0 — install anywhere
 
 Distribution release, not a features release. The brain is the same;
 the matrix of ways to reach it widened.
@@ -33,7 +33,7 @@ the matrix of ways to reach it widened.
   for `/api/queries`.
 
 No migration. Same `graph.json`, same `synapses.db`, same hooks. See
-[v0.6.1 release notes](RELEASE_NOTES_v0.6.1.md) and the
+[v0.7.0 release notes](RELEASE_NOTES_v0.7.0.md) and the
 [install-paths walkthrough](docs/use-cases/install-paths.md) for the
 full surface.
 
@@ -93,9 +93,9 @@ synapse-graph viewer in A0's web UI) is a follow-up if the
 basic MCP listing draws users. Few hundred lines of Python against
 [A0's plugin API](https://www.agent-zero.ai/p/docs/plugins/).
 
-## Now (v0.7) — Always-On
+## Now (v0.8) — Always-On
 
-Distribution is sorted (v0.6.1); the next batch makes `neuralmind
+Distribution is sorted (v0.7.0); the next batch makes `neuralmind
 watch` and `neuralmind serve` first-class production processes.
 Tracking issue: [#119](https://github.com/dfrostar/neuralmind/issues/119).
 
@@ -114,11 +114,11 @@ Tracking issue: [#119](https://github.com/dfrostar/neuralmind/issues/119).
 - **`docs/use-cases/always-on.md`** — walkthrough per platform with
   verification steps.
 
-## Then (v0.7.x) — Enterprise-Ready
+## Then (v0.8.x) — Enterprise-Ready
 
 Tracking issue: [#120](https://github.com/dfrostar/neuralmind/issues/120).
 
-- **GHCR auto-build of the v0.6.1 Dockerfile** on tag push —
+- **GHCR auto-build of the v0.7.0 Dockerfile** on tag push —
   multi-platform (`linux/amd64`, `linux/arm64`).
 - **Air-gapped install doc** — PyPI mirror + ChromaDB embedding
   model pre-download script.
@@ -129,10 +129,10 @@ Tracking issue: [#120](https://github.com/dfrostar/neuralmind/issues/120).
   [SECURITY-GUIDE](docs/SECURITY-GUIDE.md) and
   [ENTERPRISE](docs/ENTERPRISE.md).
 
-## Graph-view backlog (v0.7 or later)
+## Graph-view backlog (v0.8 or later)
 
-Frontend wins carried forward from the pre-v0.6.1 plan. Could roll
-into v0.7 if there's appetite, or stay queued.
+Frontend wins carried forward from the pre-v0.7.0 plan. Could roll
+into v0.8 if there's appetite, or stay queued.
 
 - **Saved views.** Obsidian-style named graph filter/zoom/depth
   combos, persisted in `localStorage`. Lets users keep "auth tour",

--- a/docs/LINKEDIN-POST-DRAFT.md
+++ b/docs/LINKEDIN-POST-DRAFT.md
@@ -108,9 +108,9 @@ a list. Don't post the v0.7.0 variants without it.
 - **Don't lead with the keyword bump.** PyPI keyword changes matter
   for discoverability but they're internal plumbing — the post is
   about the install experience.
-- **Phase 2 (v0.7 "Always-On") is the next post.** systemd / launchd
-  / Aider / `/healthz`. Different audience (ops / SREs). Don't try
-  to cram it into the v0.7.0 post.
+- **Phase 2 (v0.8 "Always-On") is the next post.** systemd / launchd
+  / `/healthz`. Different audience (ops / SREs). Don't try to cram it
+  into the v0.7.0 post.
 
 ---
 

--- a/docs/LINKEDIN-POST-DRAFT.md
+++ b/docs/LINKEDIN-POST-DRAFT.md
@@ -1,14 +1,14 @@
 # LinkedIn post draft — NeuralMind progress update
 
-Three sets of drafts. The **v0.6.1 launch drafts** are the current
-batch — post one of them the moment v0.6.1 is on PyPI. The
+Three sets of drafts. The **v0.7.0 launch drafts** are the current
+batch — post one of them the moment v0.7.0 is on PyPI. The
 **v0.6.0 launch drafts** below were the previous progress update.
 The **earlier drafts** below those are the v0.5-era progress update;
 kept for reference and as a backbone if you want to combine.
 
 ---
 
-## v0.6.1 launch drafts
+## v0.7.0 launch drafts
 
 The pitch frame: **"NeuralMind installs wherever you work."** This
 is the "second progress update" after v0.6.0 — same project, but
@@ -18,15 +18,15 @@ and AI-tooling early adopters: people who already have an opinion
 about pipx vs uv and will share install-method posts in their own
 networks.
 
-Pair every draft with the v0.6.1 screencast clip
-([`SCREENCAST-v0.6.1.md`](SCREENCAST-v0.6.1.md)) — the
+Pair every draft with the v0.7.0 screencast clip
+([`SCREENCAST-v0.7.0.md`](SCREENCAST-v0.7.0.md)) — the
 `pipx install neuralmind` → `docker run …` → both-canvases-side-by-side
 visual is what makes "installs anywhere" land as a *thing*, not just
-a list. Don't post the v0.6.1 variants without it.
+a list. Don't post the v0.7.0 variants without it.
 
-### Draft v0.6.1–A — feature-tour, scannable (recommended)
+### Draft v0.7.0–A — feature-tour, scannable (recommended)
 
-> NeuralMind v0.6.1 ships today. The theme: **installs wherever you work.**
+> NeuralMind v0.7.0 ships today. The theme: **installs wherever you work.**
 >
 > → **`pip install neuralmind`** — the default. Works in any venv.
 >
@@ -49,7 +49,7 @@ a list. Don't post the v0.6.1 variants without it.
 >   `python -c "import neuralmind; print(neuralmind.__version__)"`
 >   `neuralmind --help`
 >
-> Why this matters: v0.6.0 made the brain visible. v0.6.1 makes it
+> Why this matters: v0.6.0 made the brain visible. v0.7.0 makes it
 > reachable from any workflow — corporate Python that still mandates
 > pip, the uv-native indie stack, the Dockerized CI pipeline, the
 > pipx-managed dev box. NeuralMind shouldn't lose to "installing it
@@ -65,9 +65,9 @@ a list. Don't post the v0.6.1 variants without it.
 >
 > #ClaudeCode #Cursor #AIEngineering #OpenSource #DeveloperTools #Python
 
-### Draft v0.6.1–B — short, dev-honest
+### Draft v0.7.0–B — short, dev-honest
 
-> NeuralMind v0.6.1 is out today.
+> NeuralMind v0.7.0 is out today.
 >
 > No new features in the brain. Five new ways to install it.
 >
@@ -82,7 +82,7 @@ a list. Don't post the v0.6.1 variants without it.
 >   `neuralmind --help`
 >
 > v0.6.0 was about the brain becoming visible (the live activity
-> feed, the pulse rings). v0.6.1 is about the brain becoming
+> feed, the pulse rings). v0.7.0 is about the brain becoming
 > reachable. The headline number hasn't changed (40–70× per-query
 > token reduction; verifiable in 30 seconds on a fresh clone via
 > `bash scripts/demo.sh`). What's changed is who can get to it.
@@ -110,7 +110,7 @@ a list. Don't post the v0.6.1 variants without it.
   about the install experience.
 - **Phase 2 (v0.7 "Always-On") is the next post.** systemd / launchd
   / Aider / `/healthz`. Different audience (ops / SREs). Don't try
-  to cram it into the v0.6.1 post.
+  to cram it into the v0.7.0 post.
 
 ---
 

--- a/docs/SCREENCAST-v0.7.0.md
+++ b/docs/SCREENCAST-v0.7.0.md
@@ -1,7 +1,7 @@
-# 60-second screencast script — NeuralMind v0.6.1
+# 60-second screencast script — NeuralMind v0.7.0
 
 Three beats. Sixty seconds total. The job of this clip is to flip
-the v0.6.1 pitch from a list of five install commands into a single
+the v0.7.0 pitch from a list of five install commands into a single
 visual claim: **same canvas, every install path.**
 
 The previous release's screencast
@@ -105,7 +105,7 @@ visual proof.
 **Text overlay (timed to the first pulse):**
 
 > Same brain. Whichever way you install.
-> NeuralMind v0.6.1 — `pip` / `pipx` / `uv` / Docker / source.
+> NeuralMind v0.7.0 — `pip` / `pipx` / `uv` / Docker / source.
 
 **End frame (last 3 seconds):**
 
@@ -133,8 +133,8 @@ Static frame. NeuralMind logo bottom-left. URL bottom-right:
 - **Don't post without the v0.6.0 screencast having landed first.**
   Beat 3's payoff depends on the viewer already knowing what the
   pulse-rings mean. If your audience is new to NeuralMind, either
-  splice in 5s from the v0.6.0 clip or skip the v0.6.1 screencast
-  and post the v0.6.0 one again with the v0.6.1 LinkedIn copy.
+  splice in 5s from the v0.6.0 clip or skip the v0.7.0 screencast
+  and post the v0.6.0 one again with the v0.7.0 LinkedIn copy.
 
 ## Recording checklist
 
@@ -165,7 +165,7 @@ Static frame. NeuralMind logo bottom-left. URL bottom-right:
 ## Distribution
 
 - LinkedIn — native video upload preferred over embed. Use the
-  Draft v0.6.1–A caption from
+  Draft v0.7.0–A caption from
   [`LINKEDIN-POST-DRAFT.md`](LINKEDIN-POST-DRAFT.md).
 - X / Twitter — 60s fits in a single tweet. Lead with the
   two-canvases thumbnail.
@@ -175,4 +175,4 @@ Static frame. NeuralMind logo bottom-left. URL bottom-right:
   cleanly; show it as a separate animated PNG/GIF or as the full
   60s embed on the release page.
 - Blog / about page — embed the full 60s in the "What's new in
-  v0.6.1" callout.
+  v0.7.0" callout.

--- a/docs/about.html
+++ b/docs/about.html
@@ -46,8 +46,8 @@
     </header>
 
     <section>
-        <div class="container" id="whats-new-v061">
-            <h2>What's New in v0.6.1 — install anywhere</h2>
+        <div class="container" id="whats-new-v070">
+            <h2>What's New in v0.7.0 — install anywhere</h2>
             <p><strong>Distribution release, not a features release.</strong> The brain is the same brain. What changed is how many ways you can install it.</p>
             <h3>Five install paths</h3>
             <ul>
@@ -58,14 +58,14 @@
                 <li><strong>From source</strong> — for contributors.</li>
             </ul>
             <p>All five paths deliver the same package: the <code>neuralmind</code> CLI, the <code>neuralmind-mcp</code> server (for Claude Code, Cursor, Cline, Continue, and any MCP client), and the live graph view from v0.6.0. Smoke test is identical: <code>neuralmind --help</code> works everywhere; <code>python -c "import neuralmind"</code> works for pip / uv / source paths.</p>
-            <h3>Also in v0.6.1</h3>
+            <h3>Also in v0.7.0</h3>
             <ul>
                 <li><strong>PyPI keywords refresh</strong> — eight additions matching v0.6.0 product copy (<code>graph-view</code>, <code>hebbian-learning</code>, <code>force-directed-graph</code>, …) so PyPI search ranking finally matches what we ship.</li>
                 <li><strong>JSONL bridge rotation fix (#115)</strong> — P2 correctness bug from Codex review. The event-log tailer now reopens rotated files from offset 0, preserving the recovery state across failed open attempts. Silent event loss under <code>logrotate</code>/<code>copytruncate</code> is fixed.</li>
                 <li><strong><code>/api/queries</code> test coverage (#116)</strong> — the replay-last-query route is now in the automated regression suite.</li>
             </ul>
             <p>No migration. Same <code>graph.json</code>, same <code>synapses.db</code>, same hooks. Upgrade is whatever your install path's <code>--upgrade</code> equivalent is.</p>
-            <p><a href="https://github.com/dfrostar/neuralmind/blob/main/RELEASE_NOTES_v0.6.1.md">Full v0.6.1 release notes →</a> · <a href="https://github.com/dfrostar/neuralmind/blob/main/docs/use-cases/install-paths.md">Install paths walkthrough →</a></p>
+            <p><a href="https://github.com/dfrostar/neuralmind/blob/main/RELEASE_NOTES_v0.7.0.md">Full v0.7.0 release notes →</a> · <a href="https://github.com/dfrostar/neuralmind/blob/main/docs/use-cases/install-paths.md">Install paths walkthrough →</a></p>
         </div>
     </section>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -61,7 +61,7 @@
             <h1>🧠 NeuralMind</h1>
             <p>Semantic code intelligence for AI agents.<br/>40–70× token reduction. Zero data exfiltration. Enterprise-ready.</p>
             <p style="font-size: 1rem; opacity: 0.85; margin-top: 0.5rem;">
-                <strong>🆕 v0.6.1 — Install anywhere.</strong> Five install paths: <code>pip</code>, <code>pipx</code>, <code>uv</code>, Docker, and source. Same package every path. <a href="https://github.com/dfrostar/neuralmind/blob/main/RELEASE_NOTES_v0.6.1.md" style="color: white; text-decoration: underline;">Release notes →</a> · <a href="about.html#whats-new-v061" style="color: white; text-decoration: underline;">Install matrix →</a>
+                <strong>🆕 v0.7.0 — Install anywhere.</strong> Five install paths: <code>pip</code>, <code>pipx</code>, <code>uv</code>, Docker, and source. Same package every path. <a href="https://github.com/dfrostar/neuralmind/blob/main/RELEASE_NOTES_v0.7.0.md" style="color: white; text-decoration: underline;">Release notes →</a> · <a href="about.html#whats-new-v070" style="color: white; text-decoration: underline;">Install matrix →</a>
             </p>
             <p style="font-size: 0.9rem; opacity: 0.75; margin-top: 0.25rem;">
                 Earlier: <a href="https://github.com/dfrostar/neuralmind/blob/main/RELEASE_NOTES_v0.6.0.md" style="color: white; text-decoration: underline;">v0.6.0 live activity feed</a> · <a href="https://github.com/dfrostar/neuralmind/blob/main/RELEASE_NOTES_v0.4.0.md" style="color: white; text-decoration: underline;">v0.4.0 brain-like synapse layer</a>.

--- a/docs/notebooklm/v0.7.0/01-installs-anywhere.md
+++ b/docs/notebooklm/v0.7.0/01-installs-anywhere.md
@@ -1,4 +1,4 @@
-# Why NeuralMind v0.6.1 is about install paths, not features
+# Why NeuralMind v0.7.0 is about install paths, not features
 
 *Founder-narrative source for the NotebookLM video. First-person,
 conversational. Use as the "why does this release exist" arc.*
@@ -11,7 +11,7 @@ flipped from "code RAG" to "associative memory you can watch
 learn." If you read the v0.6.0 release notes, you'd be forgiven for
 thinking the next thing we'd ship would be another features release.
 
-It isn't. v0.6.1 is a distribution release.
+It isn't. v0.7.0 is a distribution release.
 
 The reason is a thing I noticed during the v0.6.0 launch week. The
 release notes shipped, the LinkedIn post went up, the screencast
@@ -31,7 +31,7 @@ this be?" If the answers don't tilt the right way, you lose them.
 You never know you lost them, because they don't open an issue
 saying "I was going to install this but I wasn't sure how."
 
-So v0.6.1 fixes that. There are five install paths now, documented
+So v0.7.0 fixes that. There are five install paths now, documented
 on the README, with a single matrix that names the trade-off of
 each in one phrase. You don't have to read the install-paths
 walkthrough to pick one. You just look at the matrix and pick.
@@ -51,7 +51,7 @@ identically. The MCP server registers the same tools. The graph
 view renders the same canvas. There's exactly one wheel on PyPI;
 the matrix is just five fronts onto it.
 
-The headline visual for v0.6.1 is two terminals, side by side. The
+The headline visual for v0.7.0 is two terminals, side by side. The
 left one is `pipx install neuralmind` followed by `neuralmind --help`.
 The right one is `docker run ghcr.io/dfrostar/neuralmind neuralmind --help`.
 The help output is identical. That's the whole pitch. Same package,
@@ -59,7 +59,7 @@ whatever your stack.
 
 There's a Dockerfile in the repo root now, multi-stage, slim
 runtime, non-root user. Build it locally if you want; the auto-publish
-to GHCR is a Phase 3 / v0.7.x thing because we want the build
+to GHCR is a Phase 3 / v0.8.x thing because we want the build
 pipeline to be hardened before we commit to "one-line `docker pull`
 works forever." The Dockerfile itself is already production-grade
 and the docs walk through how to run it against a host project
@@ -69,11 +69,11 @@ The `pyproject.toml` keywords got a long overdue refresh — graph-view,
 hebbian-learning, code-visualization, force-directed-graph,
 neuralmind-serve. PyPI search ranking is fuzzy magic but the
 existing v0.5-era keyword list was missing every word we now lead
-with in product copy. Half the v0.6.1 install path improvements are
+with in product copy. Half the v0.7.0 install path improvements are
 about discoverability before installation: if you can't find the
 package, it doesn't matter how easily it installs.
 
-The thing v0.6.1 isn't, deliberately, is a feature release. The
+The thing v0.7.0 isn't, deliberately, is a feature release. The
 brain isn't smarter than it was in v0.6.0. The graph view doesn't
 render any node it couldn't render last week. The synapse layer
 behaves the same. If you're already running NeuralMind 0.6.0 and
@@ -82,7 +82,7 @@ and approximately zero impact. That's a feature, not a problem.
 Small patches that change one thing well are the operations the
 release-please cycle is designed for.
 
-What v0.6.1 sets up is the v0.7 release after it. v0.7 is the
+What v0.7.0 sets up is the v0.8 release after it. v0.8 is the
 "Always-On" release: systemd templates, launchd plists, a `/healthz`
 endpoint, Aider MCP integration, the screencast where you see the
 canvas pulsing as you save files for forty seconds straight because
@@ -91,12 +91,12 @@ SREs. It makes no sense to ship it before "installs anywhere"
 exists — you can't tell people to `systemctl enable neuralmind-watch`
 if their answer to "how do I install it" is still "well, that depends."
 
-So this is the order. v0.6.0: brain becomes visible. v0.6.1: brain
-becomes reachable. v0.7: brain becomes persistent. v0.7.x: brain
-becomes auditable. Each release makes the next one credible. v0.6.1
+So this is the order. v0.6.0: brain becomes visible. v0.7.0: brain
+becomes reachable. v0.8: brain becomes persistent. v0.8.x: brain
+becomes auditable. Each release makes the next one credible. v0.7.0
 is the second beat in that arc and it deserves to land as its own
 small thing — not buried under feature creep, not deferred until
-the v0.7 train.
+the v0.8 train.
 
 If you've installed NeuralMind already and you're wondering whether
 this affects you: probably not directly. The reason to care is that

--- a/docs/notebooklm/v0.7.0/02-what-shipped.md
+++ b/docs/notebooklm/v0.7.0/02-what-shipped.md
@@ -1,11 +1,11 @@
-# What shipped in NeuralMind v0.6.1
+# What shipped in NeuralMind v0.7.0
 
 *Neutral third-person technical source for the NotebookLM video.
 Concrete feature-by-feature breakdown of every change.*
 
 ---
 
-NeuralMind v0.6.1 is a distribution release. It does not add product
+NeuralMind v0.7.0 is a distribution release. It does not add product
 features, change the synapse model, or alter the graph view
 rendering. It expands install coverage, ships a container image
 source, and lands the two non-blocking review-feedback patches the
@@ -40,8 +40,8 @@ documented usage patterns are mounting the host project read-only
 into `/project` and running either `neuralmind-mcp /project` for
 the MCP server or `neuralmind serve /project --host 0.0.0.0
 --no-auth` for the graph view bound to the host port. The
-auto-publish of this image to GHCR is deferred to v0.7.x (Phase 3,
-Enterprise-Ready); for v0.6.1, the Dockerfile is committed and
+auto-publish of this image to GHCR is deferred to v0.8.x (Phase 3,
+Enterprise-Ready); for v0.7.0, the Dockerfile is committed and
 users build the image locally. The pull command in the README
 documents the eventual GHCR tag so the README doesn't have to
 change again when the auto-publish lands.
@@ -78,20 +78,20 @@ all three are delivered.
 Issue 116 was a Copilot-flagged test coverage gap on the
 /api/queries server route added in PR 105. The route was
 hand-tested for happy path, clamping, and bad-input defaulting in
-the original PR; v0.6.1 adds the explicit no-argument case
+the original PR; v0.7.0 adds the explicit no-argument case
 (`GET /api/queries` with no `n` parameter must default to 20) that
 the existing parametrized tests didn't cover directly. The existing
 two tests already cover happy-path and clamping behaviour, so the
 116 work is small.
 
-The marketing artifacts shipped with v0.6.1 are scoped to drafting
+The marketing artifacts shipped with v0.7.0 are scoped to drafting
 only — the maintainer's approval is required before any are
 published. A new LinkedIn drafts block in `docs/LINKEDIN-POST-DRAFT.md`
 covers two voices (feature-tour scannable and short
-dev-honest). A new screencast script in `docs/SCREENCAST-v0.6.1.md`
+dev-honest). A new screencast script in `docs/SCREENCAST-v0.7.0.md`
 covers a sixty-second three-beat video: pipx install, docker run,
 both-canvases-pulsing side by side. A new NotebookLM source pack in
-`docs/notebooklm/v0.6.1/` follows the v0.6.0 three-document
+`docs/notebooklm/v0.7.0/` follows the v0.6.0 three-document
 structure for AI-generated video and podcast overviews.
 
 There are no breaking changes. The Python API is unchanged. CLI
@@ -102,9 +102,9 @@ projects continue to work. The minimum supported Python remains
 3.10. The dependency floor for the chromadb, pyyaml, toml, and mcp
 packages is unchanged.
 
-The next release in the published roadmap is v0.7 — the "Always-On"
+The next release in the published roadmap is v0.8 — the "Always-On"
 release covering systemd and launchd templates, the `/healthz`
 endpoint for `neuralmind serve`, the Aider MCP integration, and the
-Windows Task Scheduler documentation polish. v0.6.1 sets up that
+Windows Task Scheduler documentation polish. v0.7.0 sets up that
 release by ensuring the install story is robust before the always-on
 story extends it.

--- a/docs/notebooklm/v0.7.0/03-the-honest-take.md
+++ b/docs/notebooklm/v0.7.0/03-the-honest-take.md
@@ -1,4 +1,4 @@
-# The honest take on NeuralMind v0.6.1
+# The honest take on NeuralMind v0.7.0
 
 *Mixed developer-experience and skeptic's-view source for the
 NotebookLM video. Day-in-the-life walkthrough plus the things to
@@ -6,7 +6,7 @@ push back on.*
 
 ---
 
-Here's how a v0.6.1 install actually goes, told straight, on a
+Here's how a v0.7.0 install actually goes, told straight, on a
 machine that already has Python and Docker installed.
 
 You land on the README from a link in someone's LinkedIn post.
@@ -23,7 +23,7 @@ opens to a graph view. Total time from clicking the LinkedIn link
 to seeing the graph: maybe four minutes. Most of it was the
 `graphify update` step on a real codebase.
 
-That's the experience the v0.6.1 release is designed to produce. If
+That's the experience the v0.7.0 release is designed to produce. If
 you're an experienced developer with a clean Python install, that
 flow works. The release-cycle bet is that this flow is enough
 better than the v0.6.0 flow — which was "you have one option, hope
@@ -37,20 +37,20 @@ Now the honest pushback.
 The first thing to push back on is the framing. "Install five ways"
 sounds, on its face, like a meaningful product improvement. It
 isn't. It's PR work. The package itself is unchanged. If you read
-the v0.6.1 release notes hoping for a smarter synapse layer or a
+the v0.7.0 release notes hoping for a smarter synapse layer or a
 better graph view, you'll come away disappointed. The argument for
 shipping it as its own version isn't that there's new product
 value; it's that the v0.6.0 install story was a real conversion
 leak and fixing it as its own beat makes both the v0.6.0 launch
-moment and the v0.7 launch moment land cleaner. If you don't buy
-that argument, v0.6.1 looks like a marketing release with a version
+moment and the v0.8 launch moment land cleaner. If you don't buy
+that argument, v0.7.0 looks like a marketing release with a version
 number. That's a fair criticism. You should weigh it.
 
 The second is the Dockerfile. We shipped the Dockerfile but not
 the auto-publish to a registry. The README's `docker run
 ghcr.io/dfrostar/neuralmind` command works only after you've
 manually built and pushed that image — which the maintainer hasn't
-done as of v0.6.1. Until the GHCR auto-publish lands in v0.7.x,
+done as of v0.7.0. Until the GHCR auto-publish lands in v0.8.x,
 "run it in Docker" means "build the image yourself first." That's
 documented honestly, but it does mean the Docker line in the matrix
 is more aspirational than the other four. We considered hiding the
@@ -81,12 +81,12 @@ in a project venv is still the right answer.
 The fifth is what didn't change. The graph view is still single-user
 and single-host. The MCP server still requires a `project_path`
 argument from every client (we have an issue to make that
-inferrable from cwd, but it's not in v0.6.1). The audit log still
+inferrable from cwd, but it's not in v0.7.0). The audit log still
 writes to local SQLite, not to a remote backend. The benchmark
 suite still ships with the 500-line fixture and produces the same
 five-point-something-x reduction it produced before. None of that
 is broken; none of it is improved. If those were the things you
-were waiting for, v0.6.1 isn't your release.
+were waiting for, v0.7.0 isn't your release.
 
 And the sixth: the install-paths page makes a sales pitch ("`pipx`
 for always on PATH") that is, in fairness, what we'd say to any
@@ -96,7 +96,7 @@ preference; if you don't, just run `pip install neuralmind
 graphifyy` in whatever environment you already have open and
 you're done.
 
-When is v0.6.1 actually worth installing over v0.6.0? When you're
+When is v0.7.0 actually worth installing over v0.6.0? When you're
 on a machine where `pip install` was failing for some environmental
 reason and one of the other paths fixes it. When you want the CLI
 on global PATH and didn't realize pipx was an option. When you've
@@ -104,12 +104,12 @@ been waiting to put NeuralMind in your CI image and didn't want to
 write the Dockerfile yourself. Otherwise: upgrading is fine,
 upgrading is approximately zero work, and there's no urgency.
 
-The thing the v0.6.1 release is genuinely good for is being able to
+The thing the v0.7.0 release is genuinely good for is being able to
 send a colleague the README link and not having to explain how to
 install Python tools. That's the small, real, measurable thing it
 buys. If your team has been blocked at the install step, this fixes
-it. If your team hasn't, you can wait for v0.7 and the always-on
+it. If your team hasn't, you can wait for v0.8 and the always-on
 story.
 
-The brain in v0.6.1 is the same brain you had a week ago. There
+The brain in v0.7.0 is the same brain you had a week ago. There
 are just more doors into the room.

--- a/docs/notebooklm/v0.7.0/README.md
+++ b/docs/notebooklm/v0.7.0/README.md
@@ -1,8 +1,8 @@
-# NotebookLM source pack — NeuralMind v0.6.1
+# NotebookLM source pack — NeuralMind v0.7.0
 
 Three documents designed to be loaded as sources in NotebookLM (or
 any similar tool) to generate a video, podcast, or audio overview
-about NeuralMind v0.6.1.
+about NeuralMind v0.7.0.
 
 ## How to use
 
@@ -24,22 +24,22 @@ the v0.6.0 pack ([`../v0.6.0/`](../v0.6.0/README.md)).
 
 | Doc | Register | What it provides |
 |---|---|---|
-| `01-installs-anywhere.md` | First-person founder narrative | The conceptual arc — why the v0.6.1 release is about distribution, not features, and why that matters more than it sounds. |
-| `02-what-shipped.md` | Neutral third-person technical tour | Concrete feature-by-feature breakdown of every v0.6.1 change. Each install path, the Dockerfile, the keyword bump, the deferred review-feedback patches. |
-| `03-the-honest-take.md` | Mixed developer-experience + skeptic's-view | When is "five install paths" actually one too many? When does pipx beat pip beat uv? What's *not* in v0.6.1 that the install-anywhere framing might let you assume? |
+| `01-installs-anywhere.md` | First-person founder narrative | The conceptual arc — why the v0.7.0 release is about distribution, not features, and why that matters more than it sounds. |
+| `02-what-shipped.md` | Neutral third-person technical tour | Concrete feature-by-feature breakdown of every v0.7.0 change. Each install path, the Dockerfile, the keyword bump, the deferred review-feedback patches. |
+| `03-the-honest-take.md` | Mixed developer-experience + skeptic's-view | When is "five install paths" actually one too many? When does pipx beat pip beat uv? What's *not* in v0.7.0 that the install-anywhere framing might let you assume? |
 
 Together they cover the *why*, the *what*, and the *should you*.
 
 ## What this pack is *not*
 
 - **Not the release notes.** Those live at
-  [`/RELEASE_NOTES_v0.6.1.md`](../../../RELEASE_NOTES_v0.6.1.md)
+  [`/RELEASE_NOTES_v0.7.0.md`](../../../RELEASE_NOTES_v0.7.0.md)
   (once cut) and exist for humans skimming changelogs.
 - **Not the LinkedIn drafts.** Those live at
   [`/docs/LINKEDIN-POST-DRAFT.md`](../../LINKEDIN-POST-DRAFT.md)
   and are shorter, posty, with hashtags.
 - **Not the screencast script.** That lives at
-  [`/docs/SCREENCAST-v0.6.1.md`](../../SCREENCAST-v0.6.1.md) and is
+  [`/docs/SCREENCAST-v0.7.0.md`](../../SCREENCAST-v0.7.0.md) and is
   a beat-by-beat narration script for a 60-second demo.
 
 ## Editing notes
@@ -48,10 +48,10 @@ Together they cover the *why*, the *what*, and the *should you*.
   bullet lists past a sentence or two.
 - The three docs deliberately overlap a little. Don't dedupe.
 - If you change product positioning, update all three.
-- **Don't oversell.** v0.6.1 adds install paths, not features.
+- **Don't oversell.** v0.7.0 adds install paths, not features.
   Calling it a "major release" or a "new chapter" is the trap to
   avoid — it makes the v0.7 release ("Always-On") harder to land
-  later. Frame v0.6.1 as a clean, small, distribution-focused
+  later. Frame v0.7.0 as a clean, small, distribution-focused
   patch.
 
 ## Suggested prompts for NotebookLM
@@ -62,7 +62,7 @@ After loading the sources, try one of these:
   > "Make a 4-minute video overview targeted at experienced
   > developers. Focus on the install-method choice — when does pipx
   > beat pip, when does uv matter, when is Docker worth it. Stay
-  > honest about what v0.6.1 doesn't add."
+  > honest about what v0.7.0 doesn't add."
 
 - **For a shorter distribution-pitch video:**
   > "3-minute video. Lead with the five install paths. End on the
@@ -72,7 +72,7 @@ After loading the sources, try one of these:
 - **For a Python-tooling-fans audience:**
   > "4-minute video. Heavy on the pipx/uv/Docker tradeoffs. Treat
   > the audience as people with strong opinions about how they
-  > install Python applications. The v0.6.1 release is for them."
+  > install Python applications. The v0.7.0 release is for them."
 
 ## Re-using outside NotebookLM
 

--- a/docs/notebooklm/v0.7.0/README.md
+++ b/docs/notebooklm/v0.7.0/README.md
@@ -48,11 +48,11 @@ Together they cover the *why*, the *what*, and the *should you*.
   bullet lists past a sentence or two.
 - The three docs deliberately overlap a little. Don't dedupe.
 - If you change product positioning, update all three.
-- **Don't oversell.** v0.7.0 adds install paths, not features.
-  Calling it a "major release" or a "new chapter" is the trap to
-  avoid — it makes the v0.7 release ("Always-On") harder to land
-  later. Frame v0.7.0 as a clean, small, distribution-focused
-  patch.
+- **Don't oversell.** v0.7.0 adds install paths and an Agent Zero
+  integration, not new product surface. Calling it a "major release"
+  or a "new chapter" is the trap to avoid — it makes the v0.8
+  release ("Always-On") harder to land later. Frame v0.7.0 as a
+  clean, distribution-focused minor release.
 
 ## Suggested prompts for NotebookLM
 

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -6,11 +6,11 @@ Welcome — this wiki is the in-depth reference. For the fastest orientation, us
 
 ## What's New
 
-### v0.6.1 — Install anywhere
+### v0.7.0 — Install anywhere
 
 NeuralMind now installs five ways: `pip`, `pipx`, `uv`, Docker, and source. Same package, same CLI, same MCP server, same graph view — every path. The Quick Start matrix lives at the top of the [Installation](Installation) page and the [README](../blob/main/README.md#install--pick-your-path); the repo's root [`Dockerfile`](../blob/main/Dockerfile) is multi-stage, non-root, and pre-wheels every transitive dep so the runtime image doesn't need a C toolchain. PyPI keywords got a long-overdue refresh too, so search ranking for `graph-view`, `hebbian-learning`, and friends finally matches the v0.6.0 product copy.
 
-Also in v0.6.1: a P2 fix in the JSONL bridge (rotation race that could drop events under logrotate/copytruncate) and a test-coverage gap on `/api/queries`. Full details: [v0.6.1 release notes](../blob/main/RELEASE_NOTES_v0.6.1.md) · [Install paths walkthrough](../blob/main/docs/use-cases/install-paths.md).
+Also in v0.7.0: a P2 fix in the JSONL bridge (rotation race that could drop events under logrotate/copytruncate) and a test-coverage gap on `/api/queries`. Full details: [v0.7.0 release notes](../blob/main/RELEASE_NOTES_v0.7.0.md) · [Install paths walkthrough](../blob/main/docs/use-cases/install-paths.md).
 
 ### v0.6.0 — Graph view + live activity feed
 
@@ -84,7 +84,7 @@ sections.
 
 | Page | Contents |
 |------|----------|
-| [Installation](Installation) | `pip` / `pipx` / `uv` / Docker / source — pick your path (v0.6.1) |
+| [Installation](Installation) | `pip` / `pipx` / `uv` / Docker / source — pick your path (v0.7.0) |
 | [Usage Guide](Usage-Guide) | End-to-end examples for every command |
 | [CLI Reference](CLI-Reference) | All CLI commands, flags, and output shapes |
 | [API Reference](API-Reference) | Python API (`NeuralMind`, `ContextResult`, `TokenBudget`) |

--- a/docs/wiki/Installation.md
+++ b/docs/wiki/Installation.md
@@ -6,7 +6,7 @@ NeuralMind is a local, offline Python package — no SaaS, no accounts, no outbo
 
 ## Table of Contents
 
-- [Install — pick your path](#install--pick-your-path) *(new in v0.6.1)*
+- [Install — pick your path](#install--pick-your-path) *(new in v0.7.0)*
 - [System Requirements](#system-requirements)
 - [Quick Install](#quick-install)
 - [Installation Methods](#installation-methods)
@@ -25,7 +25,7 @@ NeuralMind is a local, offline Python package — no SaaS, no accounts, no outbo
 
 ## Install — pick your path
 
-*New in [v0.6.1](../../blob/main/RELEASE_NOTES_v0.6.1.md).* NeuralMind installs five ways. All paths deliver the same package — the `neuralmind` CLI, the `neuralmind-mcp` server, and the Python module.
+*New in [v0.7.0](../../blob/main/RELEASE_NOTES_v0.7.0.md).* NeuralMind installs five ways. All paths deliver the same package — the `neuralmind` CLI, the `neuralmind-mcp` server, and the Python module.
 
 | Method | Command | When to pick |
 |---|---|---|


### PR DESCRIPTION
## Summary

Conventional-commit semantics drove release-please to propose **0.7.0** (not 0.6.1) for the install-anywhere work merged in PR #122. This PR aligns the docs / release notes / marketing artifacts with that version label so PR #123 (release-please) lands as a coherent v0.7.0 release.

The work itself is feature-level in a fair reading — new install paths, new Dockerfile, new Agent Zero integration — so the version is honest. The reframing here is pure naming.

## Changes

**Renames** (git mv, history preserved):
- `RELEASE_NOTES_v0.6.1.md` → `RELEASE_NOTES_v0.7.0.md`
- `docs/SCREENCAST-v0.6.1.md` → `docs/SCREENCAST-v0.7.0.md`
- `docs/notebooklm/v0.6.1/` → `docs/notebooklm/v0.7.0/`

**Content** (8 files): `v0.6.1` → `v0.7.0`, pinned-version snippets bumped, `whats-new-v061` anchor renamed, forward-looking refs reframed (Always-On = `v0.8` now, Enterprise-Ready = `v0.8.x`). Tracking issues #119 and #120 stay correct — they're about the work, not the version label.

## Test plan

- [x] `python -m pytest tests/` — 388 passed, 4 environmental skips
- [x] No code changes; no test changes
- [x] No remaining `0.6.1` references outside historical files (`RELEASE_NOTES_v0.3-0.6.0`, `CHANGELOG.md`)
- [x] No orphaned `v0.7` forward refs in the renamed `v0.7.0` files (they all correctly point at `v0.8` for what's next)
- [x] All commits in this PR are `docs(...)` so release-please won't bump the version again

## Order of operations after this lands

1. Merge this PR → main has the v0.7.0-named docs
2. Release-please PR #123 will update to include these commits in the v0.7.0 release
3. Merge PR #123 (squash) → release-please cuts the v0.7.0 tag
4. Manually dispatch `release.yml` for the PyPI publish (the GITHUB_TOKEN gotcha from #98 is still active)

## Follow-up (not in this PR)

The handoff doc on PR #121 still references "v0.6.1" + "v0.7" / "v0.7.x" planning labels. That doc is on a separate branch and can be reframed when it lands.

https://claude.ai/code/session_01SH6iHNAqeMJHXdq7ubVcuJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01SH6iHNAqeMJHXdq7ubVcuJ)_