### PR TITLE
fix(ci): docker-publish version tag missing on workflow_dispatch

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -69,11 +69,15 @@ jobs:
         uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          # type=ref,event=tag → :v0.9.0 from the pushed tag
-          # type=raw,latest → :latest only when the tag has no `-`
-          #   suffix (excludes v0.10.0-rc1, v1.0.0-beta1, etc.).
+          # type=raw,value=${{ env.RELEASE_TAG }} → :v0.9.0 from RELEASE_TAG.
+          # This works for BOTH push:tag (RELEASE_TAG = github.ref_name)
+          # AND workflow_dispatch (RELEASE_TAG = inputs.tag). The earlier
+          # `type=ref,event=tag` form only fired on push:tag, so workflow-
+          # dispatched runs produced only `:latest` with no version tag.
+          # type=raw,latest → :latest only when the tag has no `-` suffix
+          # (excludes v0.10.0-rc1, v1.0.0-beta1, etc.).
           tags: |
-            type=ref,event=tag
+            type=raw,value=${{ env.RELEASE_TAG }}
             type=raw,value=latest,enable=${{ !contains(env.RELEASE_TAG, '-') }}
           labels: |
             org.opencontainers.image.title=NeuralMind


### PR DESCRIPTION
## Summary

Small workflow YAML fix. One line of `docker/metadata-action` config.

## Problem

The v0.9.0 GHCR image was pushed by `docker-publish.yml` but **only got the `:latest` tag**, not `:v0.9.0`. Confirmed via the GHCR anonymous tags API:

```
$ curl -fsS -H "Authorization: Bearer $token" \
    https://ghcr.io/v2/dfrostar/neuralmind/tags/list
{"name":"dfrostar/neuralmind","tags":["latest"]}
```

Root cause: line 76 used `type=ref,event=tag`. That pattern only fires on **push:tag** events. When the workflow is dispatched via **workflow_dispatch** (the backfill path for tags that didn't auto-fire because of #98), `github.event_name` is `workflow_dispatch`, not `push`, so `event=tag` doesn't match and **no version tag is produced**.

## Fix

```yaml
tags: |
  type=raw,value=${{ env.RELEASE_TAG }}      # ← was: type=ref,event=tag
  type=raw,value=latest,enable=${{ !contains(env.RELEASE_TAG, '-') }}
```

`type=raw,value=${{ env.RELEASE_TAG }}` reads from the `RELEASE_TAG` env var, which is set correctly for **both** event paths:

- `push:tag` → `RELEASE_TAG = github.ref_name` (= `v0.9.0`)
- `workflow_dispatch` → `RELEASE_TAG = inputs.tag` (= whatever the user typed)

The `verify-pull` job already reads the first tag from `needs.build-and-push.outputs.tags` for its smoke-test pull, so it naturally pulls the version-specific tag after the fix.

## After this merges

Re-dispatch `docker-publish.yml` for v0.9.0 once to produce the missing `:v0.9.0` tag:

```
gh workflow run docker-publish.yml --ref main -f tag=v0.9.0
```

(Or from mobile: https://github.com/dfrostar/neuralmind/actions/workflows/docker-publish.yml → Run workflow → enter `v0.9.0` → green button.)

This will overwrite `:latest` with the same content + create `:v0.9.0`. Multi-platform manifest unchanged.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(...)"` parses
- [x] No production code touched; no test changes
- [x] Verified `:latest` already exists in GHCR (so the push path works — only the tagging pattern was wrong)
- [ ] **Maintainer to verify** after merge + re-dispatch: `:v0.9.0` tag appears in GHCR tags list

## Related

- Issue #98 (GITHUB_TOKEN anti-loop guard) is the reason workflow_dispatch is the practical path until the PAT secret is set
- PR #129 introduced docker-publish.yml; this commit corrects an oversight in that PR's tagging pattern

https://claude.ai/code/session_01SH6iHNAqeMJHXdq7ubVcuJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01SH6iHNAqeMJHXdq7ubVcuJ)_