### PR TITLE
Complete remaining tasks: CI fix, dep bumps, PNG export, repo cleanup

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -69,11 +69,15 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          # type=ref,event=tag → :v0.9.0 from the pushed tag
-          # type=raw,latest → :latest only when the tag has no `-`
-          #   suffix (excludes v0.10.0-rc1, v1.0.0-beta1, etc.).
+          # type=raw,value=${{ env.RELEASE_TAG }} → :v0.9.0 from RELEASE_TAG.
+          # This works for BOTH push:tag (RELEASE_TAG = github.ref_name)
+          # AND workflow_dispatch (RELEASE_TAG = inputs.tag). The earlier
+          # `type=ref,event=tag` form only fired on push:tag, so workflow-
+          # dispatched runs produced only `:latest` with no version tag.
+          # type=raw,latest → :latest only when the tag has no `-` suffix
+          # (excludes v0.10.0-rc1, v1.0.0-beta1, etc.).
           tags: |
-            type=ref,event=tag
+            type=raw,value=${{ env.RELEASE_TAG }}
             type=raw,value=latest,enable=${{ !contains(env.RELEASE_TAG, '-') }}
           labels: |
             org.opencontainers.image.title=NeuralMind

--- a/Build Package/system.txt
+++ b/Build Package/system.txt
@@ -1,8 +1,0 @@
-2026-04-17T03:47:52.3150000Z Evaluating build.if
-2026-04-17T03:47:52.3150000Z Evaluating: success()
-2026-04-17T03:47:52.3150000Z Result: true
-2026-04-17T03:47:52.3200000Z Requested labels: ubuntu-latest
-2026-04-17T03:47:52.3200000Z Job defined at: dfrostar/neuralmind/.github/workflows/ci.yml@refs/heads/main
-2026-04-17T03:47:52.3200000Z Waiting for a runner to pick up this job...
-2026-04-17T03:47:52.8400000Z Job is about to start running on the hosted runner: GitHub Actions 1000010348
-2026-04-17T03:47:52.8400000Z Job is waiting for a hosted runner to come online.

--- a/Lint/system.txt
+++ b/Lint/system.txt
@@ -1,8 +1,0 @@
-2026-04-17T03:47:52.3130000Z Evaluating lint.if
-2026-04-17T03:47:52.3130000Z Evaluating: success()
-2026-04-17T03:47:52.3130000Z Result: true
-2026-04-17T03:47:52.3190000Z Requested labels: ubuntu-latest
-2026-04-17T03:47:52.3190000Z Job defined at: dfrostar/neuralmind/.github/workflows/ci.yml@refs/heads/main
-2026-04-17T03:47:52.3190000Z Waiting for a runner to pick up this job...
-2026-04-17T03:47:52.8400000Z Job is about to start running on the hosted runner: GitHub Actions 1000010347
-2026-04-17T03:47:52.8400000Z Job is waiting for a hosted runner to come online.

--- a/Test (Python 3.10)/system.txt
+++ b/Test (Python 3.10)/system.txt
@@ -1,8 +1,0 @@
-2026-04-17T03:47:52.3200000Z Requested labels: ubuntu-latest
-2026-04-17T03:47:52.3200000Z Job defined at: dfrostar/neuralmind/.github/workflows/ci.yml@refs/heads/main
-2026-04-17T03:47:52.3200000Z Waiting for a runner to pick up this job...
-2026-04-17T03:47:52.3160000Z Evaluating test.if
-2026-04-17T03:47:52.3160000Z Evaluating: success()
-2026-04-17T03:47:52.3160000Z Result: true
-2026-04-17T03:47:52.8410000Z Job is waiting for a hosted runner to come online.
-2026-04-17T03:47:52.8410000Z Job is about to start running on the hosted runner: GitHub Actions 1000010349

--- a/Test (Python 3.11)/system.txt
+++ b/Test (Python 3.11)/system.txt
@@ -1,8 +1,0 @@
-2026-04-17T03:47:52.3220000Z Evaluating test.if
-2026-04-17T03:47:52.3220000Z Evaluating: success()
-2026-04-17T03:47:52.3220000Z Result: true
-2026-04-17T03:47:52.3230000Z Requested labels: ubuntu-latest
-2026-04-17T03:47:52.3230000Z Job defined at: dfrostar/neuralmind/.github/workflows/ci.yml@refs/heads/main
-2026-04-17T03:47:52.3230000Z Waiting for a runner to pick up this job...
-2026-04-17T03:47:52.8420000Z Job is waiting for a hosted runner to come online.
-2026-04-17T03:47:52.8420000Z Job is about to start running on the hosted runner: GitHub Actions 1000010351

--- a/Test (Python 3.12)/system.txt
+++ b/Test (Python 3.12)/system.txt
@@ -1,8 +1,0 @@
-2026-04-17T03:47:52.3150000Z Evaluating test.if
-2026-04-17T03:47:52.3150000Z Evaluating: success()
-2026-04-17T03:47:52.3150000Z Result: true
-2026-04-17T03:47:52.3200000Z Requested labels: ubuntu-latest
-2026-04-17T03:47:52.3200000Z Job defined at: dfrostar/neuralmind/.github/workflows/ci.yml@refs/heads/main
-2026-04-17T03:47:52.3200000Z Waiting for a runner to pick up this job...
-2026-04-17T03:47:52.8410000Z Job is waiting for a hosted runner to come online.
-2026-04-17T03:47:52.8420000Z Job is about to start running on the hosted runner: GitHub Actions 1000010350

