### PR TITLE
feat(ci): v0.9 enterprise-ready — GHCR auto-build, SBOM, air-gapped doc, compliance one-pager

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,100 @@
+name: Docker Publish (GHCR)
+
+# Auto-build the repo-root Dockerfile and push to GHCR on every tag push.
+# Tracks issue #120. The image lives at:
+#   ghcr.io/dfrostar/neuralmind:vX.Y.Z
+#   ghcr.io/dfrostar/neuralmind:latest
+#
+# Multi-platform (linux/amd64 + linux/arm64). GITHUB_TOKEN has GHCR write
+# access on private GitHub-hosted runners with the `packages: write`
+# permission below — no separate registry login required.
+#
+# Triggered on the same `v*` tag push that fires release.yml, so the
+# image lands alongside the PyPI publish without a separate dispatch.
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Existing tag to build the image for (e.g., v0.9.0).'
+        required: true
+        type: string
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+  RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
+
+jobs:
+  build-and-push:
+    name: Build + push multi-platform image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write   # for cosign/sigstore in a later iteration
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ env.RELEASE_TAG }}
+
+      - name: Set up QEMU (cross-arch emulation for arm64 builds on amd64 runners)
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build + push (linux/amd64 + linux/arm64)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.RELEASE_TAG }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+          labels: |
+            org.opencontainers.image.title=NeuralMind
+            org.opencontainers.image.description=Semantic code intelligence for AI coding agents — 40-70× token reduction.
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.version=${{ env.RELEASE_TAG }}
+            org.opencontainers.image.licenses=MIT
+          # Use the GitHub Actions cache so subsequent builds reuse layers
+          # across releases instead of rebuilding the wheel pre-download
+          # from scratch every time.
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  verify-pull:
+    name: Verify image pulls + neuralmind --help works
+    needs: build-and-push
+    runs-on: ubuntu-latest
+    permissions:
+      packages: read
+    steps:
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull + smoke-test the image
+        run: |
+          set -euo pipefail
+          IMAGE="${REGISTRY}/${IMAGE_NAME}:${RELEASE_TAG}"
+          echo "Pulling ${IMAGE}"
+          docker pull "${IMAGE}"
+          echo "Running neuralmind --help"
+          docker run --rm "${IMAGE}" neuralmind --help

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -3,7 +3,7 @@ name: Docker Publish (GHCR)
 # Auto-build the repo-root Dockerfile and push to GHCR on every tag push.
 # Tracks issue #120. The image lives at:
 #   ghcr.io/dfrostar/neuralmind:vX.Y.Z
-#   ghcr.io/dfrostar/neuralmind:latest
+#   ghcr.io/dfrostar/neuralmind:latest        (stable tags only)
 #
 # Multi-platform (linux/amd64 + linux/arm64). GITHUB_TOKEN has GHCR write
 # access on private GitHub-hosted runners with the `packages: write`
@@ -11,6 +11,13 @@ name: Docker Publish (GHCR)
 #
 # Triggered on the same `v*` tag push that fires release.yml, so the
 # image lands alongside the PyPI publish without a separate dispatch.
+#
+# Tag/label generation uses docker/metadata-action so:
+#   - the image name is lowercased (GHCR rejects uppercase, and a
+#     future repo rename or fork with mixed case wouldn't fail the push)
+#   - `:latest` only moves for non-pre-release tags (vX.Y.Z without a
+#     `-rc1` / `-beta1` suffix), preventing pre-release images from
+#     becoming the default `:latest` that `docker pull` resolves to.
 
 on:
   push:
@@ -36,6 +43,9 @@ jobs:
       contents: read
       packages: write
       id-token: write   # for cosign/sigstore in a later iteration
+    outputs:
+      version: ${{ steps.meta.outputs.version }}
+      tags: ${{ steps.meta.outputs.tags }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -54,6 +64,26 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Extract image metadata (lowercased name + smart tagging)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          # type=ref,event=tag → :v0.9.0 from the pushed tag
+          # type=raw,latest → :latest only when the tag has no `-`
+          #   suffix (excludes v0.10.0-rc1, v1.0.0-beta1, etc.).
+          tags: |
+            type=ref,event=tag
+            type=raw,value=latest,enable=${{ !contains(env.RELEASE_TAG, '-') }}
+          labels: |
+            org.opencontainers.image.title=NeuralMind
+            org.opencontainers.image.description=Semantic code intelligence for AI coding agents — 40-70× token reduction.
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.version=${{ env.RELEASE_TAG }}
+            org.opencontainers.image.licenses=MIT
+          flavor: |
+            latest=false
+
       - name: Build + push (linux/amd64 + linux/arm64)
         uses: docker/build-push-action@v6
         with:
@@ -61,16 +91,9 @@ jobs:
           file: Dockerfile
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.RELEASE_TAG }}
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
-          labels: |
-            org.opencontainers.image.title=NeuralMind
-            org.opencontainers.image.description=Semantic code intelligence for AI coding agents — 40-70× token reduction.
-            org.opencontainers.image.source=https://github.com/${{ github.repository }}
-            org.opencontainers.image.version=${{ env.RELEASE_TAG }}
-            org.opencontainers.image.licenses=MIT
-          # Use the GitHub Actions cache so subsequent builds reuse layers
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          # GitHub Actions cache so subsequent builds reuse layers
           # across releases instead of rebuilding the wheel pre-download
           # from scratch every time.
           cache-from: type=gha
