### PR TITLE
v0.8.0: always-on — systemd/launchd/Windows templates + /healthz

### DIFF
--- a/RELEASE_NOTES_v0.8.0.md
+++ b/RELEASE_NOTES_v0.8.0.md
@@ -13,8 +13,10 @@ threading a session token.
 
 Distribution (v0.7.0) made NeuralMind reachable. Always-on (v0.8.0)
 makes it persistent — the synapse store accumulates 24/7 whether
-you're at the keyboard or not, and the graph view canvas is always at
-`http://127.0.0.1:8765/`.
+you're at the keyboard or not, and the graph view is always listening
+on `127.0.0.1:8765`. The canvas still requires the per-session auth
+token by default (pass `--no-auth` in the templates to disable it on
+trusted hosts, or read the tokenized URL out of the service logs).
 
 No migration. Same `graph.json`, same `synapses.db`, same hooks. New
 files are additive; existing CLI behaviour is unchanged.
@@ -33,8 +35,10 @@ files are additive; existing CLI behaviour is unchanged.
   the file watcher. Restart-on-failure, SIGTERM-clean shutdown, basic
   hardening (`NoNewPrivileges`, `PrivateTmp`, `ProtectSystem=strict`).
 - **`scripts/systemd/neuralmind-serve.service`** — same for the graph
-  view, plus an `ExecStartPost` that polls `/healthz` for up to 5
-  seconds before declaring the unit ready.
+  view, plus an `ExecStartPost` that polls `/healthz` for up to 60
+  seconds before declaring the unit ready. The window allows for
+  `neuralmind serve`'s on-startup index build on first run or large
+  projects.
 - **`scripts/launchd/com.neuralmind.watch.plist`** — macOS user agent.
   `RunAtLoad` + `KeepAlive` + `ThrottleInterval` so a crash loop
   doesn't burn CPU.
@@ -105,21 +109,36 @@ pip install --upgrade neuralmind     # or pipx upgrade neuralmind / uv pip insta
 neuralmind serve . &
 curl -fsS http://127.0.0.1:8765/healthz
 # {"status": "ok", "version": "0.8.0"}
+```
 
-# Linux: install + verify systemd units
+The `scripts/` directory isn't packaged in the wheel — pip / pipx /
+uv / Docker users fetch the templates directly from GitHub:
+
+```bash
+# Linux: install + verify systemd units (no repo checkout needed)
 mkdir -p ~/.config/systemd/user
-cp scripts/systemd/neuralmind-{watch,serve}.service ~/.config/systemd/user/
+curl -fsSL https://raw.githubusercontent.com/dfrostar/neuralmind/main/scripts/systemd/neuralmind-watch.service \
+  -o ~/.config/systemd/user/neuralmind-watch.service
+curl -fsSL https://raw.githubusercontent.com/dfrostar/neuralmind/main/scripts/systemd/neuralmind-serve.service \
+  -o ~/.config/systemd/user/neuralmind-serve.service
 # edit WorkingDirectory in both, then:
 systemctl --user daemon-reload
 systemctl --user enable --now neuralmind-watch neuralmind-serve
 systemctl --user status neuralmind-watch neuralmind-serve
 
-# macOS: install + verify launchd plists
-cp scripts/launchd/com.neuralmind.{watch,serve}.plist ~/Library/LaunchAgents/
+# macOS: install + verify launchd plists (no repo checkout needed)
+curl -fsSL https://raw.githubusercontent.com/dfrostar/neuralmind/main/scripts/launchd/com.neuralmind.watch.plist \
+  -o ~/Library/LaunchAgents/com.neuralmind.watch.plist
+curl -fsSL https://raw.githubusercontent.com/dfrostar/neuralmind/main/scripts/launchd/com.neuralmind.serve.plist \
+  -o ~/Library/LaunchAgents/com.neuralmind.serve.plist
 # edit WorkingDirectory + log paths, then:
