### PR TITLE
docs(handoff): 2026-05-19 session handoff + LLM-facing freshness updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -525,13 +525,13 @@ Why it matters: the agent-facing brain has always been a black box — you could
 see what NeuralMind retrieved, whether the graph was reasonable, or what the
 synapse layer had actually learned. The graph view exposes all three.
 
-**Coming next (graph-view Phase B):** a
-[replay-last-query overlay](https://github.com/dfrostar/neuralmind/pull/105)
-that highlights the L3 hits the agent received,
-[edge tooltips + a min-weight synapse slider](https://github.com/dfrostar/neuralmind/pull/106)
-answering "why are these two nodes related?", pin UX, and a
-`Cmd/Ctrl-K` quick-switch. Then Phase C: a live activity feed of
-synapse co-activations. Full plan in [ROADMAP.md](ROADMAP.md).
+**Now live in the graph view** (as of v0.9.0): replay-last-query
+overlay, edge tooltips + min-weight synapse slider, pin UX,
+`Cmd/Ctrl-K` quick-switch, local-graph depth slider, and the live
+activity feed of synapse co-activations + file edits. Plus
+`/healthz` for Docker / systemd monitoring (v0.8.0+), GHCR
+auto-built container image (v0.9.0+), and a CycloneDX SBOM on every
+release. Full roadmap of what's next in [ROADMAP.md](ROADMAP.md).
 
 ---
 
@@ -861,7 +861,7 @@ supported — see the upstream
 for the full schema (`command`, `args`, `env`, `url`, `headers`, `enabled`,
 per-server `tools` filtering, `timeout`, `connect_timeout`).
 
-**v0.6.0 graph view works identically here.** Run `neuralmind serve` in
+**The live graph view (v0.6.0+) works identically here.** Run `neuralmind serve` in
 the same project and any tool call from Hermes-Agent will pulse the
 corresponding nodes on the canvas. The synapse store is shared with
 Claude Code, Cursor, OpenClaw, and any other agent pointed at this
@@ -897,7 +897,7 @@ openclaw mcp show neuralmind       # echoes the JSON you stored
 Remove with `openclaw mcp unset neuralmind`. Definitions are stored under
 the `mcp.servers` key in `~/.openclaw/openclaw.json`.
 
-**v0.6.0 graph view works identically here.** Run `neuralmind serve` in
+**The live graph view (v0.6.0+) works identically here.** Run `neuralmind serve` in
 the same project and any tool call from OpenClaw will pulse the
 corresponding nodes on the canvas. OpenClaw and Claude Code talking
 to the same project reinforce the same synapse store — see
@@ -956,7 +956,7 @@ for HTTP/SSE transports, OAuth, and per-server tool filtering.
 If you haven't installed Agent Zero yet, the upstream README has the
 Docker and Python install paths.
 
-**v0.6.0 graph view works identically here.** Run `neuralmind serve` in
+**The live graph view (v0.6.0+) works identically here.** Run `neuralmind serve` in
 the same project and any tool call from Agent Zero will pulse the
 corresponding nodes on the canvas. The synapse store is shared with
 Claude Code, Cursor, Cline, Continue, OpenClaw, Hermes-Agent, and any

--- a/docs/HANDOFF-2026-05-19.md
+++ b/docs/HANDOFF-2026-05-19.md
@@ -1,0 +1,401 @@
+# NeuralMind v0.9.x+ — Session Handoff (2026-05-19)
+
+> **For the next Claude Code session.** Hand this file URL to a fresh
+> session and it has everything needed to pick up cleanly.
+>
+> Predecessor: [`docs/HANDOFF-v0.6.1.md`](HANDOFF-v0.6.1.md) — the
+> handoff that kicked off the session this doc closes.
+>
+> Stable URL (after this branch lands):
+> `https://github.com/dfrostar/neuralmind/blob/main/docs/HANDOFF-2026-05-19.md`
+
+---
+
+## 🔗 Copy-paste prompt for the next session
+
+Paste the following block into a fresh Claude Code session to resume:
+
+```
+You're picking up a multi-release NeuralMind sprint. The previous
+session's full state, what shipped, what's next, and the open
+questions are documented at:
+
+https://github.com/dfrostar/neuralmind/blob/main/docs/HANDOFF-2026-05-19.md
+
+Read CLAUDE.md and the handoff doc above, then check the open PR
+list and the four open issues to confirm state before starting. The
+v0.6.1 → v0.7.0 release-version surprise documented there is the
+single most important lesson — merge commits for non-squash merges
+MUST be conventional-commit format or release-please will mis-bump.
+
+The immediate next actions, in priority order:
+
+1. Verify PyPI v0.9.0 + GHCR v0.9.0 + SBOM v0.9.0 all live
+   (commands at top of the handoff doc § 1).
+2. Merge PR #138 (v0.9.1 Perplexity-review fixes) — already CI-green,
+   conventional-commit-title required for the merge commit.
+3. Manual dispatch of release.yml for v0.9.1 once release-please
+   proposes it (until `RELEASE_PLEASE_TOKEN` secret is set — see § 5).
+4. Triage PR #133 (dependabot tiktoken 0.12 → 0.13 bump).
+5. Phase 0 hygiene that I (the agent) can't do — see § 4. Mostly
+   you (the maintainer) clicking buttons in GitHub UI.
+
+Marketing artifacts (LinkedIn drafts, NotebookLM packs, screencast
+scripts for v0.8 and v0.9) and the Agent Zero a0-plugins cross-repo
+PR are explicitly deferred but in the queue — see § 6.
+```
+
+---
+
+## TL;DR
+
+The previous session (2026-05-17 → 2026-05-18) took NeuralMind from
+v0.6.0 through **three live PyPI releases** (v0.7.0, v0.8.0, v0.9.0)
+plus the v0.9.1 follow-up patch (in flight). Each release shipped its
+own marketing-arc theme:
+
+| Version | Theme | PyPI | GHCR | SBOM |
+|---|---|---|---|---|
+| **v0.7.0** | Install anywhere — 5 install paths | ✅ | n/a | n/a |
+| **v0.8.0** | Always-On — systemd/launchd/Windows | ✅ | n/a | n/a |
+| **v0.9.0** | Enterprise-Ready — GHCR + SBOM + air-gapped + compliance | ✅ | *check § 1* | *check § 1* |
+| **v0.9.1** | Perplexity-review fixes — Grep matcher clarity, hook health-check, ROI caveat | PR #138 open | — | — |
+
+Plus the foundational infrastructure for those releases: a multi-stage
+`Dockerfile` in repo root, a `/healthz` endpoint on `neuralmind serve`,
+systemd + launchd templates, Windows Task Scheduler walkthrough,
+CycloneDX SBOM generation workflow, GHCR auto-build workflow,
+air-gapped install walkthrough, NIST/SOC 2/GDPR compliance one-pager,
+and a release-please PAT workflow change (PAT secret pending § 5).
+
+What's *not* done is the **marketing rollout** for v0.7/v0.8/v0.9
+(LinkedIn drafts for v0.7 done; v0.8 + v0.9 pending; NotebookLM packs
+for v0.8 + v0.9 pending; screencasts pending) and the **Agent Zero
+a0-plugins cross-repo PR** (recipe drafted, ready to submit).
+
+---
+
+## 1. First action for the next session — verify v0.9.0 is fully live
+
+Three independent surfaces need to be confirmed. The previous session
+left monitors running for SBOM and GHCR (they may have timed out by
+the time you read this); re-verify:
+
+```bash
+# PyPI v0.9.0 live (the previous session's monitor confirmed this)
+curl -fsS https://pypi.org/pypi/neuralmind/0.9.0/json | python -c "import json,sys; print(json.load(sys.stdin)['info']['version'])"
+# Expected: 0.9.0
+
+# GHCR image v0.9.0 live (the docker-publish.yml dispatch may have
+# completed since the session ended)
+curl -fsS "https://ghcr.io/token?service=ghcr.io&scope=repository:dfrostar/neuralmind:pull" \
+  | python -c "import json,sys,os,urllib.request; t=json.load(sys.stdin)['token']; \
+    req=urllib.request.Request('https://ghcr.io/v2/dfrostar/neuralmind/manifests/v0.9.0', \
+    headers={'Authorization':'Bearer '+t,'Accept':'application/vnd.oci.image.index.v1+json'}); \
+    print('GHCR v0.9.0 manifest:', urllib.request.urlopen(req).status)"
+# Expected: GHCR v0.9.0 manifest: 200
+# If 401 / 404 → the GHCR package may default to PRIVATE on first push.
+# Fix once: github.com/dfrostar?tab=packages → click `neuralmind` →
+# Package settings → Danger zone → Change visibility → Public.
+
+# SBOM v0.9.0 attached to the GitHub Release
+curl -fsSL https://github.com/dfrostar/neuralmind/releases/download/v0.9.0/neuralmind-v0.9.0.sbom.json \
+  | python -c "import json,sys; d=json.load(sys.stdin); print('components:', len(d.get('components',[])))"
+# Expected: components: 50+
+```
+
+If any are missing, re-dispatch the corresponding workflow with tag
+`v0.9.0` from the Actions UI or `gh workflow run`. See § 5 for the
+underlying `RELEASE_PLEASE_TOKEN` issue.
+
+---
+
+## 2. What shipped this session (full audit)
+
+### Releases on PyPI (3)
+
+- **v0.7.0** (2026-05-17) — "Install Anywhere"
+  - 5-path install matrix (pip, pipx, uv, Docker, source) in README + Setup-Guide + wiki Installation + 5 comparison pages
+  - Multi-stage `Dockerfile` in repo root (non-root runtime, transitive deps pre-wheeled in builder so runtime never reaches PyPI)
+  - 8 new PyPI keywords matching v0.6.0 product copy (`graph-view`, `hebbian-learning`, `force-directed-graph`, etc.)
+  - `fix(event_log)` for #115 — rotated logs reopen from offset 0; `reopen_at_start` preserved across failed opens
+  - `test(server)` for #116 — explicit `/api/queries` no-arg default-20 coverage
+  - Agent Zero MCP integration block in README (matching Hermes/OpenClaw pattern)
+  - Marketing artifacts: LinkedIn drafts (2 voices) + 60-sec screencast script + 3-doc NotebookLM pack
+  - **Version surprise:** release-please bumped `feat(...)` commits to **0.7.0** (minor), not the planned `0.6.1`. The docs were renamed v0.6.1 → v0.7.0 to match (PR #124). **Process-fix lesson:** install-anywhere docs were `feat`-tagged, which is correct semver; the "v0.6.1 patch" label was always wishful.
+
+- **v0.8.0** (2026-05-18) — "Always-On"
+  - `/healthz` endpoint on `neuralmind serve` (unauthenticated, returns `{"status":"ok","version":...}`, 3 new tests). Designed for Docker `HEALTHCHECK` + systemd `ExecStartPost`.
+  - `scripts/systemd/neuralmind-{watch,serve}.service` — user-scope units with `NoNewPrivileges`, `PrivateTmp`, `ProtectSystem=strict`, `ReadWritePaths=%h` (replaces the invalid `ProtectHome=read-write` Codex caught).
+  - `scripts/launchd/com.neuralmind.{watch,serve}.plist` — macOS user agents with `RunAtLoad` + `KeepAlive` + `ThrottleInterval`. The serve plist had a `--host` literal inside the XML comment block that broke `plutil` — Copilot caught, fixed.
+  - Windows Task Scheduler "Always-on" section in `docs/wiki/Scheduling-Guide.md` with `--no-browser` and `ExecutionTimeLimit=0` (avoids the 72-hour default cap).
+  - `docs/use-cases/always-on.md` — cross-platform walkthrough (Linux/macOS/Windows + Docker HEALTHCHECK) with install + verify + uninstall + troubleshooting. Includes a "no checkout? fetch templates via curl" snippet for pip/pipx/Docker users.
+  - Aider integration block **deferred** — confirmed via WebFetch that current Aider stable has no MCP-client support (2026-05-17). Adds when upstream lands it.
+  - **Version surprise #2:** PR #125 was merged with a non-conventional commit title (`"v0.8.0: always-on..."`), so release-please missed the `feat(serve)` content and proposed v0.7.1. Resolved via a `Release-As: 0.8.0` override commit (PR #128).
+
+- **v0.9.0** (2026-05-18) — "Enterprise-Ready"
+  - `.github/workflows/docker-publish.yml` — GHCR auto-build on tag push. Multi-platform (`linux/amd64` + `linux/arm64`). Uses `docker/metadata-action` for case-safe naming + smart `:latest` gating (excludes pre-release tags). `verify-pull` job pulls the freshly-pushed image and runs `neuralmind --help` inside it.
+  - `.github/workflows/sbom.yml` — CycloneDX JSON SBOM via Anchore syft. 6-minute polling loop around `gh release view` so it lands on first publish even when `release.yml` is still in flight.
+  - `docs/use-cases/air-gapped.md` — bundle-and-sneakernet for PyPI wheels + ChromaDB ONNX model cache, with the Docker variant via `docker save`. Cross-platform tag selection for `pip download --platform`.
+  - `docs/COMPLIANCE-SUMMARY.md` — NIST AI RMF + SOC 2 + GDPR consolidation. Every claim has a "how to verify yourself" command so readers don't have to take our word.
+
+### v0.9.1 in flight
+
+- **PR #138** open, CI green at last check. Three small post-Perplexity-review fixes:
+  - `neuralmind/hooks.py` — comment on the `Grep` matcher noting Claude Code v2.1.117+ behavior (Grep/Glob folded into Bash on native macOS/Linux); our matcher list stays robust because the `Bash` matcher catches the rerouted searches.
+  - `docs/wiki/Troubleshooting.md` — new "Hook Issues" section with post-Claude-Code-update health check + explicit PostToolUse scope (we compress built-in tools, not third-party MCP tools).
+  - `USAGE.md` — stronger inline caveat above the ROI Calculator dollar figures (project-side projections, not independently audited; cross-link to `HONEST-ASSESSMENT.md`).
+  - Single commit with `Release-As: 0.9.1` footer so release-please proposes a clean patch despite all changes being `docs(...)`.
+
+### Infrastructure / process improvements
+
+- **PR #126 / Issue #98** — release-please workflow now uses `RELEASE_PLEASE_TOKEN || GITHUB_TOKEN` fallback. The `|| GITHUB_TOKEN` part means it's safe to merge before the secret exists; once you add the secret (see § 5), every future release-please tag push auto-fires `release.yml` + `docker-publish.yml` + `sbom.yml` without manual dispatch.
+- **Issue #85** closed as duplicate of #98.
+- **Dependabot PRs #93, #94, #95** closed as stale-against-pre-v0.7.0 base. Dependabot recreates if the bumps are still relevant.
+- **PR #100 (self-improvement engine)** converted to **draft** + parked with a comment. The planning docs (`evals/self_improvement/PLAN.md`, `evals/faithfulness/PLAN.md`) are the unique value worth preserving even if the D1/D2 code itself ends up rewritten.
+- **PR #117 (Phase 0 hygiene)** — partially complete (dependabot triage done); the rest is your UI work (see § 4).
+
+### Documentation propagated
+
+- README hero callout cascade: v0.9.0 (top) → v0.8.0 → v0.7.0 → v0.6.0
+- `docs/wiki/Home.md` "What's New" entries for v0.9.0 + v0.8.0 above v0.7.0
+- `docs/about.html` new sections `#whats-new-v090` + `#whats-new-v080`
+- `docs/index.html` (GitHub Pages hero) leads with v0.9.0
+- `docs/wiki/Installation.md` Docker section uses `ghcr.io/dfrostar/neuralmind:latest`
+- `docs/wiki/Setup-Guide.md` Docker row matched
+- `docs/wiki/Scheduling-Guide.md` Always-on Windows section
+- `ROADMAP.md` — "Shipped in v0.9.0 / v0.8.0 / v0.7.0" sections; "Now — marketing rollout" + "Next" sections forward
+- `RELEASE_NOTES_v0.7.0.md`, `RELEASE_NOTES_v0.8.0.md`, `RELEASE_NOTES_v0.9.0.md` all in repo
+
+### Renames / file moves
+
+- `RELEASE_NOTES_v0.6.1.md` → `RELEASE_NOTES_v0.7.0.md` (git mv preserved history)
+- `docs/SCREENCAST-v0.6.1.md` → `docs/SCREENCAST-v0.7.0.md`
+- `docs/notebooklm/v0.6.1/` → `docs/notebooklm/v0.7.0/`
+
+---
+
+## 3. What's next — priority order
+
+### High priority — short cycle
+
+1. **Verify v0.9.0 fully landed** (§ 1 commands). If GHCR package is private on first push, flip to public via the Packages UI.
+2. **Merge PR #138** (v0.9.1 Perplexity-review fixes). Use conventional-commit-format merge commit title — e.g., `docs(post-review): v0.9.1 patch fixes (#138)`. Then merge the release-please PR that follows (squash), dispatch `release.yml` for v0.9.1 (or auto-fire if `RELEASE_PLEASE_TOKEN` secret is set per § 5).
+3. **Triage PR #133** (dependabot `tiktoken 0.12 → 0.13`). Was opened during the session. Changelog is benign (regex perf, pyo3 update). Either merge after CI confirms or close-as-stale-pattern like the earlier dependabot bumps.
+
+### Medium priority — process
+
+4. **`RELEASE_PLEASE_TOKEN` PAT secret setup (§ 5)** — ~5 minutes UI work; makes every future release auto-publish.
+5. **Phase 0 hygiene completion (§ 4)** — branch deletion, About-box rewrite, repo topics. All your UI work.
+6. **Agent Zero a0-plugins cross-repo PR** — recipe + draft ready at `docs/integration-submissions/agent-zero/index.yaml`. ~3 min: fork `agent0ai/a0-plugins`, add `plugins/neuralmind/index.yaml`, submit. Full instructions in the deferred-work section of this doc's predecessor (`HANDOFF-v0.6.1.md` § 5).
+
+### Lower priority — marketing rollout
+
+7. **v0.8 LinkedIn drafts** — pattern matches v0.7's `docs/LINKEDIN-POST-DRAFT.md` block. Audience: ops/SREs. Voice: "set it and forget it" / always-on framing.
+8. **v0.9 LinkedIn drafts** — same file, new block. Audience: CTOs, security teams, regulated industries. Voice: "containerized + SBOM + audit-ready."
+9. **v0.8 NotebookLM pack** at `docs/notebooklm/v0.8.0/` — 3 docs matching v0.7.0's structure (origin-story / what-shipped / honest-take registers).
+10. **v0.9 NotebookLM pack** at `docs/notebooklm/v0.9.0/`.
+11. **v0.8 + v0.9 screencast scripts** at `docs/SCREENCAST-v0.8.0.md` + `docs/SCREENCAST-v0.9.0.md`.
+12. **Optional Hacker News submission** for the v0.9 enterprise pitch — "Show HN: NeuralMind 0.9 — local AI code memory, containerized + SBOM + NIST AI RMF." Higher variance but right audience for this phase.
+
+### Strategic / longer-horizon
+
+13. **GitHub App** for release automation (more durable than PAT — survives maintainer turnover, no rotation; ~30 min one-time setup). Alternative to the PAT in § 5.
+14. **Cosign image signing** for GHCR images — provenance attestation. Enterprise-pitch upgrade.
+15. **`punkpeye/awesome-mcp-servers`** — drive-by listing in the community awesome-list. Low effort, additional discoverability.
+16. **PR #100 (self-improvement engine)** — parked draft. Decide rebase vs close after v0.9.x stabilizes. The planning docs (`evals/self_improvement/PLAN.md`) are worth preserving even if the code is rewritten.
+17. **mypy 2.0 upgrade** — PR #95 was closed as stale, but the bump has breaking defaults worth a focused PR (`--strict-bytes`, `--local-partial-types` enabled by default, new `--allow-redefinition` semantics).
+
+### Architecture / engineering candidates — v0.10+ themes
+
+The previously-tracked graph-view backlog stays open but un-prioritised:
+
+- **Saved views** — Obsidian-style named filter/zoom/depth presets, `localStorage`-backed
+- **Right-click context menu** on graph nodes (open-in-editor, pin/unpin, focus, copy id)
+- **PNG / SVG canvas export**
+- **Time-based edge filter** complementing v0.6.0's min-weight slider
+- **Unify `neuralmind watch` with the in-process bus** when they share a process (JSONL bridge becomes a pure cross-process fallback)
+
+Potential v0.10+ themes worth scoping:
+
+- **"Brain-Visible-By-Default"** — make the live activity feed even more discoverable (auto-open canvas on first `neuralmind serve`, in-canvas tutorials, etc.)
+- **"Multi-Project Mode"** — one MCP server, many projects; the agent picks the right project per query
+- **"Eval Framework"** — the faithfulness eval scaffolded in PR #100 could mature into a v0.10 product (independent token-reduction × answer-correctness measurement)
+- **"Self-Improvement Engine"** — D2/D3 from PR #100, opt-in `NEURALMIND_SELECTOR_AUTOTUNE=1` that adjusts retrieval params from observed agent usage
+
+---
+
+## 4. Phase 0 hygiene — what's left for the maintainer
+
+Most of these require GitHub UI access I (the agent) can't reach.
+Issue tracker: [#117](https://github.com/dfrostar/neuralmind/issues/117).
+
+- [ ] **Delete stale `claude/*` branches.** Use this one-liner from a
+      maintainer shell:
+      ```bash
+      git fetch --prune origin
+      git for-each-ref --merged origin/main --format='%(refname:short)' \
+        refs/remotes/origin/claude/ refs/remotes/origin/copilot/ | \
+        sed 's|^origin/||' | xargs -I {} git push origin :{}
+      ```
+- [ ] **Rewrite the repo About-box** (top of repo page on GitHub).
+      Suggested copy:
+      > Local-first semantic code intelligence for AI coding agents.
+      > 40-70× token reduction on code questions, brain-like synapse
+      > layer that learns from co-activation, Obsidian-style graph
+      > view (`neuralmind serve`), and now containerized + SBOM-signed
+      > for enterprise deployment. MCP server + PostToolUse compression
+      > for Claude Code, Cursor, Cline, Continue, Agent Zero,
+      > Hermes-Agent, OpenClaw.
+- [ ] **Add repo topics chips** if not done already: `graph-view`,
+      `code-visualization`, `synapse`, `hebbian-learning`, `obsidian`,
+      `force-directed-graph`, `code-graph`, `air-gapped`, `sbom`,
+      `nist-ai-rmf`. (Current count + target: ~17.)
+- [ ] **Verify PyPI trusted publisher** still pinned to `release.yml`
+      at https://pypi.org/manage/project/neuralmind/settings/publishing/.
+      v0.7.0/v0.8.0/v0.9.0 all published successfully so it works,
+      but worth a glance.
+
+---
+
+## 5. `RELEASE_PLEASE_TOKEN` PAT setup — the one-time secret
+
+PR #126 added the workflow change that respects this secret if it
+exists (falling back to `GITHUB_TOKEN` if not). The secret itself is
+still pending. Without it, **every release-please tag push needs a
+manual `gh workflow run release.yml --ref vX.Y.Z` dispatch**, like
+this session manually dispatched for v0.7.0, v0.8.0, and v0.9.0.
+
+### Fine-grained PAT setup (~5 min, recommended)
+
+1. https://github.com/settings/personal-access-tokens/new
+2. Fields:
+   - **Token name:** `neuralmind release-please`
+   - **Expiration:** 1 year
+   - **Resource owner:** `dfrostar`
+   - **Repository access:** Only select repositories → `dfrostar/neuralmind`
+   - **Repository permissions:**
+     - Contents: Read and write
+     - Pull requests: Read and write
+     - (Metadata: Read auto-ticked)
+3. Generate. Copy the `github_pat_…` value.
+4. https://github.com/dfrostar/neuralmind/settings/secrets/actions →
+   New repository secret:
+   - **Name:** `RELEASE_PLEASE_TOKEN` (exact spelling)
+   - **Secret:** paste from step 3
+5. Done. Next release-please tag push auto-fires `release.yml` +
+   `docker-publish.yml` + `sbom.yml`.
+
+### Why not a GitHub App (option B)
+
+A GitHub App is more durable (no per-account expiry, survives
+maintainer turnover, more granular permissions). But it's ~30 min to
+set up (create App, install on repo, store private key as secret,
+wire into the workflow with `actions/create-github-app-token`). PAT is
+the 10-minute unblock. Migrate later if the project grows multiple
+maintainers.
+
+---
+
+## 6. Cross-release marketing arc (deferred work)
+
+The three releases each target a different audience. The arc was the
+whole point of the multi-phase split:
+
+| Release | Audience | Frame | LinkedIn block | NotebookLM | Screencast |
+|---|---|---|---|---|---|
+| v0.7.0 | Python developers, AI-tooling early adopters | "Install five ways" | ✅ drafted in `docs/LINKEDIN-POST-DRAFT.md` | ✅ `docs/notebooklm/v0.7.0/` | ✅ `docs/SCREENCAST-v0.7.0.md` |
+| v0.8.0 | Ops / SREs / dev-tooling power users | "Runs as a service" | ⏳ pending | ⏳ pending | ⏳ pending |
+| v0.9.0 | CTOs / security teams / regulated industries | "Containerized + auditable" | ⏳ pending | ⏳ pending | ⏳ pending |
+
+All v0.8 + v0.9 marketing was explicitly deferred to keep the
+code-shipping PRs scope-clean. Whenever you (or a future session) want
+to do the marketing rollout, the v0.7 drafts are the template — copy
+the structure, swap the frame, the audience, and the headline visual.
+
+**One open question** worth deciding before drafting v0.9's
+marketing: do you want to do the **Hacker News submission**? Higher
+variance than LinkedIn but right audience. If yes, the screencast
+script for v0.9 should explicitly anchor on the GHCR-pull-side-by-side
++ SBOM-curl visual the v0.9.0 release notes hint at.
+
+---
+
+## 7. Open questions for the next session
+
+1. **Skip the v0.8 + v0.9 marketing entirely?** The code is shipped
+   and the GitHub Release pages have auto-generated changelogs. If
+   the previous marketing arc framing isn't yielding traction, it's
+   fair to just skip the structured marketing rollout for v0.8 + v0.9
+   and use the next release moment (v0.10?) for a consolidated push.
+2. **PR #100 — close or rebase?** It's a substantial parked draft
+   (1694 lines, 14 commits) with planning value. Decide.
+3. **GitHub App vs PAT for release automation?** Per § 5. PAT is the
+   10-min option; GitHub App is the right long-term answer.
+4. **What's the v0.10 theme?** The release arc has run out of pre-
+   planned themes — v0.6.0 visible, v0.7 reachable, v0.8 persistent,
+   v0.9 auditable. v0.10 needs a new story. Candidates in § 3
+   "Architecture / engineering candidates."
+
+---
+
+## 8. Repo conventions (carried forward, with lessons learned)
+
+Same as `HANDOFF-v0.6.1.md` § 7, plus three hard-learned lessons:
+
+- **Conventional-commit-format merge commit titles are not optional.**
+  If you merge a PR with `merge` method (not squash) and the merge
+  commit title doesn't start with `feat(...)` / `fix(...)` / etc.,
+  release-please reads the merge commit title and misses the
+  `feat`/`fix` content inside. v0.8.0 mis-bumped because of this;
+  required a `Release-As:` override commit to fix.
+- **release-please bumps `0.x` on `feat(...)` as MINOR.** Configured
+  in PR #114 long ago. So a "small feature" like install-paths
+  documentation tagged `feat(install)` jumps a whole minor version.
+  Use `docs(...)` for doc-only work; reserve `feat(...)` for real
+  product-surface additions, *or* accept the minor bump and adjust
+  the narrative.
+- **The `GITHUB_TOKEN` anti-recursion guard (#98) bites every
+  release-please-driven release** until the PAT secret is set (§ 5).
+  PR #126 shipped the workflow change that respects the secret;
+  setting the secret itself is the unblock.
+
+---
+
+## 9. Final state — open PRs / issues at handoff
+
+**Open PRs:**
+
+| # | Title | State |
+|---|---|---|
+| 100 | Self-improvement engine | Draft, parked |
+| 121 | v0.6.1+ release handoff doc | Predates this session; the handoff doc itself |
+| 133 | chore(deps): bump tiktoken 0.12 → 0.13 | Dependabot, opened mid-session, needs triage |
+| 138 | docs: v0.9.1 — post-Perplexity-review fixes | CI green, ready to merge |
+| (new) | docs: HANDOFF-2026-05-19.md (this doc) | This one |
+
+**Open issues:**
+
+| # | Title | State |
+|---|---|---|
+| 98 | release.yml not triggered by release-please tag push | Workflow fix shipped; secret pending |
+| 117 | Phase 0 hygiene | Partial — dependabot triaged; UI work remains |
+
+#115, #116, #119, #120 all closed by the v0.7/v0.8/v0.9 releases.
+
+---
+
+## 10. Lessons learned (compact)
+
+For the next agent session, in priority order:
+
+1. **Use conventional-commit titles for merge commits**, not free-form (`merge` method PRs).
+2. **`feat(...)` in `0.x` bumps minor**, not patch. Tag intent accurately or accept the version bump.
+3. **Verify upstream claims before propagating.** This session debunked 2 of 6 Perplexity claims about NeuralMind that would have shipped as wrong docs if accepted on face value. Specific issue numbers and version strings from AI research tools are exactly what they confabulate.
+4. **Defer marketing artifacts unless you have time to do them well.** Marketing-arc deferrals didn't hurt the releases; rushed marketing would have.
+5. **The Phase 0 hygiene work is small in hours but high in repo-look-and-feel impact.** Worth doing whenever you have a session with the GitHub UI open anyway.
+
+---
+
+*Generated by the 2026-05-17 → 2026-05-18 Claude Code session that
+shipped v0.7.0, v0.8.0, v0.9.0, and queued v0.9.1.*

--- a/docs/HANDOFF-2026-05-19.md
+++ b/docs/HANDOFF-2026-05-19.md
@@ -313,11 +313,185 @@ code-shipping PRs scope-clean. Whenever you (or a future session) want
 to do the marketing rollout, the v0.7 drafts are the template — copy
 the structure, swap the frame, the audience, and the headline visual.
 
-**One open question** worth deciding before drafting v0.9's
-marketing: do you want to do the **Hacker News submission**? Higher
-variance than LinkedIn but right audience. If yes, the screencast
-script for v0.9 should explicitly anchor on the GHCR-pull-side-by-side
-+ SBOM-curl visual the v0.9.0 release notes hint at.
+### 6.1 Distribution channels — corporates, agent hubs, Reddit
+
+The audience matrix above tells you *who* — this section is *where*.
+Ranked by leverage-per-effort, highest first.
+
+**Tier 1 — One-shot, high-leverage moments**
+
+| Channel | Effort | Best release to anchor on | Notes |
+|---|---|---|---|
+| **Hacker News Show HN** | 30 min to write + post | v0.9.0 enterprise-ready (or v0.10 if you wait) | Single shot with high variance. Wednesday/Thursday US morning is the conventional best slot. Anchor on the SBOM + GHCR + air-gapped story for HN's audience. Don't post both v0.8 and v0.9 separately — pick one. Recommend v0.9 because the "AI tool with NIST + SOC 2 + SBOM" angle is a fresher HN frame than "another AI dev tool." |
+| **Agent Zero `agent0ai/a0-plugins` submission** | 3 min UI work | v0.7.0+ (any current) | 17.7k stars, in-app one-click discovery for users. Already drafted at `docs/integration-submissions/agent-zero/`. **Just needs the maintainer to submit the cross-repo PR.** Single highest-leverage move for agent-hub presence. |
+| **LinkedIn post per release** | 1-2 hr each (drafts + screencast pairing) | v0.7 done, v0.8 + v0.9 pending | Each release targets a different network — `#ClaudeCode`, `#DevOps`, `#CTOs`. Don't bundle. v0.7 drafts at `docs/LINKEDIN-POST-DRAFT.md`. |
+| **Reddit Show / Update posts** | 30 min each per subreddit | One post per release across 2-3 subs max | See 6.2 below for subreddit-specific tactics. |
+
+**Tier 2 — Passive discoverability (low effort, sustained value)**
+
+- **`punkpeye/awesome-mcp-servers`** — community awesome-list. Single
+  PR adds NeuralMind to a list 1k+ developers reference when choosing
+  MCP servers. ~10 min.
+- **GitHub repo topics** (Phase 0 hygiene § 4) — finally adding the
+  pending topics (`air-gapped`, `sbom`, `nist-ai-rmf`, etc.) so
+  GitHub's topic-based discovery surfaces NeuralMind.
+- **PyPI keyword refresh on every release** — v0.7.0 already bumped
+  keywords; future releases can iterate. PyPI's full-text search
+  matches against this aggressively.
+- **MCP Cheat Sheets / "awesome" lists** — search GitHub for
+  "awesome-claude-code" / "awesome-mcp" / "awesome-llm-tools" and
+  PR a one-line entry.
+
+**Tier 3 — Active community pushes (moderate effort)**
+
+- **Hermes-Agent community channels** — Nous Research has an active
+  Discord. Post in their tools/extensions channel when v0.8 + v0.9
+  marketing lands. Direct outreach to a maintainer for a sticky in
+  the docs site is also reasonable.
+- **OpenClaw community** — same shape; OpenClaw has Discussions on
+  the GitHub repo and a Discord. The `docs/comparisons/` page on
+  OpenClaw already lists NeuralMind as the "go-to fix for token
+  costs" per the Perplexity review. Worth confirming + thanking +
+  asking for a sticky.
+- **Agent Zero Discord / Discussions** — after the a0-plugins
+  submission lands, post a "NeuralMind is now in the Plugin Hub"
+  announcement.
+- **Conferences** — PyCon, KubeCon, security cons (Black Hat, RSA).
+  Long lead times; only worth pursuing if you want to commit to a
+  talk. Higher cost-per-impression than online channels.
+
+### 6.2 Reddit strategy specifically
+
+Reddit's culture is hostile to overt promotion. The frame that works
+is "I built/use this; here's what it does for me" with a clear
+technical hook, not a marketing tagline. **One post per release at
+most**, and not the same week as your HN submission (HN traffic
+spillover can read as astroturfing).
+
+| Subreddit | Audience | Best release fit | Posting frame |
+|---|---|---|---|
+| `r/ClaudeAI` (~150k) | Claude Code + Claude Desktop users | v0.7 install matrix / v0.8 always-on | "I cut my Claude bill 60× with this. PostToolUse hooks + semantic retrieval. 100% local." Include the screencast. |
+| `r/LocalLLaMA` (~400k) | Local-first AI / privacy-conscious | v0.9 enterprise-ready | "Local-first code RAG for AI coding agents. No telemetry, no cloud, MIT, now with SBOM + air-gapped install." Anchor on the no-data-leaves-your-machine guarantee. |
+| `r/ChatGPTCoding` (~200k) | Mixed AI coding tools | v0.7 install matrix | Frame as "here's how I keep context cheap for the AI." The 40-70× number lands here. |
+| `r/programming` (~6M) | Generic dev | Only if you have something genuinely novel | Hardest to land. Skip unless you have a story like "we shipped a new SBOM workflow that runs on every release." |
+| `r/devops` (~500k) | Ops / SRE | v0.8 always-on | "systemd unit for our internal code-RAG daemon — share what you got." More community than promo. |
+| `r/Python` (~1.3M) | Python dev | v0.7 install matrix | "Five ways to install a Python tool: pip / pipx / uv / Docker / source — here's why each matters." Frame as a teaching post, not a NeuralMind ad. |
+
+**Do not crosspost** the same content to multiple subs simultaneously
+— Reddit's automod treats this as spam and shadow-bans the link.
+
+### 6.3 Influencer outreach — specific names
+
+Not endorsements; these are people whose audience overlaps NeuralMind's
+ideal user. Cold outreach via Twitter DM, email (if listed), or
+public reply to a relevant tweet.
+
+**Highest-signal targets** (most aligned, most likely to bite):
+
+- **Simon Willison** (@simonw on Twitter, simonwillison.net) — runs
+  the most-referenced "TIL local AI tooling" blog in this space.
+  Has covered MCP servers, agent infrastructure, and local-first AI
+  tools extensively. Probably the single most-aligned single person
+  to email/DM about NeuralMind. He'll dismiss anything that smells
+  like a pitch; lead with the technical "look what we built and
+  here's the SBOM workflow" angle.
+- **swyx (Shawn Wang)** (@swyx) — hosts Latent Space podcast, runs
+  the AI Engineer newsletter (~50k+). Has covered MCP ecosystem,
+  agent infra. Latent Space episode pitch would be a longer-form
+  fit (45-60 min interview).
+- **Hamel Husain** (@HamelHusain) — focused on eval + agent
+  infrastructure. The faithfulness eval scaffolding in PR #100
+  would resonate here.
+
+**Adjacent (covers the space but less directly):**
+
+- **Jeremy Howard** (@jeremyphoward, fast.ai) — would care about
+  the cost-reduction angle. Wide audience.
+- **Eugene Yan** (@eugeneyan) — ML engineer who writes about
+  practical agent / LLM infra.
+- **Chip Huyen** (@chipro) — ML infra; author of *Designing
+  Machine Learning Systems*. Less likely to amplify a single tool
+  but high credibility if she does.
+
+**Newsletters worth pitching for an inclusion:**
+
+- **Simon Willison's Weeknotes** (same person; mentioned above
+  because his blog is the primary surface).
+- **Latent Space newsletter** (swyx).
+- **Import AI** (Jack Clark, ex-OpenAI) — strategic AI coverage;
+  enterprise NIST/SBOM angle could fit.
+- **The Pragmatic Engineer** (Gergely Orosz) — covers dev tools,
+  has a "tools I use" theme. The token-reduction story is exactly
+  his audience.
+- **AI Engineer Newsletter / The Sequence / The Algorithmic
+  Bridge** — broader AI coverage; likely a brief inclusion at best.
+
+**Podcasts worth pitching (longer-form):**
+
+- **Latent Space** (swyx + Alessio) — top AI engineering podcast.
+- **Practical AI** (Chris Benson + Daniel Whitenack).
+- **The TWIML AI Podcast** (Sam Charrington).
+- **Cognitive Revolution** (Nathan Labenz) — covers AI strategy.
+
+**Outreach template (compact, for cold DM/email):**
+
+> Hi <name> — built NeuralMind, an MCP server that reduces AI-coding
+> token costs 40-70× per query via semantic retrieval + PostToolUse
+> output compression. v0.9 just shipped containerized + SBOM + NIST
+> AI RMF audit trail. 100% local, MIT, 388 tests, ~5k stars [adjust
+> to actual].
+>
+> Two relevant angles for your audience: (1) the local-first
+> compliance story (CTOs / regulated industries) and (2) the
+> shared-synapse-store-across-agents pattern (Claude Code + Cursor +
+> Agent Zero all reinforcing one brain).
+>
+> 60-second screencast: [link]
+> Repo: github.com/dfrostar/neuralmind
+>
+> Happy to go deeper if any of this lands; otherwise no obligation.
+
+Keep it under 100 words, anchor on a single specific claim, and
+include the screencast link. Don't follow up more than once if no
+response.
+
+### 6.4 Corporate adoption playbook
+
+NeuralMind is MIT and there's no commercial entity, so "sell to
+corporates" means "make adoption frictionless and have the proof
+artifacts ready when their security team asks." The v0.9.0 release
+already shipped the proof artifacts:
+
+- **First procurement contact:** `docs/COMPLIANCE-SUMMARY.md` is the
+  one-page that a procurement reviewer or CTO can read in 3 min.
+  Cross-link it prominently from any external write-ups.
+- **Second contact:** the SBOM and GHCR image. Both auto-generated
+  on every release; both linkable by URL.
+- **Third contact:** `docs/use-cases/air-gapped.md` for the
+  network-isolated deployment story.
+
+What's still missing for the corporate motion:
+
+- **A "talk to us" channel.** Currently the only surface is GitHub
+  Issues. A pinned Discussions thread for "regulated-industry
+  deployment Q&A" (mentioned in #120) gives security teams a
+  public-but-quiet space to ask. Lower-friction than opening an
+  issue.
+- **Case studies.** Even one or two named customers with a "here's
+  what we deploy and why" writeup would 10× the credibility for
+  the next reviewer. Hard to engineer; happens organically over
+  ~12 months if the adoption curve has any slope.
+- **A non-personal email contact.** The "Security disclosures" path
+  in `SECURITY.md` is fine for security, but procurement /
+  compliance reviewers don't always want to open a public issue
+  for their first question. A `compliance@<domain>` or even a
+  Cal.com link would help. Tradeoff: visible inbox + commitment to
+  respond.
+
+**Direct outreach to specific companies** is high-cost / high-touch
+work. Only worth pursuing for clearly-aligned targets (DoD / FedRAMP
+contractors, regulated fintech, healthcare AI startups), and only
+once at least one of the case-studies above lands.
 
 ---
 

--- a/docs/about.html
+++ b/docs/about.html
@@ -85,7 +85,7 @@
                 <li><strong><code>pip install neuralmind graphifyy</code></strong> — the default. Works in any venv.</li>
                 <li><strong><code>pipx install neuralmind</code></strong> — global CLI, isolated env. <code>neuralmind</code> on PATH everywhere without activation.</li>
                 <li><strong><code>uv pip install neuralmind graphifyy</code></strong> — ~10× faster than pip, same wheel.</li>
-                <li><strong><code>docker build -t neuralmind:dev .</code></strong> — multi-stage Dockerfile in the repo root, non-root runtime, transitive deps pre-wheeled in the builder. GHCR auto-publish lands in a later release; build locally for now.</li>
+                <li><strong><code>docker build -t neuralmind:dev .</code></strong> — multi-stage Dockerfile in the repo root, non-root runtime, transitive deps pre-wheeled in the builder. <em>(GHCR auto-publish landed in v0.9.0 — see the v0.9.0 section above for the <code>docker pull ghcr.io/dfrostar/neuralmind</code> path.)</em></li>
                 <li><strong>From source</strong> — for contributors.</li>
             </ul>
             <p>All five paths deliver the same package: the <code>neuralmind</code> CLI, the <code>neuralmind-mcp</code> server (for Claude Code, Cursor, Cline, Continue, and any MCP client), and the live graph view from v0.6.0. Smoke test is identical: <code>neuralmind --help</code> works everywhere; <code>python -c "import neuralmind"</code> works for pip / uv / source paths.</p>


### PR DESCRIPTION
## Summary

Two-purpose doc-only PR. All commits are `docs(...)` so release-please won't bump the version.

### 1. `docs/HANDOFF-2026-05-19.md` (new file)

Session handoff for the next Claude Code agent picking up after the v0.7.0/v0.8.0/v0.9.0 release train. Modeled on the [predecessor `HANDOFF-v0.6.1.md`](docs/HANDOFF-v0.6.1.md) that kicked off this entire session.

**Includes a copy-paste prompt at the top** — paste into a fresh session and the agent has everything it needs to pick up cleanly.

Sections: TL;DR · § 1 verify v0.9.0 fully landed · § 2 full audit of what shipped · § 3 prioritized "what's next" · § 4 Phase 0 hygiene maintainer-UI items · § 5 PAT secret setup · § 6 cross-release marketing arc · § 7 open questions · § 8 lessons learned · § 9 final state · § 10 compact lessons.

### 2. README + about.html freshness pass

The LLM/agent install-instructions surface had three stale spots that survived earlier doc rollouts:

- **README § "🕸️ Graph view":** the "Coming next (Phase B)" paragraph described features that **all shipped in v0.6.0**. Replaced with a "Now live in the graph view (as of v0.9.0)" status listing every feature actually live today — replay overlay, edge tooltips, min-weight slider, pin UX, Cmd/Ctrl-K, depth slider, live activity feed, `/healthz`, GHCR image, SBOM.

- **README Hermes-Agent / OpenClaw / Agent Zero sections (×3):** each said "v0.6.0 graph view works identically here." Replaced with "The live graph view (v0.6.0+) works identically here." — same claim, no longer pinned to a specific 3-releases-old version.

- **docs/about.html v0.7.0 "What's New" Docker bullet:** was "GHCR auto-publish lands in a later release; build locally for now." Added a parenthetical noting it landed in v0.9.0, preserving the v0.7.0 historical context.

## What was deliberately NOT touched (scope-control)

- **v0.8 + v0.9 marketing artifacts** (LinkedIn drafts, NotebookLM packs, screencast scripts) — substantial work, need their own focused session. Handoff doc § 6 documents the queue.
- **Wiki Comparisons / FAQ / Usage-Guide / API-Reference / Architecture / Learning-Guide:** don't reference version-specific install or agent-integration instructions, so not stale in the way that affects LLM/agent consumers.
- **`docs/use-cases/*.md`:** many use `pip install neuralmind graphifyy` (correct — one of the 5 paths). The install matrix is the canonical "all paths" view and these pages link to it.

## Test plan

- [x] No code changes; no test changes
- [x] HANDOFF doc renders cleanly as markdown
- [x] No `0.6.0`-only callouts remain in the Hermes/OpenClaw/Agent Zero blocks
- [x] README "🕸️ Graph view" section reflects v0.9.0 state
- [x] `docs/about.html` v0.7.0 section's "build locally for now" caveat now references its v0.9.0 successor

## Order vs PR #138

This PR doesn't depend on #138 (v0.9.1 fixes) merging first. They're independent doc-only branches. Merge either order with `merge` method + conventional-commit-format title.

https://claude.ai/code/session_01SH6iHNAqeMJHXdq7ubVcuJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01SH6iHNAqeMJHXdq7ubVcuJ)_