### PR TITLE
fix(ci): use PAT for release-please so tag pushes trigger release.yml

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,5 +16,24 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@v5
         with:
+          # Token override so the tag push triggers downstream workflows.
+          # GitHub deliberately suppresses workflow-from-workflow triggers
+          # when the actor is GITHUB_TOKEN (anti-infinite-loop guard), so
+          # tags release-please creates with the default token never fire
+          # release.yml — which means the PyPI publish never runs without
+          # a manual `gh workflow run release.yml` dispatch.
+          #
+          # Set `RELEASE_PLEASE_TOKEN` as a repo secret (a classic PAT
+          # from a maintainer account, or a fine-grained PAT, with
+          # `contents:write` + `pull_requests:write` on this repo). When
+          # the secret is present, this `token:` override picks it up;
+          # when it isn't, `secrets.RELEASE_PLEASE_TOKEN` evaluates to
+          # empty and the action falls back to GITHUB_TOKEN — so adding
+          # the secret is a zero-risk follow-up.
+          #
+          # Tracked in #98. Long-term, a GitHub App is more durable
+          # (no per-human-account expiry, survives maintainer turnover);
+          # PAT is the 10-minute option that unblocks publishing.
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json


### PR DESCRIPTION
## Summary

Closes #98. Fixes the GITHUB_TOKEN anti-recursion guard that has bitten **every release-please-driven release** so far (v0.5.1 / v0.5.3 / v0.7.0 just now).

GitHub deliberately suppresses workflow-from-workflow triggers when the actor is `GITHUB_TOKEN`. So when release-please creates the `vX.Y.Z` tag with the default token, `release.yml` (which triggers on `push: tags: ['v*']`) never fires, and PyPI is left at the previous version until you manually `gh workflow run release.yml`.

## Fix

One line in `.github/workflows/release-please.yml`:

```yaml
token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
```

The `|| secrets.GITHUB_TOKEN` fallback means the change is **safe to merge before the secret exists** — behaviour is unchanged until you add the secret.

## Setup (one-time, after merge)

1. **Create a PAT** with `contents:write` + `pull_requests:write` scoped to this repo. Classic PAT (no expiry) or fine-grained PAT (90-day max but auto-rotate-able).
2. **Add it as a repo secret** named `RELEASE_PLEASE_TOKEN`:
   - Repo Settings → Secrets and variables → Actions → New repository secret
3. **Verify on the next release** — when release-please's tag push fires `release.yml` automatically, PyPI updates without intervention.

## Why not a GitHub App (option B from #98)?

A GitHub App is more durable (no per-human-account expiry, survives maintainer turnover) but ~30 min to set up vs ~10 min for the PAT. This PR ships the PAT path now to unblock the next release; we can migrate to a GitHub App in a follow-up without touching this workflow file again.

## Test plan

- [x] No-op behaviour confirmed: when `RELEASE_PLEASE_TOKEN` is unset, the expression evaluates to `GITHUB_TOKEN` (current behaviour). No regression.
- [ ] **Maintainer:** add the secret and confirm next release's `release.yml` triggers from the tag push.

## Closes

- Closes #98

https://claude.ai/code/session_01SH6iHNAqeMJHXdq7ubVcuJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01SH6iHNAqeMJHXdq7ubVcuJ)_