-launchctl load -w ~/Library/LaunchAgents/com.neuralmind.{watch,serve}.plist
+launchctl load -w ~/Library/LaunchAgents/com.neuralmind.watch.plist
+launchctl load -w ~/Library/LaunchAgents/com.neuralmind.serve.plist
 launchctl list | grep com.neuralmind
 ```
+
+If you have a repo checkout, `cp scripts/systemd/...` / `cp scripts/launchd/...`
+work as drop-in equivalents for the `curl` lines above.
 
 Full per-platform walkthrough in
 [`docs/use-cases/always-on.md`](docs/use-cases/always-on.md).

--- a/RELEASE_NOTES_v0.8.0.md
+++ b/RELEASE_NOTES_v0.8.0.md
@@ -1,0 +1,142 @@
+# NeuralMind v0.8.0 — always-on
+
+**Release Date:** May 2026
+
+## TL;DR
+
+`neuralmind watch` and `neuralmind serve` are now first-class
+production processes. Committed systemd, launchd, and Windows Task
+Scheduler templates keep both running across reboots and crashes.
+`neuralmind serve` exposes a `/healthz` endpoint so Docker
+`HEALTHCHECK` and systemd `ExecStartPost` can probe it without
+threading a session token.
+
+Distribution (v0.7.0) made NeuralMind reachable. Always-on (v0.8.0)
+makes it persistent — the synapse store accumulates 24/7 whether
+you're at the keyboard or not, and the graph view canvas is always at
+`http://127.0.0.1:8765/`.
+
+No migration. Same `graph.json`, same `synapses.db`, same hooks. New
+files are additive; existing CLI behaviour is unchanged.
+
+> Note on cross-doc rollout: the marketing artifacts (LinkedIn drafts,
+> NotebookLM v0.8 pack, screencast script, About-page + wiki Home
+> callouts) are deferred to a follow-up pass. This release is the code
+> + minimum docs. Frame the marketing arc once you've seen which parts
+> users adopt.
+
+## What's new
+
+### Service templates
+
+- **`scripts/systemd/neuralmind-watch.service`** — user-scope unit for
+  the file watcher. Restart-on-failure, SIGTERM-clean shutdown, basic
+  hardening (`NoNewPrivileges`, `PrivateTmp`, `ProtectSystem=strict`).
+- **`scripts/systemd/neuralmind-serve.service`** — same for the graph
+  view, plus an `ExecStartPost` that polls `/healthz` for up to 5
+  seconds before declaring the unit ready.
+- **`scripts/launchd/com.neuralmind.watch.plist`** — macOS user agent.
+  `RunAtLoad` + `KeepAlive` + `ThrottleInterval` so a crash loop
+  doesn't burn CPU.
+- **`scripts/launchd/com.neuralmind.serve.plist`** — same for the
+  graph view.
+
+All four are templates — they ship with placeholder
+`WorkingDirectory` / `ProgramArguments` paths the user edits before
+loading. The
+[always-on walkthrough](docs/use-cases/always-on.md) covers the edit
++ enable + verify loop per platform.
+
+### `/healthz` on `neuralmind serve`
+
+New stdlib-only endpoint, unauthenticated, returns:
+
+```json
+{"status": "ok", "version": "0.8.0"}
+```
+
+The route is intentionally before the session-token gate so a fresh
+container or systemd unit can probe it without threading auth. Three
+new tests in `tests/test_server.py` lock in the behaviour (200 status,
+correct version, no `Set-Cookie` header).
+
+### Always-on walkthrough
+
+New page: [`docs/use-cases/always-on.md`](docs/use-cases/always-on.md).
+Per-platform install + verify + uninstall + troubleshooting for Linux
+(systemd), macOS (launchd), Windows (Task Scheduler), and Docker
+(`HEALTHCHECK`). Closes the "I want NeuralMind running across reboots
+but I don't want to figure out the unit file" gap.
+
+### Windows Task Scheduler — always-on section
+
+[`docs/wiki/Scheduling-Guide.md`](docs/wiki/Scheduling-Guide.md) gains
+an "Always-on `neuralmind watch` + `neuralmind serve`" section above
+the existing recurring-audit instructions. Two PowerShell
+`Register-ScheduledTask` blocks for the watcher and graph view, with
+the `/healthz` verification snippet.
+
+## Deferred
+
+- **Aider integration block in README.** Investigated 2026-05-17: the
+  current Aider stable does not ship MCP-client support. Will add
+  when upstream lands it.
+- **Cross-doc marketing rollout.** README hero callout, wiki Home
+  "What's New" entry, GitHub Pages, LinkedIn drafts, NotebookLM pack,
+  screencast script — all deferred to a follow-up so this release
+  ships code + minimum docs.
+
+## Behaviour controls (unchanged)
+
+| Env var | Default | Effect |
+|---|---|---|
+| `NEURALMIND_EVENT_LOG` | `1` | `0` disables the cross-process JSONL bridge. |
+| `NEURALMIND_BYPASS` | unset | `1` skips PostToolUse compression. |
+| `NEURALMIND_SYNAPSE_INJECT` | `1` | `0` skips prompt-time synapse recall. |
+| `NEURALMIND_SYNAPSE_EXPORT` | `1` | `0` skips memory export to Claude Code's auto-memory. |
+
+## Verification
+
+```bash
+# Upgrade
+pip install --upgrade neuralmind     # or pipx upgrade neuralmind / uv pip install -U
+
+# /healthz works without auth
+neuralmind serve . &
+curl -fsS http://127.0.0.1:8765/healthz
+# {"status": "ok", "version": "0.8.0"}
+
+# Linux: install + verify systemd units
+mkdir -p ~/.config/systemd/user
+cp scripts/systemd/neuralmind-{watch,serve}.service ~/.config/systemd/user/
+# edit WorkingDirectory in both, then:
+systemctl --user daemon-reload
+systemctl --user enable --now neuralmind-watch neuralmind-serve
+systemctl --user status neuralmind-watch neuralmind-serve
+
+# macOS: install + verify launchd plists
+cp scripts/launchd/com.neuralmind.{watch,serve}.plist ~/Library/LaunchAgents/
+# edit WorkingDirectory + log paths, then:
+launchctl load -w ~/Library/LaunchAgents/com.neuralmind.{watch,serve}.plist
+launchctl list | grep com.neuralmind
+```
+
+Full per-platform walkthrough in
+[`docs/use-cases/always-on.md`](docs/use-cases/always-on.md).
+
+## What's next
+
+- **v0.8.1** — marketing rollout for v0.8 (LinkedIn, NotebookLM,
+  screencast, README + wiki + Pages callouts).
+- **v0.8.x — Enterprise-Ready.** GHCR auto-build of the repo-root
+  Dockerfile, air-gapped install doc, SBOM publication on tagged
+  releases, consolidated compliance one-pager. Tracking issue:
+  [#120](https://github.com/dfrostar/neuralmind/issues/120).
+
+## Thanks
+
+The v0.7.0 install matrix made it possible to recommend a single
+"upgrade and enable a unit" path that works the same regardless of how
+the user installed NeuralMind. Without that, each install-method
+permutation would have needed its own `ExecStart` example. Small
+release; the foundations underneath did most of the work.

--- a/docs/use-cases/always-on.md
+++ b/docs/use-cases/always-on.md
@@ -9,6 +9,31 @@ Three platforms, same shape: pick the template, point it at your
 project, enable it. The templates live in [`scripts/systemd/`](../../scripts/systemd/)
 and [`scripts/launchd/`](../../scripts/launchd/) in this repo.
 
+### No checkout? Fetch the templates directly
+
+The PyPI wheel doesn't include the repo's `scripts/` directory — it
+ships only the importable `neuralmind` package. If you installed via
+`pip` / `pipx` / `uv` / Docker, pull the templates straight from
+GitHub:
+
+```bash
+# Linux — systemd
+mkdir -p ~/.config/systemd/user
+curl -fsSL https://raw.githubusercontent.com/dfrostar/neuralmind/main/scripts/systemd/neuralmind-watch.service \
+  -o ~/.config/systemd/user/neuralmind-watch.service
+curl -fsSL https://raw.githubusercontent.com/dfrostar/neuralmind/main/scripts/systemd/neuralmind-serve.service \
+  -o ~/.config/systemd/user/neuralmind-serve.service
+
+# macOS — launchd
+curl -fsSL https://raw.githubusercontent.com/dfrostar/neuralmind/main/scripts/launchd/com.neuralmind.watch.plist \
+  -o ~/Library/LaunchAgents/com.neuralmind.watch.plist
+curl -fsSL https://raw.githubusercontent.com/dfrostar/neuralmind/main/scripts/launchd/com.neuralmind.serve.plist \
+  -o ~/Library/LaunchAgents/com.neuralmind.serve.plist
+```
+
+The `cp scripts/...` commands below assume you have a repo checkout —
+substitute one of the `curl` lines above if you don't.
+
 NeuralMind ships a `/healthz` endpoint on the graph-view server
 (`GET /healthz` → `{"status": "ok", "version": "..."}`, no auth). The
 systemd unit uses it in `ExecStartPost` to fail fast if `serve` didn't
@@ -41,7 +66,12 @@ systemctl --user enable --now neuralmind-serve
 # 4. Verify both are up and /healthz responds
 systemctl --user status neuralmind-watch neuralmind-serve
 curl -fsS http://127.0.0.1:8765/healthz
-# {"status": "ok", "version": "0.7.0"}
+# {"status": "ok", "version": "0.8.0"}
+
+# The graph view canvas itself requires the per-session token. The
+# tokenized URL prints to journalctl on every startup:
+journalctl --user -u neuralmind-serve | grep -F "http://127.0.0.1:8765/"
+# (or pass --no-auth in ExecStart if you understand the implications)
 
 # 5. Tail logs
 journalctl --user -u neuralmind-watch -f
@@ -114,27 +144,31 @@ rm ~/Library/LaunchAgents/com.neuralmind.{watch,serve}.plist
 
 Run-at-startup tasks for `neuralmind watch` and `neuralmind serve`.
 
-The [Scheduling Guide](../wiki/Scheduling-Guide.md#always-on-neuralmind-watch--neuralmind-serve)
+The [Scheduling Guide](../wiki/Scheduling-Guide.md#always-on-neuralmind-watch--neuralmind-serve-v08)
 has the full PowerShell script + Task Scheduler GUI walkthrough.
 Short version:
 
 ```powershell
-# Register the always-on watcher (replaces the file polling daemon)
+# Register the always-on watcher (replaces the file polling daemon).
+# ExecutionTimeLimit = 0 disables Task Scheduler's default 72-hour cap.
 Register-ScheduledTask -TaskName "NeuralMind-Watch" `
   -Action (New-ScheduledTaskAction `
     -Execute "neuralmind" `
     -Argument "watch C:\path\to\your-project --quiet") `
   -Trigger (New-ScheduledTaskTrigger -AtLogOn) `
   -Settings (New-ScheduledTaskSettingsSet -StartWhenAvailable `
+    -ExecutionTimeLimit (New-TimeSpan -Seconds 0) `
     -RestartCount 3 -RestartInterval (New-TimeSpan -Minutes 1))
 
-# Register the always-on graph view
+# Register the always-on graph view. --no-browser keeps it from
+# spawning a browser on every login.
 Register-ScheduledTask -TaskName "NeuralMind-Serve" `
   -Action (New-ScheduledTaskAction `
     -Execute "neuralmind" `
-    -Argument "serve C:\path\to\your-project --port 8765") `
+    -Argument "serve C:\path\to\your-project --port 8765 --no-browser") `
   -Trigger (New-ScheduledTaskTrigger -AtLogOn) `
   -Settings (New-ScheduledTaskSettingsSet -StartWhenAvailable `
+    -ExecutionTimeLimit (New-TimeSpan -Seconds 0) `
     -RestartCount 3 -RestartInterval (New-TimeSpan -Minutes 1))
 
 # Verify
@@ -149,15 +183,23 @@ Invoke-WebRequest -UseBasicParsing http://127.0.0.1:8765/healthz
 If you run NeuralMind via the repo-root Dockerfile, add a `HEALTHCHECK`
 that probes `/healthz`:
 
+The repo-root `Dockerfile` is `python:slim`-based and does not
+include `curl`. Use a stdlib Python probe instead so the HEALTHCHECK
+works without adding a package:
+
 ```dockerfile
-HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
-  CMD curl -fsS http://127.0.0.1:8765/healthz || exit 1
+HEALTHCHECK --interval=30s --timeout=3s --start-period=60s --retries=3 \
+  CMD python -c "import urllib.request, sys; r = urllib.request.urlopen('http://127.0.0.1:8765/healthz', timeout=2); sys.exit(0 if r.status == 200 else 1)" || exit 1
 ```
 
+`--start-period=60s` matches the systemd template's readiness window
+— `neuralmind serve` builds the embedding index before binding the
+HTTP socket, and first runs on large projects can take a while.
+
 The shipped Dockerfile doesn't bake this in by default because the
-default container command is `neuralmind --help`, not `serve`. Add the
-directive in your downstream image when you do run `serve` as the
-container entrypoint.
+default container command is `neuralmind --help`, not `serve`. Add
+the directive in your downstream image when you do run `serve` as
+the container entrypoint.
 
 ---
 

--- a/docs/use-cases/always-on.md
+++ b/docs/use-cases/always-on.md
@@ -1,0 +1,233 @@
+# Run NeuralMind as a service
+
+> Goal: `neuralmind watch` and `neuralmind serve` survive reboots,
+> crashes, and tmux closes. The synapse layer accumulates 24/7 instead
+> of only while you're actively coding, and the graph view canvas is
+> always at `http://127.0.0.1:8765/` when you want to look at it.
+
+Three platforms, same shape: pick the template, point it at your
+project, enable it. The templates live in [`scripts/systemd/`](../../scripts/systemd/)
+and [`scripts/launchd/`](../../scripts/launchd/) in this repo.
+
+NeuralMind ships a `/healthz` endpoint on the graph-view server
+(`GET /healthz` → `{"status": "ok", "version": "..."}`, no auth). The
+systemd unit uses it in `ExecStartPost` to fail fast if `serve` didn't
+come up; Docker `HEALTHCHECK` and any external monitor can probe the
+same endpoint.
+
+---
+
+## Linux — systemd user units
+
+User-scope (no root). The unit lives in `~/.config/systemd/user/` and
+is enabled per-login user.
+
+```bash
+# 1. Copy the templates
+mkdir -p ~/.config/systemd/user
+cp scripts/systemd/neuralmind-watch.service ~/.config/systemd/user/
+cp scripts/systemd/neuralmind-serve.service ~/.config/systemd/user/
+
+# 2. Edit the WorkingDirectory line in both files to your project path:
+#    WorkingDirectory=%h/your-project
+$EDITOR ~/.config/systemd/user/neuralmind-watch.service
+$EDITOR ~/.config/systemd/user/neuralmind-serve.service
+
+# 3. Enable + start
+systemctl --user daemon-reload
+systemctl --user enable --now neuralmind-watch
+systemctl --user enable --now neuralmind-serve
+
+# 4. Verify both are up and /healthz responds
+systemctl --user status neuralmind-watch neuralmind-serve
+curl -fsS http://127.0.0.1:8765/healthz
+# {"status": "ok", "version": "0.7.0"}
+
+# 5. Tail logs
+journalctl --user -u neuralmind-watch -f
+journalctl --user -u neuralmind-serve -f
+```
+
+User units don't run when no user session is active by default. If
+you need it across logouts, enable lingering:
+
+```bash
+sudo loginctl enable-linger "$USER"
+```
+
+To uninstall:
+
+```bash
+systemctl --user disable --now neuralmind-watch neuralmind-serve
+rm ~/.config/systemd/user/neuralmind-{watch,serve}.service
+```
+
+---
+
+## macOS — launchd user agents
+
+The plists live in `~/Library/LaunchAgents/` and run under your user
+session — RunAtLoad + KeepAlive together mean "start at login, restart
+if it crashes."
+
+```bash
+# 1. Copy the templates
+cp scripts/launchd/com.neuralmind.watch.plist ~/Library/LaunchAgents/
+cp scripts/launchd/com.neuralmind.serve.plist ~/Library/LaunchAgents/
+
+# 2. Edit both files — replace YOUR_USERNAME and the project path:
+#    WorkingDirectory → /Users/YOUR_USERNAME/your-project
+#    StandardOutPath  → /Users/YOUR_USERNAME/Library/Logs/...
+#    StandardErrorPath → /Users/YOUR_USERNAME/Library/Logs/...
+$EDITOR ~/Library/LaunchAgents/com.neuralmind.watch.plist
+$EDITOR ~/Library/LaunchAgents/com.neuralmind.serve.plist
+
+# 3. Load
+launchctl load -w ~/Library/LaunchAgents/com.neuralmind.watch.plist
+launchctl load -w ~/Library/LaunchAgents/com.neuralmind.serve.plist
+
+# 4. Verify
+launchctl list | grep com.neuralmind
+curl -fsS http://127.0.0.1:8765/healthz
+
+# 5. Tail logs
+tail -f ~/Library/Logs/neuralmind-watch.out.log
+tail -f ~/Library/Logs/neuralmind-serve.out.log
+```
+
+The `which neuralmind` path matters — if you installed via `pipx`,
+your binary is in `~/.local/bin/neuralmind`, not `/usr/local/bin/neuralmind`.
+Update the `ProgramArguments` array's first element accordingly. If
+you use `pyenv` or a per-project venv, point at the absolute path of
+that venv's `neuralmind` binary, not the system one.
+
+To unload:
+
+```bash
+launchctl unload -w ~/Library/LaunchAgents/com.neuralmind.{watch,serve}.plist
+rm ~/Library/LaunchAgents/com.neuralmind.{watch,serve}.plist
+```
+
+---
+
+## Windows — Task Scheduler
+
+Run-at-startup tasks for `neuralmind watch` and `neuralmind serve`.
+
+The [Scheduling Guide](../wiki/Scheduling-Guide.md#always-on-neuralmind-watch--neuralmind-serve)
+has the full PowerShell script + Task Scheduler GUI walkthrough.
+Short version:
+
+```powershell
+# Register the always-on watcher (replaces the file polling daemon)
+Register-ScheduledTask -TaskName "NeuralMind-Watch" `
+  -Action (New-ScheduledTaskAction `
+    -Execute "neuralmind" `
+    -Argument "watch C:\path\to\your-project --quiet") `
+  -Trigger (New-ScheduledTaskTrigger -AtLogOn) `
+  -Settings (New-ScheduledTaskSettingsSet -StartWhenAvailable `
+    -RestartCount 3 -RestartInterval (New-TimeSpan -Minutes 1))
+
+# Register the always-on graph view
+Register-ScheduledTask -TaskName "NeuralMind-Serve" `
+  -Action (New-ScheduledTaskAction `
+    -Execute "neuralmind" `
+    -Argument "serve C:\path\to\your-project --port 8765") `
+  -Trigger (New-ScheduledTaskTrigger -AtLogOn) `
+  -Settings (New-ScheduledTaskSettingsSet -StartWhenAvailable `
+    -RestartCount 3 -RestartInterval (New-TimeSpan -Minutes 1))
+
+# Verify
+Get-ScheduledTask NeuralMind-*
+Invoke-WebRequest -UseBasicParsing http://127.0.0.1:8765/healthz
+```
+
+---
+
+## Docker — HEALTHCHECK
+
+If you run NeuralMind via the repo-root Dockerfile, add a `HEALTHCHECK`
+that probes `/healthz`:
+
+```dockerfile
+HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
+  CMD curl -fsS http://127.0.0.1:8765/healthz || exit 1
+```
+
+The shipped Dockerfile doesn't bake this in by default because the
+default container command is `neuralmind --help`, not `serve`. Add the
+directive in your downstream image when you do run `serve` as the
+container entrypoint.
+
+---
+
+## What "always-on" actually buys you
+
+The synapse store is shared across all processes that touch the same
+project. With `neuralmind watch` running 24/7:
+
+- **Every file save** while you're working (editor, git operations,
+  formatters, generators) becomes a `file_activity` event that the
+  graph view's canvas pulses on and the synapse layer reinforces.
+- **Every agent tool call** from any agent (Claude Code, Cursor,
+  Cline, Continue, OpenClaw, Hermes-Agent, Agent Zero) that points at
+  the same project reinforces the same synapse store.
+- The brain accumulates whether you're at the keyboard or not.
+
+With `neuralmind serve` running 24/7:
+
+- **`http://127.0.0.1:8765/`** is always there. No "wait, I need to
+  start the canvas first" friction when you want to debug a retrieval.
+- The canvas shows the union of every agent's activity — your editor,
+  every running session, the watcher daemon — in real time.
+
+Pair with the v0.6.0 [multi-agent walkthrough](multi-agent.md) for the
+full "one brain, many agents" story.
+
+---
+
+## Troubleshooting
+
+### `/healthz` returns 404
+
+You're on NeuralMind < v0.8. The endpoint shipped in v0.8. Upgrade:
+
+```bash
+pip install --upgrade neuralmind     # or pipx upgrade / uv pip install -U
+```
+
+For the systemd unit: remove the `ExecStartPost` line or drop the
+probe loop until you upgrade.
+
+### systemd unit starts then immediately exits
+
+Check the logs for the root cause:
+
+```bash
+journalctl --user -u neuralmind-watch --since "5 minutes ago"
+```
+
+Common causes:
+- `neuralmind` binary not on the PATH for the systemd `Service` env.
+  Pass an explicit absolute path in `ExecStart` (e.g.
+  `/home/$USER/.local/bin/neuralmind`).
+- `WorkingDirectory` doesn't exist or doesn't have a `graphify-out/`
+  yet. Run `graphify update .` and `neuralmind build .` in the
+  project first.
+
+### launchd "Could not find service"
+
+You loaded the plist with the wrong path or the file has a typo. Try:
+
+```bash
+plutil -lint ~/Library/LaunchAgents/com.neuralmind.watch.plist
+```
+
+If `plutil` reports OK and `launchctl load -w ...` still fails, check
+that the `Label` inside the plist matches the filename
+(`com.neuralmind.watch`).
+
+### Graph view canvas is blank
+
+Check `/healthz` first — if that returns OK, the server is up but the
+graph isn't indexed yet. Run `neuralmind build .` in the project.

--- a/docs/wiki/Scheduling-Guide.md
+++ b/docs/wiki/Scheduling-Guide.md
@@ -90,22 +90,27 @@ register two At-Logon scheduled tasks so the watcher and graph view come
 back automatically after every reboot or crash.
 
 ```powershell
-# Always-on synapse watcher
+# Always-on synapse watcher.
+# ExecutionTimeLimit = 0 disables Task Scheduler's default 72-hour cap,
+# which would otherwise stop a continuously-running task.
 Register-ScheduledTask -TaskName "NeuralMind-Watch" `
   -Action (New-ScheduledTaskAction `
     -Execute "neuralmind" `
     -Argument "watch C:\path\to\your-project --quiet") `
   -Trigger (New-ScheduledTaskTrigger -AtLogOn) `
   -Settings (New-ScheduledTaskSettingsSet -StartWhenAvailable `
+    -ExecutionTimeLimit (New-TimeSpan -Seconds 0) `
     -RestartCount 3 -RestartInterval (New-TimeSpan -Minutes 1))
 
-# Always-on graph view (http://127.0.0.1:8765/)
+# Always-on graph view (tokenized URL printed to the task's stdout).
+# --no-browser stops it from spawning a browser on every login.
 Register-ScheduledTask -TaskName "NeuralMind-Serve" `
   -Action (New-ScheduledTaskAction `
     -Execute "neuralmind" `
-    -Argument "serve C:\path\to\your-project --port 8765") `
+    -Argument "serve C:\path\to\your-project --port 8765 --no-browser") `
   -Trigger (New-ScheduledTaskTrigger -AtLogOn) `
   -Settings (New-ScheduledTaskSettingsSet -StartWhenAvailable `
+    -ExecutionTimeLimit (New-TimeSpan -Seconds 0) `
     -RestartCount 3 -RestartInterval (New-TimeSpan -Minutes 1))
 
 # Verify both

--- a/docs/wiki/Scheduling-Guide.md
+++ b/docs/wiki/Scheduling-Guide.md
@@ -80,6 +80,56 @@ Linux/macOS:
 
 ## Windows Task Scheduler
 
+### Always-on `neuralmind watch` + `neuralmind serve` *(v0.8)*
+
+The Linux/macOS analogues live in [`scripts/systemd/`](../../scripts/systemd/)
+and [`scripts/launchd/`](../../scripts/launchd/); the full cross-platform
+walkthrough is at
+[`docs/use-cases/always-on.md`](../use-cases/always-on.md). On Windows,
+register two At-Logon scheduled tasks so the watcher and graph view come
+back automatically after every reboot or crash.
+
+```powershell
+# Always-on synapse watcher
+Register-ScheduledTask -TaskName "NeuralMind-Watch" `
+  -Action (New-ScheduledTaskAction `
+    -Execute "neuralmind" `
+    -Argument "watch C:\path\to\your-project --quiet") `
+  -Trigger (New-ScheduledTaskTrigger -AtLogOn) `
+  -Settings (New-ScheduledTaskSettingsSet -StartWhenAvailable `
+    -RestartCount 3 -RestartInterval (New-TimeSpan -Minutes 1))
+
+# Always-on graph view (http://127.0.0.1:8765/)
+Register-ScheduledTask -TaskName "NeuralMind-Serve" `
+  -Action (New-ScheduledTaskAction `
+    -Execute "neuralmind" `
+    -Argument "serve C:\path\to\your-project --port 8765") `
+  -Trigger (New-ScheduledTaskTrigger -AtLogOn) `
+  -Settings (New-ScheduledTaskSettingsSet -StartWhenAvailable `
+    -RestartCount 3 -RestartInterval (New-TimeSpan -Minutes 1))
+
+# Verify both
+Get-ScheduledTask NeuralMind-*
+Invoke-WebRequest -UseBasicParsing http://127.0.0.1:8765/healthz
+# StatusCode 200, JSON body: {"status": "ok", "version": "0.8.0"}
+```
+
+`Invoke-WebRequest` calls the unauthenticated `/healthz` endpoint that
+shipped in v0.8 — the same probe Docker `HEALTHCHECK` and Linux
+`systemd ExecStartPost` use.
+
+Stop and remove:
+
+```powershell
+Unregister-ScheduledTask -TaskName NeuralMind-Watch -Confirm:$false
+Unregister-ScheduledTask -TaskName NeuralMind-Serve -Confirm:$false
+```
+
+The Recurring Audit / Benchmark schedule below remains the right shape
+for the *batch* job (run nightly, log to a file, exit). Use that for
+periodic CI-style audits; use the always-on tasks above for the live
+synapse + graph view.
+
 ### PowerShell Script (Recommended)
 
 **Step 1: Create the script** at a persistent location like `C:\scripts\run-neuralmind.ps1`:

--- a/neuralmind/server.py
+++ b/neuralmind/server.py
@@ -304,6 +304,16 @@ class _Handler(BaseHTTPRequestHandler):
     def do_GET(self) -> None:  # noqa: N802 - http.server API
         parsed = urlparse(self.path)
         route = parsed.path
+
+        # /healthz is intentionally unauthenticated so Docker HEALTHCHECK
+        # and systemd ExecStartPost can probe a fresh container without
+        # threading a session token. Returns nothing sensitive.
+        if route == "/healthz":
+            from . import __version__
+
+            self._send_json({"status": "ok", "version": __version__})
+            return
+
         ok, new_cookie = self._check_auth(parsed)
         if not ok:
             self._deny(route)

--- a/scripts/launchd/com.neuralmind.serve.plist
+++ b/scripts/launchd/com.neuralmind.serve.plist
@@ -3,8 +3,12 @@
 NeuralMind graph-view server — macOS launchd user agent.
 
 Keeps `neuralmind serve` reachable across logins. Bound to 127.0.0.1
-by default. Use `--host 0.0.0.0` only if you understand the security
-implications (see docs/SECURITY-GUIDE.md).
+by default. To bind a non-loopback address, edit ProgramArguments and
+use the host override from `neuralmind serve` `'help'`; read
+docs/SECURITY-GUIDE.md first.
+
+(Avoid double hyphens in this XML comment block — they are forbidden
+by the XML spec and break plutil and launchctl load.)
 
 Install (user scope — no sudo needed):
   cp scripts/launchd/com.neuralmind.serve.plist ~/Library/LaunchAgents/
@@ -38,6 +42,7 @@ Docs: https://github.com/dfrostar/neuralmind/blob/main/docs/use-cases/always-on.
     <string>.</string>
     <string>--port</string>
     <string>8765</string>
+    <string>--no-browser</string>
   </array>
 
   <key>WorkingDirectory</key>

--- a/scripts/launchd/com.neuralmind.serve.plist
+++ b/scripts/launchd/com.neuralmind.serve.plist
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+NeuralMind graph-view server — macOS launchd user agent.
+
+Keeps `neuralmind serve` reachable across logins. Bound to 127.0.0.1
+by default. Use `--host 0.0.0.0` only if you understand the security
+implications (see docs/SECURITY-GUIDE.md).
+
+Install (user scope — no sudo needed):
+  cp scripts/launchd/com.neuralmind.serve.plist ~/Library/LaunchAgents/
+  # Edit WorkingDirectory and the project path below, then:
+  launchctl load -w ~/Library/LaunchAgents/com.neuralmind.serve.plist
+
+Verify:
+  launchctl list | grep com.neuralmind.serve
+  curl -fsS http://127.0.0.1:8765/healthz
+  tail -f ~/Library/Logs/neuralmind-serve.out.log
+
+Stop / unload:
+  launchctl unload -w ~/Library/LaunchAgents/com.neuralmind.serve.plist
+
+This is a TEMPLATE — change WorkingDirectory and the project path in
+ProgramArguments. The two log paths under ~/Library/Logs are created
+automatically by launchd.
+
+Docs: https://github.com/dfrostar/neuralmind/blob/main/docs/use-cases/always-on.md
+-->
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.neuralmind.serve</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>/usr/local/bin/neuralmind</string>
+    <string>serve</string>
+    <string>.</string>
+    <string>--port</string>
+    <string>8765</string>
+  </array>
+
+  <key>WorkingDirectory</key>
+  <string>/Users/YOUR_USERNAME/your-project</string>
+
+  <key>RunAtLoad</key>
+  <true/>
+
+  <key>KeepAlive</key>
+  <dict>
+    <key>SuccessfulExit</key>
+    <false/>
+    <key>Crashed</key>
+    <true/>
+  </dict>
+
+  <key>ThrottleInterval</key>
+  <integer>10</integer>
+
+  <key>StandardOutPath</key>
+  <string>/Users/YOUR_USERNAME/Library/Logs/neuralmind-serve.out.log</string>
+
+  <key>StandardErrorPath</key>
+  <string>/Users/YOUR_USERNAME/Library/Logs/neuralmind-serve.err.log</string>
+
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key>
+    <string>/usr/local/bin:/usr/bin:/bin</string>
+  </dict>
+</dict>
+</plist>

--- a/scripts/launchd/com.neuralmind.watch.plist
+++ b/scripts/launchd/com.neuralmind.watch.plist
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+NeuralMind file-watch daemon — macOS launchd user agent.
+
+Keeps `neuralmind watch` running across logins and crashes. Coalesces
+file edits into synapse + file_activity events that the always-on
+`neuralmind serve` graph view pulses on.
+
+Install (user scope — no sudo needed):
+  cp scripts/launchd/com.neuralmind.watch.plist ~/Library/LaunchAgents/
+  # Edit WorkingDirectory and the ProgramArguments path below to point
+  # at your project, then:
+  launchctl load -w ~/Library/LaunchAgents/com.neuralmind.watch.plist
+
+Verify:
+  launchctl list | grep com.neuralmind.watch     # should show PID + status
+  tail -f ~/Library/Logs/neuralmind-watch.out.log
+
+Stop / unload:
+  launchctl unload -w ~/Library/LaunchAgents/com.neuralmind.watch.plist
+
+This is a TEMPLATE — change WorkingDirectory and the project path in
+ProgramArguments. The two log paths under ~/Library/Logs are created
+automatically by launchd.
+
+Docs: https://github.com/dfrostar/neuralmind/blob/main/docs/use-cases/always-on.md
+-->
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.neuralmind.watch</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>/usr/local/bin/neuralmind</string>
+    <string>watch</string>
+    <string>.</string>
+    <string>--quiet</string>
+  </array>
+
+  <key>WorkingDirectory</key>
+  <string>/Users/YOUR_USERNAME/your-project</string>
+
+  <key>RunAtLoad</key>
+  <true/>
+
+  <key>KeepAlive</key>
+  <dict>
+    <key>SuccessfulExit</key>
+    <false/>
+    <key>Crashed</key>
+    <true/>
+  </dict>
+
+  <key>ThrottleInterval</key>
+  <integer>10</integer>
+
+  <key>StandardOutPath</key>
+  <string>/Users/YOUR_USERNAME/Library/Logs/neuralmind-watch.out.log</string>
+
+  <key>StandardErrorPath</key>
+  <string>/Users/YOUR_USERNAME/Library/Logs/neuralmind-watch.err.log</string>
+
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key>
+    <string>/usr/local/bin:/usr/bin:/bin</string>
+    <!--
+    <key>NEURALMIND_EVENT_LOG</key>
+    <string>1</string>
+    -->
+  </dict>
+</dict>
+</plist>

--- a/scripts/systemd/neuralmind-serve.service
+++ b/scripts/systemd/neuralmind-serve.service
@@ -38,11 +38,13 @@ RestartSec=5
 KillSignal=SIGTERM
 TimeoutStopSec=10
 
-# Hardening
+# Hardening. See neuralmind-watch.service for the rationale on
+# ReadWritePaths=%h (ProtectHome doesn't accept "read-write" — valid
+# values are true/false/read-only/tmpfs).
 NoNewPrivileges=true
 PrivateTmp=true
 ProtectSystem=strict
-ProtectHome=read-write
+ReadWritePaths=%h
 
 # Environment=NEURALMIND_EVENT_LOG=1
 

--- a/scripts/systemd/neuralmind-serve.service
+++ b/scripts/systemd/neuralmind-serve.service
@@ -2,20 +2,25 @@
 #
 # Keeps `neuralmind serve` reachable across reboots. The graph view is
 # bound to 127.0.0.1 by default; the unit below exposes only loopback.
-# Set --host 0.0.0.0 in ExecStart only if you understand the security
-# implications (see docs/SECURITY-GUIDE.md).
+# To bind a non-loopback address, edit ExecStart — see
+# docs/SECURITY-GUIDE.md before doing so.
 #
 # Install (user scope — no root needed):
 #   mkdir -p ~/.config/systemd/user
 #   cp scripts/systemd/neuralmind-serve.service ~/.config/systemd/user/
-#   # Edit WorkingDirectory and the --port flag below if needed, then:
+#   # Edit WorkingDirectory and the port flag below if needed, then:
 #   systemctl --user daemon-reload
 #   systemctl --user enable --now neuralmind-serve
+#
+# For reboot survival without logging in, enable lingering once:
+#   sudo loginctl enable-linger "$USER"
 #
 # Verify:
 #   systemctl --user status neuralmind-serve
 #   curl -fsS http://127.0.0.1:8765/healthz
 #   journalctl --user -u neuralmind-serve -f
+#   # The full tokenized URL prints to journalctl on startup;
+#   # `neuralmind serve` requires the per-session token by default.
 #
 # Stop / disable:
 #   systemctl --user disable --now neuralmind-serve
@@ -31,8 +36,13 @@ After=network.target
 [Service]
 Type=simple
 WorkingDirectory=%h/your-project
-ExecStart=/usr/local/bin/neuralmind serve . --port 8765
-ExecStartPost=/bin/sh -c 'for i in $(seq 1 20); do curl -fsS http://127.0.0.1:8765/healthz >/dev/null && exit 0; sleep 0.25; done; exit 1'
+ExecStart=/usr/local/bin/neuralmind serve . --port 8765 --no-browser
+# Readiness probe — gives `neuralmind serve` up to 60 seconds to come
+# up. `serve` builds the embedding index before binding the HTTP
+# socket; first runs and large projects can take a while. Remove this
+# line if you're on a tight-startup-window deploy and prefer to let
+# the unit report ready immediately.
+ExecStartPost=/bin/sh -c 'for i in $(seq 1 240); do curl -fsS http://127.0.0.1:8765/healthz >/dev/null && exit 0; sleep 0.25; done; exit 1'
 Restart=on-failure
 RestartSec=5
 KillSignal=SIGTERM

--- a/scripts/systemd/neuralmind-serve.service
+++ b/scripts/systemd/neuralmind-serve.service
@@ -1,0 +1,50 @@
+# NeuralMind graph-view server — user-scope systemd unit.
+#
+# Keeps `neuralmind serve` reachable across reboots. The graph view is
+# bound to 127.0.0.1 by default; the unit below exposes only loopback.
+# Set --host 0.0.0.0 in ExecStart only if you understand the security
+# implications (see docs/SECURITY-GUIDE.md).
+#
+# Install (user scope — no root needed):
+#   mkdir -p ~/.config/systemd/user
+#   cp scripts/systemd/neuralmind-serve.service ~/.config/systemd/user/
+#   # Edit WorkingDirectory and the --port flag below if needed, then:
+#   systemctl --user daemon-reload
+#   systemctl --user enable --now neuralmind-serve
+#
+# Verify:
+#   systemctl --user status neuralmind-serve
+#   curl -fsS http://127.0.0.1:8765/healthz
+#   journalctl --user -u neuralmind-serve -f
+#
+# Stop / disable:
+#   systemctl --user disable --now neuralmind-serve
+#
+# This is a TEMPLATE — change WorkingDirectory and ExecStart to your
+# project. The graph view embeds a per-session auth token in URLs.
+
+[Unit]
+Description=NeuralMind graph-view server
+Documentation=https://github.com/dfrostar/neuralmind/blob/main/docs/use-cases/always-on.md
+After=network.target
+
+[Service]
+Type=simple
+WorkingDirectory=%h/your-project
+ExecStart=/usr/local/bin/neuralmind serve . --port 8765
+ExecStartPost=/bin/sh -c 'for i in $(seq 1 20); do curl -fsS http://127.0.0.1:8765/healthz >/dev/null && exit 0; sleep 0.25; done; exit 1'
+Restart=on-failure
+RestartSec=5
+KillSignal=SIGTERM
+TimeoutStopSec=10
+
+# Hardening
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=strict
+ProtectHome=read-write
+
+# Environment=NEURALMIND_EVENT_LOG=1
+
+[Install]
+WantedBy=default.target

--- a/scripts/systemd/neuralmind-watch.service
+++ b/scripts/systemd/neuralmind-watch.service
@@ -11,6 +11,9 @@
 #   systemctl --user daemon-reload
 #   systemctl --user enable --now neuralmind-watch
 #
+# For reboot survival without logging in, enable lingering once:
+#   sudo loginctl enable-linger "$USER"
+#
 # Verify:
 #   systemctl --user status neuralmind-watch
 #   journalctl --user -u neuralmind-watch -f
@@ -19,9 +22,11 @@
 #   systemctl --user disable --now neuralmind-watch
 #
 # This is a TEMPLATE — change WorkingDirectory and ExecStart to point
-# at your project. Multiple projects? Copy the file with a suffix:
-#   cp neuralmind-watch.service ~/.config/systemd/user/neuralmind-watch@.service
-# and use the @<project> instance form.
+# at your project. Multiple projects? Copy the file once per project
+# with a distinct name (e.g. neuralmind-watch-projA.service,
+# neuralmind-watch-projB.service) and edit each one's WorkingDirectory.
+# This template doesn't use systemd's %i instance suffix; convert it
+# yourself if you want one unit file with @<project> instance support.
 
 [Unit]
 Description=NeuralMind file watcher (synapse activity capture)

--- a/scripts/systemd/neuralmind-watch.service
+++ b/scripts/systemd/neuralmind-watch.service
@@ -1,0 +1,52 @@
+# NeuralMind file-watch daemon — user-scope systemd unit.
+#
+# Keeps `neuralmind watch` running across reboots and crashes. Coalesces
+# file edits into synapse + file_activity events that the always-on
+# `neuralmind serve` graph view pulses on.
+#
+# Install (user scope — no root needed):
+#   mkdir -p ~/.config/systemd/user
+#   cp scripts/systemd/neuralmind-watch.service ~/.config/systemd/user/
+#   # Edit WorkingDirectory below to your project path, then:
+#   systemctl --user daemon-reload
+#   systemctl --user enable --now neuralmind-watch
+#
+# Verify:
+#   systemctl --user status neuralmind-watch
+#   journalctl --user -u neuralmind-watch -f
+#
+# Stop / disable:
+#   systemctl --user disable --now neuralmind-watch
+#
+# This is a TEMPLATE — change WorkingDirectory and ExecStart to point
+# at your project. Multiple projects? Copy the file with a suffix:
+#   cp neuralmind-watch.service ~/.config/systemd/user/neuralmind-watch@.service
+# and use the @<project> instance form.
+
+[Unit]
+Description=NeuralMind file watcher (synapse activity capture)
+Documentation=https://github.com/dfrostar/neuralmind/blob/main/docs/use-cases/always-on.md
+After=network.target
+
+[Service]
+Type=simple
+WorkingDirectory=%h/your-project
+ExecStart=/usr/local/bin/neuralmind watch . --quiet
+Restart=on-failure
+RestartSec=5
+# `neuralmind watch` is a long-running poll loop; SIGTERM is enough.
+KillSignal=SIGTERM
+TimeoutStopSec=10
+
+# Hardening — adjust if you mount your project on a read-only filesystem.
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=strict
+ProtectHome=read-write
+
+# Environment toggles (see neuralmind docs):
+# Environment=NEURALMIND_EVENT_LOG=1
+# Environment=NEURALMIND_SYNAPSE_INJECT=1
+
+[Install]
+WantedBy=default.target

--- a/scripts/systemd/neuralmind-watch.service
+++ b/scripts/systemd/neuralmind-watch.service
@@ -38,11 +38,16 @@ RestartSec=5
 KillSignal=SIGTERM
 TimeoutStopSec=10
 
-# Hardening — adjust if you mount your project on a read-only filesystem.
+# Hardening. ProtectSystem=strict makes /, /usr, /boot, /etc read-only;
+# `neuralmind watch` only needs to write under the project's .neuralmind/
+# state directory, which we allowlist explicitly via ReadWritePaths.
+# (ProtectHome only accepts true/false/read-only/tmpfs — we don't set it
+# here so $HOME stays writable; the explicit ReadWritePaths is what
+# actually documents intent.)
 NoNewPrivileges=true
 PrivateTmp=true
 ProtectSystem=strict
-ProtectHome=read-write
+ReadWritePaths=%h
 
 # Environment toggles (see neuralmind docs):
 # Environment=NEURALMIND_EVENT_LOG=1

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -187,10 +187,18 @@ def test_healthz_does_not_require_auth(tmp_path):
 
 
 def test_healthz_sets_no_cookie(tmp_path):
-    """/healthz should not start a session — no Set-Cookie header.
-    Avoids polluting the cookie jar of monitoring clients."""
+    """/healthz must not start a session — no Set-Cookie header. Covers
+    both auth-disabled and auth-enabled paths so a regression that
+    starts a cookie only when auth is configured can't slip through."""
     fake_mind = SimpleNamespace(recent_queries=lambda n=20: [])
+
+    # Auth disabled.
     with _running_server(fake_mind) as base:
+        with urllib.request.urlopen(base + "/healthz", timeout=5) as resp:
+            assert resp.getheader("Set-Cookie") is None
+
+    # Auth enabled — /healthz must still skip the cookie path entirely.
+    with _running_server(fake_mind, auth_token="secret-token") as base:
         with urllib.request.urlopen(base + "/healthz", timeout=5) as resp:
             assert resp.getheader("Set-Cookie") is None
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -159,6 +159,42 @@ def _running_server(mind, **handler_overrides):
             setattr(_Handler, k, v)
 
 
+def test_healthz_returns_ok_and_version(tmp_path):
+    """/healthz returns 200 with status=ok and the package version.
+    Docker HEALTHCHECK and systemd ExecStartPost rely on this shape."""
+    import neuralmind
+
+    fake_mind = SimpleNamespace(recent_queries=lambda n=20: [])
+    with _running_server(fake_mind) as base:
+        with urllib.request.urlopen(base + "/healthz", timeout=5) as resp:
+            assert resp.status == 200
+            assert resp.getheader("Content-Type", "").startswith("application/json")
+            data = json.loads(resp.read())
+    assert data == {"status": "ok", "version": neuralmind.__version__}
+
+
+def test_healthz_does_not_require_auth(tmp_path):
+    """/healthz must bypass the session-token gate so a fresh container
+    can be probed by Docker HEALTHCHECK without threading auth."""
+    fake_mind = SimpleNamespace(recent_queries=lambda n=20: [])
+    # Set a real auth token; any other route would 401/302 without the
+    # token cookie. /healthz must succeed anyway.
+    with _running_server(fake_mind, auth_token="secret-token") as base:
+        with urllib.request.urlopen(base + "/healthz", timeout=5) as resp:
+            assert resp.status == 200
+            data = json.loads(resp.read())
+    assert data["status"] == "ok"
+
+
+def test_healthz_sets_no_cookie(tmp_path):
+    """/healthz should not start a session — no Set-Cookie header.
+    Avoids polluting the cookie jar of monitoring clients."""
+    fake_mind = SimpleNamespace(recent_queries=lambda n=20: [])
+    with _running_server(fake_mind) as base:
+        with urllib.request.urlopen(base + "/healthz", timeout=5) as resp:
+            assert resp.getheader("Set-Cookie") is None
+
+
 def test_api_queries_returns_recent_records_newest_first(tmp_path):
     queries_payload = [
         {"ts": "2026-05-15T01:00:00Z", "question": "older", "tokens": 100, "top_hits": []},


### PR DESCRIPTION
## Summary

v0.8 "Always-On" — first beat. Ships the four service templates + the `/healthz` endpoint + the cross-platform walkthrough. Marketing rollout (LinkedIn, NotebookLM, screencast, cross-doc callouts) deferred per "ship code + minimum docs" scope.

The user-facing claim: `neuralmind watch` and `neuralmind serve` now survive reboots and crashes on Linux (systemd), macOS (launchd), and Windows (Task Scheduler). The synapse store accumulates 24/7; the graph view canvas is always at `http://127.0.0.1:8765/`.

## Changes

| File | What |
|---|---|
| `neuralmind/server.py` | `/healthz` route registered **before** the session-token gate so Docker `HEALTHCHECK` and systemd `ExecStartPost` can probe without auth. Returns 200 + `{"status": "ok", "version": __version__}`. |
| `tests/test_server.py` | 3 new tests — status+version shape, no-auth, no-Set-Cookie. |
| `scripts/systemd/neuralmind-{watch,serve}.service` | User-scope units. Restart-on-failure, SIGTERM-clean shutdown, basic hardening. The serve unit's `ExecStartPost` polls `/healthz` for up to 5s. |
| `scripts/launchd/com.neuralmind.{watch,serve}.plist` | macOS user agents. `RunAtLoad` + `KeepAlive` + `ThrottleInterval`. |
| `docs/use-cases/always-on.md` | New page — per-platform install/verify/uninstall/troubleshooting + Docker `HEALTHCHECK` snippet. |
| `docs/wiki/Scheduling-Guide.md` | New "Always-on" section above the existing recurring-audit instructions — two PowerShell `Register-ScheduledTask` blocks + the `/healthz` verification snippet. |
| `RELEASE_NOTES_v0.8.0.md` | Minimal release notes. Marketing arc explicitly deferred. |

## Deferred

- **Aider integration block in README.** Investigated 2026-05-17: current Aider stable has no MCP-client support. Will add when upstream lands it.
- **Cross-doc marketing rollout.** README hero callout, wiki Home "What's New" entry, GitHub Pages, LinkedIn drafts, NotebookLM pack, screencast script — all deferred so this release ships code + minimum docs.

## Test plan

- [x] `python -m pytest tests/` — 391 passed (3 new), 4 environmental skips
- [x] `ruff check` clean on changed files
- [x] `black --check` clean on changed files
- [x] **Maintainer to verify:** `systemctl --user enable --now neuralmind-{watch,serve}` works on a real Linux machine
- [ ] **Maintainer to verify:** `launchctl load -w` works on a real macOS machine (if you have one)
- [ ] **Maintainer to verify:** the Windows `Register-ScheduledTask` blocks land cleanly on a Windows host

## Order vs the rename PR (#124)

This PR doesn't depend on #124 merging first. It branched off the same main as #124 and only touches code + new scripts/docs. Merge either order. When #124 lands, this branch can rebase to pick up the v0.7.0 naming in shared docs (LinkedIn drafts, etc.), but nothing here breaks.

## Versioning

Two `feat(...)` commits (the /healthz + templates landing). Per the project's `0.x feat = minor` rule (PR #114), this should propose a clean v0.8.0 from release-please once it merges.

## Issues

Closes part of [#119](https://github.com/dfrostar/neuralmind/issues/119) — the code + minimum docs. Full close once the marketing pass lands as a v0.8.1 or rolled into v0.8.x.

https://claude.ai/code/session_01SH6iHNAqeMJHXdq7ubVcuJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01SH6iHNAqeMJHXdq7ubVcuJ)_