--- a/Type Check/system.txt
+++ b/Type Check/system.txt
@@ -1,8 +1,0 @@
-2026-04-17T03:47:52.3180000Z Requested labels: ubuntu-latest
-2026-04-17T03:47:52.3180000Z Job defined at: dfrostar/neuralmind/.github/workflows/ci.yml@refs/heads/main
-2026-04-17T03:47:52.3180000Z Waiting for a runner to pick up this job...
-2026-04-17T03:47:52.3130000Z Evaluating type-check.if
-2026-04-17T03:47:52.3130000Z Evaluating: success()
-2026-04-17T03:47:52.3130000Z Result: true
-2026-04-17T03:47:52.8400000Z Job is about to start running on the hosted runner: GitHub Actions 1000010346
-2026-04-17T03:47:52.8400000Z Job is waiting for a hosted runner to come online.

--- a/neuralmind/web/app.js
+++ b/neuralmind/web/app.js
@@ -1147,6 +1147,29 @@
     wake();
   });
 
+  document.getElementById("export-png").addEventListener("click", () => {
+    // The on-screen canvas is transparent (it clearRect()s each frame and
+    // lets the page --bg show through), so a raw toDataURL would save a
+    // see-through PNG. Compose it onto an opaque fill matching the UI bg.
+    const out = document.createElement("canvas");
+    out.width = canvas.width;
+    out.height = canvas.height;
+    const octx = out.getContext("2d");
+    const bg = getComputedStyle(document.documentElement)
+      .getPropertyValue("--bg")
+      .trim();
+    octx.fillStyle = bg || "#1a1b1e";
+    octx.fillRect(0, 0, out.width, out.height);
+    octx.drawImage(canvas, 0, 0);
+
+    const stamp = new Date().toISOString().slice(0, 19).replace(/[T:]/g, "-");
+    const name = (state.project || "graph").replace(/[^\w.-]+/g, "_");
+    const a = document.createElement("a");
+    a.download = `neuralmind-${name}-${stamp}.png`;
+    a.href = out.toDataURL("image/png");
+    a.click();
+  });
+
   /* ---------- live activity stream ---------- */
 
   // nodeId → pulse-end timestamp (performance.now() units). The render

--- a/neuralmind/web/index.html
+++ b/neuralmind/web/index.html
@@ -56,6 +56,7 @@
         <div class="button-row">
           <button id="reset-layout" type="button" class="ghost">Reset saved layout</button>
           <button id="unpin-all" type="button" class="ghost">Unpin all</button>
+          <button id="export-png" type="button" class="ghost">Export PNG</button>
         </div>
       </section>
 

--- a/requirements-pinned.txt
+++ b/requirements-pinned.txt
@@ -19,9 +19,9 @@ mcp==1.27.0
 # arbitrary-file-write cache vuln (GHSA-3936-cmfr-pm3m).
 pytest==9.0.3
 pytest-asyncio==1.3.0
-black==26.3.1
-ruff==0.15.12
-mypy==1.20.2
+black==26.5.0
+ruff==0.15.13
+mypy==2.1.0
 
 # External tools (required separately)
 # graphify - install from: git clone https://github.com/safishamsi/graphify.git && cd graphify && pip install -e .
@@ -31,5 +31,5 @@ mypy==1.20.2
 # sphinx-rtd-theme==2.0.0
 
 # Benchmarking
-tiktoken==0.12.0
+tiktoken==0.13.0
 matplotlib==3.10.9


### PR DESCRIPTION
## Summary

A consolidated pass over outstanding maintenance items. Four independent, low-risk changes:

- **`fix(ci)`** — `docker-publish.yml` now sets the version tag on `workflow_dispatch` runs. `type=ref,event=tag` only fired on `push:tag`, so manually dispatched builds produced an image with only `:latest` and no `vX.Y.Z`. Switched to `type=raw,value=${RELEASE_TAG}`, which resolves for both triggers. (Supersedes the standalone fix in #140.)
- **`chore(deps)`** — consolidates the four open dependabot pins in `requirements-pinned.txt`: black 26.5.0, ruff 0.15.13, mypy 2.1.0, tiktoken 0.13.0.
- **`feat(graph-view)`** — adds an "Export PNG" sidebar button. The canvas is transparent, so the export composes it onto an opaque `--bg` fill before `toDataURL` and downloads as `neuralmind-<project>-<timestamp>.png`. (Graph-view backlog item from ROADMAP.)
- **`chore`** — removes six accidentally-committed CI runner-log directories (`Lint`, `Type Check`, `Build Package`, `Test (Python 3.10/3.11/3.12)`), each holding a single `system.txt` of GitHub Actions runner logs.

## Test plan

- [x] `ruff check .` clean and `black --check .` clean (the blocking CI gates) with the bumped tool versions
- [x] Full `pytest` suite green (only the expected graphify-fixture / S3-model skips)
- [x] mypy 2.1.0 (major bump) surfaces pre-existing type issues only; the type-check job is `continue-on-error: true` so it does not gate
- [x] `docker-publish.yml` validates as YAML
- [x] `node --check neuralmind/web/app.js` passes; PNG export logic verified against canvas DPR/transparency handling (no browser test harness available)

https://claude.ai/code/session_01TbVzuy37bW5ENo1VgJT2iA

---
_Generated by [Claude Code](https://claude.ai/code/session_01TbVzuy37bW5ENo1VgJT2iA)_