### PR TITLE
docs: v0.9.1 — post-Perplexity-review fixes (Grep matcher, hook health-check, cost caveat)

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -508,6 +508,8 @@ echo "✅ Maintenance complete!"
 
 ## ROI Calculator
 
+> **Honest framing:** the dollar figures in this section are **best-case project-side projections**, not independently audited cost studies. They assume every query loads ~50,000 tokens of context without NeuralMind and ~800 tokens with it — true for the "loading-the-codebase-to-answer" pattern this tool was built for, generous if your real workload mixes in queries that don't touch source files. Match the line that fits your usage; treat anything beyond that as upper-bound. For the skeptic's read on what these numbers mean (and don't), see [`docs/HONEST-ASSESSMENT.md`](docs/HONEST-ASSESSMENT.md).
+
 ### Cost Comparison by Model
 
 | Model | Input Price | Without NeuralMind | With NeuralMind | Per-Query Savings |

--- a/docs/wiki/Troubleshooting.md
+++ b/docs/wiki/Troubleshooting.md
@@ -313,6 +313,41 @@ graphify update /path
 
 ---
 
+## Hook Issues (Claude Code)
+
+### Verify hooks are still firing after a Claude Code update
+
+**Symptoms**: After updating Claude Code itself (not NeuralMind), tool-output token counts feel higher than they used to, or the compression noted in `neuralmind benchmark` doesn't match what you observe in Claude Code's actual usage.
+
+**Cause**: Claude Code's hook matcher names and tool dispatch path can change between versions. The most notable change so far: **v2.1.117 (April 2026)** folded the standalone `Grep`/`Glob` tools into `Bash` on native macOS/Linux builds. Our installed-hooks still cover that case (the `Bash` matcher catches the rerouted searches), but it's a useful health check after any Claude Code upgrade.
+
+**Diagnosis** — run the benchmark:
+
+```bash
+neuralmind benchmark .
+```
+
+If the reduction ratio dropped sharply vs. your last run (and you didn't change your project), the hook layer may have regressed. Then check `~/.claude/settings.json` to confirm NeuralMind's PostToolUse block is still present:
+
+```bash
+python -c "import json; cfg = json.load(open('$HOME/.claude/settings.json')); \
+  print('NeuralMind hooks installed:', '_neuralmind_v' in str(cfg.get('hooks', {})))"
+```
+
+**Fix**: if the block is missing, reinstall:
+
+```bash
+neuralmind install-hooks .
+```
+
+If the block is present but the benchmark still looks off, open an issue with the Claude Code version (`claude --version`) and the `neuralmind benchmark .` output — the matcher list may need an update.
+
+### PostToolUse scope — what NeuralMind compresses
+
+NeuralMind's hooks compress the output of Claude Code's built-in tools (`Read`, `Bash`, `Grep`, plus rerouted searches on v2.1.117+ native builds). They do **not** compress responses from third-party MCP servers — MCP tool calls match on `mcp__<server>__<tool>` patterns, which NeuralMind's installed block deliberately doesn't subscribe to (we don't know what those MCP tools return or whether compression would be safe). If a third-party MCP server is dominating your token bill, that compression is a separate problem from what `install-hooks` solves.
+
+---
+
 ## MCP Issues
 
 ### "MCP server failed to start"

--- a/docs/wiki/Troubleshooting.md
+++ b/docs/wiki/Troubleshooting.md
@@ -327,17 +327,34 @@ graphify update /path
 neuralmind benchmark .
 ```
 
-If the reduction ratio dropped sharply vs. your last run (and you didn't change your project), the hook layer may have regressed. Then check `~/.claude/settings.json` to confirm NeuralMind's PostToolUse block is still present:
+If the reduction ratio dropped sharply vs. your last run (and you didn't change your project), the hook layer may have regressed. Then check both possible settings files — `install-hooks` defaults to **project scope** (`<project>/.claude/settings.json`), and `--global` writes to `~/.claude/settings.json`. NeuralMind hook blocks are identified by the `neuralmind _hook ...` command embedded in each block (not by a metadata field). One-liner that scans both:
 
 ```bash
-python -c "import json; cfg = json.load(open('$HOME/.claude/settings.json')); \
-  print('NeuralMind hooks installed:', '_neuralmind_v' in str(cfg.get('hooks', {})))"
+python - <<'PY'
+import json, os
+from pathlib import Path
+
+paths = [Path(".claude/settings.json"), Path.home() / ".claude/settings.json"]
+for p in paths:
+    if not p.exists():
+        print(f"{p}: not present")
+        continue
+    cfg = json.loads(p.read_text())
+    hits = []
+    for event, blocks in (cfg.get("hooks") or {}).items():
+        for b in blocks or []:
+            for h in b.get("hooks") or []:
+                if "neuralmind _hook" in (h.get("command") or ""):
+                    hits.append(f"{event}/{b.get('matcher', '*')}")
+    print(f"{p}: {hits if hits else 'no neuralmind hooks'}")
+PY
 ```
 
-**Fix**: if the block is missing, reinstall:
+**Fix**: if neither path lists any blocks, reinstall — match the scope you originally used:
 
 ```bash
-neuralmind install-hooks .
+neuralmind install-hooks .              # project scope (default)
+neuralmind install-hooks . --global     # ~/.claude/settings.json
 ```
 
 If the block is present but the benchmark still looks off, open an issue with the Claude Code version (`claude --version`) and the `neuralmind benchmark .` output — the matcher list may need an update.

--- a/neuralmind/hooks.py
+++ b/neuralmind/hooks.py
@@ -46,6 +46,16 @@ def _hook_block() -> dict:
     """
     return {
         BLOCK_KEY: HOOK_VERSION,
+        # PostToolUse matchers below. Compatibility note for
+        # Claude Code v2.1.117+ (April 2026): on *native* macOS/Linux
+        # builds the standalone Grep + Glob tools were folded into
+        # Bash (searches now invoke embedded bfs/ugrep, no separate
+        # tool round-trip). The Grep matcher entry stays — it's
+        # still active on Windows + npm-installed Claude Code, and
+        # the Bash matcher below catches any rerouted search
+        # invocations on native builds, so end-to-end coverage is
+        # preserved either way.
+        # See: https://github.com/anthropics/claude-agent-sdk-typescript/issues/301
         "PostToolUse": [
             {
                 "matcher": "Read",


### PR DESCRIPTION
## Summary

Three small precision fixes flagged by a Perplexity Deep Research review of NeuralMind. Each was fact-checked against primary sources before landing. Single commit with `Release-As: 0.9.1` footer so release-please proposes a clean v0.9.1 patch.

| File | Fix |
|---|---|
| `neuralmind/hooks.py` | Comment block above the `PostToolUse` matchers documenting Claude Code v2.1.117+ behavior (Grep/Glob folded into Bash on native macOS/Linux). Our matcher list is robust: Grep stays for Windows + npm-install, Bash matcher catches rerouted searches on native builds. |
| `docs/wiki/Troubleshooting.md` | New "Hook Issues" section with two entries: (1) post-Claude-Code-update health check via `neuralmind benchmark .`, (2) explicit scope statement — what NeuralMind compresses (built-in Read/Bash/Grep) vs. what it doesn't (third-party MCP tools via `mcp__<server>__<tool>`). |
| `USAGE.md` | Inline caveat above the ROI Calculator dollar figures — best-case project-side projections, not independently audited; cross-link to `HONEST-ASSESSMENT.md` made prominent. |

## What was NOT changed, and why

- **No version pinning of `graphifyy>=0.5.2`.** Perplexity confused our `graphifyy` (two y's) with the unrelated `safishamsi/graphify` repo. Whatever "v0.5.2 hotfix" they cite isn't ours.
- **No "MCP hooks don't work" warning.** [Current Claude Code hooks docs](https://code.claude.com/docs/en/hooks) explicitly support MCP tool matchers via `mcp__<server>__<tool>`. Perplexity's architectural claim was wrong. Our hooks just don't subscribe to MCP tools (separate, intentional choice — now documented).
- **No reference to "GitHub bug #34713" (false hook-error labels).** Unverified; specific issue numbers are exactly what AI research tools confabulate.

## Test plan

- [x] `python -m pytest tests/test_hooks.py tests/test_hooks_synapses.py` — 26 of 26 passing
- [x] `ruff check neuralmind/hooks.py` — clean
- [x] `black --check neuralmind/hooks.py` — clean
- [x] No production code changes (hooks.py change is comment-only); no test changes
- [x] All claims verified against primary sources ([Claude Code hooks reference](https://code.claude.com/docs/en/hooks), [claude-agent-sdk-typescript#301](https://github.com/anthropics/claude-agent-sdk-typescript/issues/301))

## Order of operations after this merges

1. release-please proposes **v0.9.1** (the `Release-As: 0.9.1` footer forces the patch bump even though the commit is `docs(...)`)
2. Merge that release-please PR (squash) → cuts v0.9.1 tag
3. `release.yml` + `docker-publish.yml` + `sbom.yml` all fire on the tag (auto if `RELEASE_PLEASE_TOKEN` secret is set, else `gh workflow run` from your laptop)

https://claude.ai/code/session_01SH6iHNAqeMJHXdq7ubVcuJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01SH6iHNAqeMJHXdq7ubVcuJ)_