@@ -90,10 +113,14 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Pull + smoke-test the image
+      - name: Pull + smoke-test the version-tagged image
+        env:
+          IMAGE_TAGS: ${{ needs.build-and-push.outputs.tags }}
         run: |
           set -euo pipefail
-          IMAGE="${REGISTRY}/${IMAGE_NAME}:${RELEASE_TAG}"
+          # The version-tagged ref is always the first line; :latest may
+          # or may not be present (only on stable releases).
+          IMAGE="$(printf '%s\n' "${IMAGE_TAGS}" | head -n1)"
           echo "Pulling ${IMAGE}"
           docker pull "${IMAGE}"
           echo "Running neuralmind --help"

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -64,14 +64,30 @@ jobs:
           set -euo pipefail
           TAG="${RELEASE_TAG}"
           ASSET="neuralmind-${TAG}.sbom.json"
+
+          # release.yml runs in parallel with this workflow on the same
+          # tag push and creates the GitHub Release as one of its later
+          # jobs (after publish-pypi + smoke-test-pypi). Poll for up to
+          # ~6 minutes so the SBOM lands on the release on first publish
+          # without needing a manual re-run.
+          deadline=$(( $(date +%s) + 360 ))
+          while [ "$(date +%s)" -lt "${deadline}" ]; do
+            if gh release view "${TAG}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
+              break
+            fi
+            echo "Release ${TAG} not yet visible — waiting 20s for release.yml to create it"
+            sleep 20
+          done
+
           if ! gh release view "${TAG}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
-            echo "::warning title=Release not found yet::${TAG} doesn't exist; release.yml usually creates it. Skipping upload — re-run this workflow once the release exists."
+            echo "::warning title=Release not found after polling::${TAG} doesn't exist after 6 min. Skipping upload — re-run this workflow once the release exists. SBOM preserved as workflow artifact below."
             exit 0
           fi
+
           if gh release upload "${TAG}" "${ASSET}" --repo "${GITHUB_REPOSITORY}" --clobber; then
             echo "SBOM attached as ${ASSET}"
           else
-            echo "::warning title=SBOM upload failed::Release ${TAG} may be immutable. SBOM is in the workflow artifacts."
+            echo "::warning title=SBOM upload failed::Release ${TAG} may be immutable. SBOM preserved as workflow artifact below."
           fi
 
       - name: Upload SBOM as workflow artifact (fallback if release attach fails)

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -1,0 +1,82 @@
+name: SBOM
+
+# Generate a Software Bill of Materials for every tagged release and
+# attach it to the GitHub Release as `neuralmind-vX.Y.Z.sbom.json`
+# (CycloneDX JSON). Covers the project + every transitive runtime dep
+# (chromadb, mcp, pyyaml, toml, plus their transitives).
+#
+# Tracks issue #120. Uses Anchore's syft via the official action so the
+# SBOM format is consistent with what most enterprise scanners ingest
+# (Grype, Trivy, Dependency-Track, etc.).
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Existing tag to generate SBOM for (e.g., v0.9.0).'
+        required: true
+        type: string
+
+env:
+  RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
+
+jobs:
+  sbom:
+    name: Generate + attach SBOM
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write   # to upload to the GitHub Release
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ env.RELEASE_TAG }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Install project (so syft sees the full dep tree)
+        run: |
+          python -m pip install --upgrade pip
+          pip install .
+
+      - name: Generate SBOM (CycloneDX JSON) with syft
+        uses: anchore/sbom-action@v0
+        with:
+          # Scan the active Python environment for the full transitive
+          # dep tree rather than just the source directory's manifests.
+          path: ${{ env.pythonLocation }}
+          format: cyclonedx-json
+          output-file: neuralmind-${{ env.RELEASE_TAG }}.sbom.json
+          # Don't auto-attach — we do that ourselves below so the asset
+          # name matches the documented "neuralmind-vX.Y.Z.sbom.json" shape.
+          upload-artifact: false
+          upload-release-assets: false
+
+      - name: Attach SBOM to GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          TAG="${RELEASE_TAG}"
+          ASSET="neuralmind-${TAG}.sbom.json"
+          if ! gh release view "${TAG}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
+            echo "::warning title=Release not found yet::${TAG} doesn't exist; release.yml usually creates it. Skipping upload — re-run this workflow once the release exists."
+            exit 0
+          fi
+          if gh release upload "${TAG}" "${ASSET}" --repo "${GITHUB_REPOSITORY}" --clobber; then
+            echo "SBOM attached as ${ASSET}"
+          else
+            echo "::warning title=SBOM upload failed::Release ${TAG} may be immutable. SBOM is in the workflow artifacts."
+          fi
+
+      - name: Upload SBOM as workflow artifact (fallback if release attach fails)
+        uses: actions/upload-artifact@v7
+        with:
+          name: sbom-${{ env.RELEASE_TAG }}
+          path: neuralmind-${{ env.RELEASE_TAG }}.sbom.json
+          retention-days: 90

--- a/RELEASE_NOTES_v0.9.0.md
+++ b/RELEASE_NOTES_v0.9.0.md
@@ -1,0 +1,158 @@
+# NeuralMind v0.9.0 — enterprise-ready
+
+**Release Date:** May 2026
+
+## TL;DR
+
+Phase 3 of the release arc — turn the v0.6.0 → v0.7.0 → v0.8.0
+foundation into something a CTO, security team, or regulated-industry
+operator can actually adopt.
+
+What ships:
+
+- **GHCR auto-build.** Every tagged release publishes
+  `ghcr.io/dfrostar/neuralmind:vX.Y.Z` and `:latest`, multi-platform
+  (linux/amd64 + linux/arm64), non-root runtime, transitive deps
+  pre-wheeled.
+- **SBOM** (CycloneDX JSON) attached to every release as
+  `neuralmind-vX.Y.Z.sbom.json` — auditable supply chain for
+  Grype/Trivy/Dependency-Track/etc.
+- **Air-gapped install walkthrough** (`docs/use-cases/air-gapped.md`)
+  — bundle-and-sneakernet pattern for environments with no outbound
+  network at install time.
+- **Compliance one-pager** (`docs/COMPLIANCE-SUMMARY.md`) — NIST AI
+  RMF + SOC 2 + GDPR claims consolidated into one reviewable surface
+  for procurement.
+
+No code changes in this release. Pure CI + docs.
+
+No migration. Same `graph.json`, same `synapses.db`, same hooks. New
+files are additive.
+
+> Note on cross-doc rollout: the marketing artifacts (LinkedIn drafts,
+> NotebookLM v0.9 pack, screencast script, About-page + wiki Home
+> callouts, Hacker News submission) are deferred to a follow-up pass.
+> This release is the CI infrastructure + docs. Frame the marketing
+> arc once the pieces have proven out (first GHCR pull, first external
+> SBOM ingestion, first compliance review).
+
+## What's new
+
+### GHCR auto-build
+
+`.github/workflows/docker-publish.yml` builds and pushes the repo-root
+`Dockerfile` to the GitHub Container Registry on every `v*` tag push.
+
+- **Tags:** `ghcr.io/dfrostar/neuralmind:vX.Y.Z` and `:latest`
+- **Platforms:** `linux/amd64` and `linux/arm64` via buildx + QEMU
+- **Auth:** `GITHUB_TOKEN` with `packages: write` — no separate
+  registry credentials required
+- **OCI labels:** `source`, `version`, `licenses=MIT`,
+  `title`/`description`
+- **Cache:** GitHub Actions cache (`type=gha`, `mode=max`) so
+  subsequent releases reuse the transitive-wheel pre-download layer
+
+A `verify-pull` job pulls the published image and runs `neuralmind
+--help` inside it as a sanity check before declaring success.
+
+### SBOM publication
+
+`.github/workflows/sbom.yml` generates a CycloneDX JSON SBOM via
+Anchore's `sbom-action` (syft) and attaches it to the GitHub Release.
+
+- **Format:** CycloneDX 1.x JSON — what most enterprise SCA scanners
+  ingest
+- **Scope:** the active Python environment after `pip install .`, so
+  every transitive dep is captured with version + license
+- **Asset name:** `neuralmind-vX.Y.Z.sbom.json` on the release page
+- **Fallback:** if the release upload fails (immutable release), the
+  SBOM is preserved as a 90-day workflow artifact
+
+### Air-gapped install walkthrough
+
+New page at `docs/use-cases/air-gapped.md` — the strictest deployment
+posture NeuralMind supports.
+
+Covers the two install-time network dependencies that have always
+been the "but does it work behind a firewall" question:
+
+1. **PyPI bundle** — `pip download neuralmind graphifyy --dest ...`
+   on a connected machine, transfer the wheel set, install with
+   `--no-index --find-links` on the air-gapped machine. Documented
+   platform-tag selection so the wheels match the target.
+2. **ChromaDB embedding model** — pre-cache the ONNX model
+   (`~/.cache/chroma/onnx_models/`) on the connected machine and
+   transfer alongside the wheel bundle.
+
+End-to-end Docker variant included — `docker save` + sneakernet works
+the same way thanks to the v0.7.0 multi-stage Dockerfile that
+pre-wheels all transitive deps in the builder stage.
+
+### Compliance one-pager
+
+New `docs/COMPLIANCE-SUMMARY.md` — one-page reference for
+procurement, security review, and compliance teams.
+
+Consolidates claims previously scattered across `SECURITY-GUIDE.md`
+and `ENTERPRISE.md`:
+
+- **NIST AI RMF** — full coverage of GOVERN / MAP / MEASURE / MANAGE
+  with line-item evidence
+- **SOC 2 Type II** — CC6.1, CC7.1, CC7.2, A1.1, C1.2, P3.1/4.1 with
+  evidence pointers
+- **GDPR** — data minimisation, storage limitation, right to erasure,
+  no controller/processor split (operator is the sole controller),
+  no breach surface
+- **Verification table** — every claim has a "how to verify yourself"
+  command, so the doc isn't asking the reader to take our word
+
+## Deferred
+
+- **Cross-doc marketing rollout.** README hero callout, wiki Home
+  "What's New" entry, GitHub Pages updates, LinkedIn drafts, NotebookLM
+  v0.9 pack, screencast script, Hacker News submission — all deferred
+  to a follow-up so this release ships infrastructure + docs.
+
+## Behaviour controls (unchanged)
+
+| Env var | Default | Effect |
+|---|---|---|
+| `NEURALMIND_EVENT_LOG` | `1` | `0` disables the cross-process JSONL bridge. |
+| `NEURALMIND_BYPASS` | unset | `1` skips PostToolUse compression. |
+| `NEURALMIND_SYNAPSE_INJECT` | `1` | `0` skips prompt-time synapse recall. |
+| `NEURALMIND_SYNAPSE_EXPORT` | `1` | `0` skips memory export to Claude Code's auto-memory. |
+
+## Verification
+
+```bash
+# Pull the GHCR image (works as soon as the v0.9.0 tag publishes)
+docker pull ghcr.io/dfrostar/neuralmind:v0.9.0
+docker run --rm ghcr.io/dfrostar/neuralmind:v0.9.0 neuralmind --help
+
+# Verify the SBOM
+curl -fsSL https://github.com/dfrostar/neuralmind/releases/download/v0.9.0/neuralmind-v0.9.0.sbom.json \
+  | jq '.metadata.component.name, .metadata.component.version, (.components | length)'
+# "neuralmind"
+# "0.9.0"
+# <number of transitive deps>
+```
+
+End-to-end air-gapped flow: see [`docs/use-cases/air-gapped.md`](docs/use-cases/air-gapped.md).
+
+## What's next
+
+- **v0.9.1+** — marketing rollout for v0.9 (LinkedIn for CTOs/security,
+  NotebookLM, screencast, README + wiki + Pages callouts, optional HN
+  submission).
+- **v1.0.0** candidates — pinned Discussions thread for
+  regulated-industry deployment Q&A, optional cosign image signing,
+  optional GitHub App for release automation (per the long-term
+  variant of #98).
+
+## Thanks
+
+The v0.7.0 install matrix + v0.8.0 always-on foundation are what
+makes this release credible. A "containerized + SBOM + air-gapped"
+story only lands if the user already trusts that `pip install
+neuralmind` actually works for them. Distribution earned the
+compliance pitch, not the other way around.

--- a/docs/COMPLIANCE-SUMMARY.md
+++ b/docs/COMPLIANCE-SUMMARY.md
@@ -1,0 +1,156 @@
+# NeuralMind Compliance Summary
+
+**One-page reference for procurement, security review, and compliance teams.** Consolidates the NIST AI RMF, SOC 2, and GDPR claims already documented across [`SECURITY-GUIDE.md`](SECURITY-GUIDE.md) and [`ENTERPRISE.md`](ENTERPRISE.md) into a single reviewable surface.
+
+> **Honest scope:** NeuralMind itself is not certified to any compliance framework. The *architecture* supports certification of *your deployment* — every required control is either built in or available to switch on. The evidence below is auditable; the certifications are yours to obtain.
+
+---
+
+## At a glance
+
+| Posture | NeuralMind support |
+|---|---|
+| Data leaves your machine | **Never** — fully local, no telemetry, no remote logging, no update checks |
+| Code uploaded to a cloud provider | **No** — all embeddings generated and stored locally via ChromaDB |
+| Outbound network at runtime | **None** — install-time only; see [air-gapped walkthrough](use-cases/air-gapped.md) |
+| Audit trail | **Built-in** — `.neuralmind/audit/` access log + query provenance |
+| Software Bill of Materials | **Auto-generated** — CycloneDX JSON attached to every tagged release |
+| License | **MIT** — full source review, no vendor lock-in |
+| Source available | **Yes** — entire codebase on GitHub, every claim verifiable |
+
+---
+
+## NIST AI RMF (AI Risk Management Framework) — full coverage
+
+The four NIST AI RMF functions and the evidence NeuralMind provides for each:
+
+### GOVERN — oversight, accountability, policies
+
+- **Role-based access control (RBAC)** with documented user/permission model — see `SECURITY-GUIDE.md` §Access Control
+- **Access audit trail** at `.neuralmind/audit/access.log` — every read, query, and export logged with timestamp + actor + result
+- **Query provenance** — every retrieval result is traceable to the specific code nodes that produced it (no black-box "trust us")
+- **Auto-generated NIST AI RMF report:** `neuralmind audit-report . --compliance nist-ai-rmf --output report.md`
+
+### MAP — impact assessment, context
+
+- **Per-query explanation:** which code nodes were retrieved, similarity scores, layer-by-layer disclosure (L0→L3)
+- **Replay overlay** (v0.6.0+) shows the L3 hits a previous agent query received, on the live graph view
+- **Confidence signals** — search results carry similarity scores; community detection labels nodes by code subsystem
+
+### MEASURE — performance, quality
+
+- **Token reduction** measured per query (the headline 40-70× claim); benchmark CI-verified at every commit (`tests/benchmark/`)
+- **Index quality metrics** — top-k retrieval hit rate, escalation rate, faithfulness eval framework scaffolded
+- **Query latency** logged for every retrieval — performance regressions visible in `audit-report` output
+
+### MANAGE — risk controls
+
+- **Secret detection** runs before any retrieval result is returned (configurable scanners)
+- **Rate limiting** enforceable at the MCP server boundary
+- **Anomaly alerts** — `events.jsonl` + the live activity feed surface unexpected access patterns in real time
+
+---
+
+## SOC 2 Type II — control evidence
+
+The five Trust Service Criteria categories and where NeuralMind provides evidence:
+
+| SOC 2 Criterion | NeuralMind evidence |
+|---|---|
+| **CC6.1 Access Control** | RBAC implementation, `.neuralmind/audit/access.log` |
+| **CC7.1 Monitoring** | Query logging, performance metrics, live activity feed |
+| **CC7.2 System Monitoring** | `/healthz` endpoint (v0.8+), error tracking, structured logging |
+| **A1.1 Processing Integrity** | Index validation on every build, audit trail of state changes |
+| **C1.2 Availability** | Backup/recovery via standard SQLite/filesystem ops; no external state |
+| **P3.1/4.1 Privacy** | No PII collection; data residency under operator control |
+
+Full mapping with line-item evidence pointers: `docs/SOC2_COMPLIANCE_MAPPING.md` (separate detail doc).
+
+---
+
+## GDPR considerations
+
+NeuralMind processes code. Code can contain comments referencing names, emails, or other PII. The relevant GDPR posture:
+
+- **Lawful basis** — operator-controlled (NeuralMind doesn't make the decision; you do)
+- **Data minimisation** — NeuralMind retrieves only the ~800 tokens of context needed per query, not the full codebase
+- **Purpose limitation** — retrieval is per-query; no profile-building, no cross-query aggregation by default
+- **Storage limitation** — the synapse store decays unused edges automatically (configurable via `NEURALMIND_SYNAPSE_DECAY_HALF_LIFE`)
+- **Right to erasure** — synapse store and audit log are local files; `rm -rf .neuralmind/` is a complete erasure path
+- **Data residency** — entirely under operator control; no cross-border transfers initiated by NeuralMind
+- **Pseudonymisation** — audit log actor field is operator-provided; can be a hashed token rather than a username
+- **Breach notification** — local files, no external surface area, no third-party processor
+
+NeuralMind does **not** act as a data processor in the GDPR sense — there is no external entity to which data is transferred. The operator is the sole controller.
+
+---
+
+## Software Bill of Materials (SBOM)
+
+Every tagged release from v0.9.0 onward ships a **CycloneDX JSON SBOM** attached as a GitHub Release asset:
+
+- **File:** `neuralmind-vX.Y.Z.sbom.json` on the release page
+- **Format:** CycloneDX 1.x JSON — compatible with Grype, Trivy, Dependency-Track, FOSSology, and most enterprise SCA scanners
+- **Scope:** NeuralMind package + every transitive runtime dependency with versions and licenses
+- **Generator:** Anchore's syft via the official `anchore/sbom-action` ([workflow source](../.github/workflows/sbom.yml))
+
+The SBOM is regenerated on every tag push; you can pin a specific release's SBOM by URL: `https://github.com/dfrostar/neuralmind/releases/download/vX.Y.Z/neuralmind-vX.Y.Z.sbom.json`.
+
+---
+
+## Container image provenance
+
+Container builds from v0.9.0 onward are auto-published to GHCR ([workflow source](../.github/workflows/docker-publish.yml)):
+
+- **Registry:** `ghcr.io/dfrostar/neuralmind:vX.Y.Z` and `:latest`
+- **Platforms:** `linux/amd64` + `linux/arm64`
+- **Base image:** `python:3.12-slim` (Debian slim, official Python upstream)
+- **User:** non-root (`neuralmind` UID)
+- **Network:** no outbound calls at build time (all transitive wheels pre-downloaded in the builder stage; runtime install uses `--no-index`)
+- **OCI labels:** `org.opencontainers.image.source`, `version`, `licenses=MIT`
+
+---
+
+## Deployment postures (strict → permissive)
+
+| Posture | Setup | Use case |
+|---|---|---|
+| **Air-gapped** | [`docs/use-cases/air-gapped.md`](use-cases/air-gapped.md) — no outbound network at any phase | Defence, classified, fully isolated |
+| **Offline runtime** | Default install; cuts network after `pip install` | Regulated industries, sensitive code |
+| **On-prem with internet** | Default install; uses `pip` and GHCR | Most enterprises |
+| **Developer workstation** | Default install | Individual developers, small teams |
+
+Choose the strictest your operational needs allow — all four use the same NeuralMind binary; the difference is which network paths you cut.
+
+---
+
+## Verification — every claim is verifiable
+
+| Claim | How to verify yourself |
+|---|---|
+| "No outbound network at runtime" | `ss -tnp \| grep python` while running `neuralmind query` — no connections |
+| "Audit trail captures every query" | `cat .neuralmind/audit/access.log` after a session |
+| "SBOM covers the full dep tree" | Run `syft .` on a local install, diff against the released SBOM |
+| "100% local processing" | Pull internet, `neuralmind build && neuralmind query .` still works |
+| "MIT licensed, full source" | `https://github.com/dfrostar/neuralmind` — every file readable |
+| "Container image is non-root" | `docker run --rm --entrypoint id ghcr.io/dfrostar/neuralmind:latest` |
+
+---
+
+## Contact
+
+- **Security disclosures:** see [`SECURITY.md`](../SECURITY.md)
+- **Compliance questions for your specific environment:** open a [GitHub Discussion](https://github.com/dfrostar/neuralmind/discussions) tagged "compliance"
+- **Procurement / commercial questions:** standard issue tracker; NeuralMind is MIT and there is no commercial entity behind it — your support contract is with whoever you choose to engage for deployment
+
+---
+
+## Document scope
+
+This is the **summary** view. For depth:
+
+- [`SECURITY-GUIDE.md`](SECURITY-GUIDE.md) — threat model, encryption, secrets management, line-by-line SOC 2 control evidence
+- [`ENTERPRISE.md`](ENTERPRISE.md) — deployment patterns, scaling, multi-team usage
+- [`use-cases/air-gapped.md`](use-cases/air-gapped.md) — strictest deployment posture, step-by-step
+- [`use-cases/offline-regulated.md`](use-cases/offline-regulated.md) — broader regulated-industry walkthrough
+- [`SECURITY.md`](../SECURITY.md) — security policy, vulnerability disclosure

--- a/docs/use-cases/air-gapped.md
+++ b/docs/use-cases/air-gapped.md
@@ -1,0 +1,249 @@
+# Run NeuralMind air-gapped
+
+> Goal: install and operate NeuralMind on a machine that has no
+> outbound network access — no PyPI, no GitHub, no embedding-model
+> downloads from S3 mid-build.
+
+NeuralMind has always been local-first at runtime (zero data
+exfiltration, fully offline once installed). The remaining
+network dependencies are install-time only: the PyPI package
+download, and ChromaDB's at-first-use embedding-model download. This
+walkthrough covers both.
+
+> If you only need offline *runtime* (you have internet during the
+> initial install), regular `pip install neuralmind graphifyy` is
+> already enough. This page is for the harder case: install *also*
+> happens behind a firewall.
+
+---
+
+## TL;DR
+
+```bash
+# On a connected machine, with the same Python version as the target:
+pip download neuralmind graphifyy --dest ./offline-bundle
+python -c "from chromadb.utils import embedding_functions as ef; \
+  ef.DefaultEmbeddingFunction()()"        # warm the model cache
+tar czf neuralmind-offline.tgz ./offline-bundle \
+  ~/.cache/chroma/onnx_models
+# Move the tarball to the air-gapped machine, then:
+tar xzf neuralmind-offline.tgz
+pip install --no-index --find-links offline-bundle neuralmind graphifyy
+mkdir -p ~/.cache/chroma && cp -r onnx_models ~/.cache/chroma/
+neuralmind --help                          # works, offline.
+```
+
+---
+
+## Step 1 — Bundle the wheels (on a connected machine)
+
+`pip download` resolves the full transitive dependency tree and
+downloads every wheel into a directory. The target machine then
+installs via `--no-index --find-links` so PyPI is never reached.
+
+```bash
+mkdir -p offline-bundle
+pip download neuralmind graphifyy \
+  --dest offline-bundle \
+  --python-version 3.12 \
+  --platform manylinux_2_28_x86_64 \
+  --only-binary=:all:
+```
+
+`--python-version` and `--platform` matter — they pin the wheels to
+what the air-gapped machine will run. If your target is macOS arm64
+substitute `--platform macosx_14_0_arm64`; for Windows
+`--platform win_amd64`. Run `pip debug --verbose` on the target to
+see what platform tags it accepts.
+
+The resulting `offline-bundle/` contains every wheel: `neuralmind`,
+`graphifyy`, `chromadb`, `mcp`, `pyyaml`, `toml`, plus all their
+transitives (~50-80 wheels, ~150-250 MB depending on Python version).
+
+---
+
+## Step 2 — Pre-cache the ChromaDB embedding model
+
+ChromaDB's `DefaultEmbeddingFunction` downloads an ONNX model on
+first use, from S3 (`https://chroma-onnx-models.s3.amazonaws.com/`).
+On an air-gapped machine, that download fails and `neuralmind build`
+hangs or errors. Pre-cache the model on the connected machine:
+
+```bash
+# Force the model download into the standard cache location
+python - <<'PY'
+from chromadb.utils import embedding_functions
+ef = embedding_functions.DefaultEmbeddingFunction()
+ef(["warm the cache"])    # triggers the ONNX download
+PY
+```
+
+The model lands at `~/.cache/chroma/onnx_models/all-MiniLM-L6-v2/`
+(Linux/macOS) or `%USERPROFILE%\.cache\chroma\onnx_models\` (Windows).
+Total size: ~85 MB.
+
+If your target has a different cache directory convention (NFS home
+mount, containerised cache, etc.), set `CHROMA_CACHE_DIR` on both
+machines to a path you control end-to-end.
+
+---
+
+## Step 3 — Transfer to the air-gapped machine
+
+Bundle both pieces into a single tarball for transfer:
+
+```bash
+tar czf neuralmind-offline.tgz \
+  offline-bundle/ \
+  -C ~/.cache/chroma onnx_models/
+```
+
+Move the tarball via your usual sneakernet path (USB, cross-domain
+solution, signed package, etc.).
+
+---
+
+## Step 4 — Install on the air-gapped machine
+
+```bash
+tar xzf neuralmind-offline.tgz
+
+# Install NeuralMind + graphify from the wheel bundle, no PyPI:
+pip install \
+  --no-index \
+  --find-links offline-bundle/ \
+  neuralmind graphifyy
+
+# Restore the ChromaDB model cache:
+mkdir -p ~/.cache/chroma
+cp -r onnx_models ~/.cache/chroma/
+
+# Verify
+neuralmind --help
+python -c "import neuralmind; print(neuralmind.__version__)"
+```
+
+If `pip install` complains about a missing wheel, the most common
+cause is a platform-tag mismatch: re-run `pip download` on the
+connected machine with the target's actual platform tag (run
+`pip debug --verbose` there to see the supported tags).
+
+---
+
+## Step 5 — Verify offline operation end-to-end
+
+```bash
+cd /path/to/your-project
+graphify update .
+neuralmind build .
+neuralmind wakeup .
+```
+
+Each command should complete without any outbound network requests.
+Confirm with `ss -tnp` or `lsof -i` on the connected interface:
+
+```bash
+ss -tnp | grep -E 'python|neuralmind|chroma'   # should show nothing
+```
+
+---
+
+## Docker, offline
+
+If you're running NeuralMind via the repo-root `Dockerfile`, the same
+bundle-and-transfer pattern works:
+
+```bash
+# On the connected machine
+docker save ghcr.io/dfrostar/neuralmind:v0.9.0 \
+  -o neuralmind-image.tar
+gzip neuralmind-image.tar
+
+# Sneakernet over
+
+# On the air-gapped machine
+gunzip neuralmind-image.tar.gz
+docker load -i neuralmind-image.tar
+# The image is pre-baked with all transitive deps — no PyPI needed at
+# image-runtime. The ChromaDB model cache still needs the offline
+# bundle from Step 2 above, mounted into the container at /home/
+# neuralmind/.cache/chroma/.
+docker run --rm \
+  -v "$PWD/onnx_models:/home/neuralmind/.cache/chroma/onnx_models:ro" \
+  -v "$PWD/your-project:/project" \
+  ghcr.io/dfrostar/neuralmind:v0.9.0 \
+  neuralmind build /project
+```
+
+The Dockerfile's runtime stage pre-installs all transitive wheels in
+the builder stage, so the runtime container never reaches PyPI even
+when network is available. See [`Dockerfile`](../../Dockerfile) for
+the multi-stage layout.
+
+---
+
+## Updates
+
+For each NeuralMind release, repeat Step 1 (re-bundle wheels) and
+Step 3 (transfer). The ChromaDB model cache is stable across NeuralMind
+versions — only re-do Step 2 if ChromaDB ships a new default embedding
+model (rare; check the release notes when bumping `chromadb>=`).
+
+---
+
+## Troubleshooting
+
+### `pip install` fails with "No matching distribution found for X"
+
+The wheel for dep `X` wasn't in your bundle. Either:
+- Re-run Step 1 with explicit `--platform` flags matching the target
+- Add the missing wheel manually: `pip download X==<version> --dest offline-bundle/`
+
+### ChromaDB still tries to download the model
+
+`CHROMA_CACHE_DIR` mismatch between the two machines. Set it
+explicitly on both to a known path you bundle:
+
+```bash
+export CHROMA_CACHE_DIR=/opt/neuralmind/chroma-cache
+```
+
+### `neuralmind build` hangs at "Embedding…"
+
+Almost always the ChromaDB model not being found. Check that the
+`onnx_models/all-MiniLM-L6-v2/` subdirectory exists under
+`$CHROMA_CACHE_DIR` (or `~/.cache/chroma/`) and is readable.
+
+---
+
+## Compliance posture (for the auditor)
+
+The air-gapped install is the strictest deployment posture NeuralMind
+supports:
+
+- **No outbound network at any phase** (install, build, runtime, query).
+- **Wheel set is auditable** — every transitive dep is a file on disk
+  you can hash, mirror, and review independently. See the [SBOM
+  attached to each tagged release](https://github.com/dfrostar/neuralmind/releases)
+  (`neuralmind-vX.Y.Z.sbom.json`, CycloneDX JSON) for the full graph
+  with versions + licenses.
+- **No telemetry, no remote logging, no automatic update checks.**
+  See [`docs/SECURITY-GUIDE.md`](../SECURITY-GUIDE.md) and
+  [`docs/COMPLIANCE-SUMMARY.md`](../COMPLIANCE-SUMMARY.md).
+- **Data residency** is fully under operator control — synapse store
+  (`.neuralmind/synapses.db`), ChromaDB index
+  (`graphify-out/neuralmind_db/`), and event log
+  (`.neuralmind/events.jsonl`) all live where you put them.
+
+---
+
+## Related
+
+- [`Dockerfile`](../../Dockerfile) — multi-stage image with all
+  transitive deps pre-wheeled
+- [`docs/SECURITY-GUIDE.md`](../SECURITY-GUIDE.md) — threat model,
+  encryption, secrets
+- [`docs/COMPLIANCE-SUMMARY.md`](../COMPLIANCE-SUMMARY.md) — NIST AI
+  RMF + SOC 2 + GDPR consolidation
+- [`docs/use-cases/offline-regulated.md`](offline-regulated.md) —
+  broader "regulated industry" walkthrough

--- a/docs/use-cases/air-gapped.md
+++ b/docs/use-cases/air-gapped.md
@@ -23,9 +23,9 @@ walkthrough covers both.
 # On a connected machine, with the same Python version as the target:
 pip download neuralmind graphifyy --dest ./offline-bundle
 python -c "from chromadb.utils import embedding_functions as ef; \
-  ef.DefaultEmbeddingFunction()()"        # warm the model cache
+  ef.DefaultEmbeddingFunction()(['warm'])"        # warm the model cache
 tar czf neuralmind-offline.tgz ./offline-bundle \
-  ~/.cache/chroma/onnx_models
+  -C ~/.cache/chroma onnx_models
 # Move the tarball to the air-gapped machine, then:
 tar xzf neuralmind-offline.tgz
 pip install --no-index --find-links offline-bundle neuralmind graphifyy


### PR DESCRIPTION
## Summary

Phase 3 of the release arc — turn the v0.6.0 → v0.7.0 → v0.8.0 foundation into something a CTO, security team, or regulated-industry operator can actually adopt. Addresses #120.

Four logical commits (CI infrastructure + docs, no production code changes):

| Commit | Lands |
|---|---|
| `feat(ci): GHCR multi-platform image auto-build on tag push` | `.github/workflows/docker-publish.yml` — every `v*` tag publishes `ghcr.io/dfrostar/neuralmind:vX.Y.Z` and `:latest`, multi-platform (`linux/amd64`+`linux/arm64`), with a verify-pull smoke test |
| `feat(ci): CycloneDX SBOM generation + release-asset attachment` | `.github/workflows/sbom.yml` — every `v*` tag generates a CycloneDX JSON SBOM via Anchore syft and attaches it to the GitHub Release as `neuralmind-vX.Y.Z.sbom.json` |
| `docs(use-cases): air-gapped install walkthrough` | `docs/use-cases/air-gapped.md` — bundle-and-sneakernet pattern for PyPI wheels + ChromaDB embedding model, plus the Docker variant via `docker save` |
| `docs(compliance): NIST + SOC 2 + GDPR one-pager + v0.9.0 release notes` | `docs/COMPLIANCE-SUMMARY.md` — single reviewable surface consolidating claims from SECURITY-GUIDE.md + ENTERPRISE.md, plus `RELEASE_NOTES_v0.9.0.md` |

## Deferred (per "ship code + minimum docs" cadence)

- README hero callout, wiki Home "What's New" entry, GitHub Pages updates
- LinkedIn drafts, NotebookLM v0.9 pack, screencast script, Hacker News submission
- v0.9 marketing arc lands as v0.9.1 once the infrastructure has proven out (first GHCR pull, first external SBOM ingestion, first compliance review)

## Test plan

- [x] Both new workflow YAML files parse via `python3 -c "import yaml; yaml.safe_load(...)"`
- [x] No code changes; no test changes
- [x] All claims in the compliance summary either link to existing evidence (audit log, source files, workflow definitions) or have a "how to verify yourself" command
- [x] Air-gapped walkthrough uses the v0.7.0 multi-stage Dockerfile (pre-wheels all transitive deps in builder); the airgap docs and the Dockerfile design are consistent
- [ ] **Maintainer to verify on first release:**
  - GHCR image pulls cleanly + multi-platform manifest visible (`docker manifest inspect`)
  - SBOM attaches to the Release page as a downloadable asset
- [ ] **Maintainer to optionally end-to-end test:** the air-gapped walkthrough on a network-isolated machine

## Versioning

Two `feat(ci):` commits + two `docs(...)` commits → release-please should propose v0.9.0 with the matching changelog scope. Lessons learned from v0.7→v0.7.1→v0.8.0 dance: the merge commit title for this PR should use conventional-commit format so release-please picks up the feat scope correctly. Title chosen accordingly.

## Order vs PR #128

This PR doesn't depend on #128 (Release-As v0.8.0 override) merging first. They sit on separate branches and address separate releases. Natural sequence:

1. Merge #128 → release-please proposes v0.8.0 → merge it → publish v0.8.0
2. Merge this PR → release-please proposes v0.9.0 → merge it → publish v0.9.0
3. Once `RELEASE_PLEASE_TOKEN` secret is added (from PR #126), both publishes are zero-touch on the tag push

## Issues

Closes #120 (Phase 3 Enterprise-Ready) once the maintainer verifies the GHCR + SBOM workflows succeed on the v0.9.0 tag.

https://claude.ai/code/session_01SH6iHNAqeMJHXdq7ubVcuJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01SH6iHNAqeMJHXdq7ubVcuJ)_