### PR TITLE
feat(cli): neuralmind doctor — install health check + friendlier first-run error

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@
 
 > Works with Claude Code, Cursor, Cline, Continue, and any MCP-compatible agent. 100% local — your code never leaves your machine. (Side effect: ~5–10× cheaper agent sessions because the agent stops re-loading context it already understood. [Benchmarks below ↓](#-benchmarks).)
 
-> **🆕 New in v0.11.0** — **Directional Synapses.** The brain-like layer now learns *what comes next*, not just *what goes together*. A new `synapse_transitions` table records ordered `(from_node, to_node)` observations every time the watcher flushes a batch, so the agent can ask `neuralmind next <file>` (or call the `neuralmind_next_likely` MCP tool) and get a probability distribution over what's typically edited after that file. Additive — the existing undirected synapse graph keeps doing its job. [Release notes](RELEASE_NOTES_v0.11.0.md)
+> **🆕 New in v0.12.0** — **Install Doctor.** One command — `neuralmind doctor` — inspects your setup (code graph, semantic index, synapse memory, MCP server, Claude Code hooks, query-memory consent) and prints each piece with a status and the exact command to fix it. Exits non-zero on a real failure so you can gate CI or an agent's setup step on it; `--json` gives a stable machine-readable snapshot. Querying before the graph exists now raises a clear setup hint instead of a stack trace. [Release notes](RELEASE_NOTES_v0.12.0.md)
+>
+> **v0.11.0** — **Directional Synapses.** The brain-like layer now learns *what comes next*, not just *what goes together*. A new `synapse_transitions` table records ordered `(from_node, to_node)` observations every time the watcher flushes a batch, so the agent can ask `neuralmind next <file>` (or call the `neuralmind_next_likely` MCP tool) and get a probability distribution over what's typically edited after that file. Additive — the existing undirected synapse graph keeps doing its job. [Release notes](RELEASE_NOTES_v0.11.0.md)
 >
 > **v0.10.0** — **Agent Ergonomics.** The PostToolUse Bash footer now tells the agent *what was dropped* (categorized line counts + repeated-line detection), not just how many bytes. New `neuralmind last` CLI recovers the dropped middle without re-running the command, fed by an atomic cache the hook writes to `<project>/.neuralmind/last_output.json`. Tiny failing commands no longer get buried under marker overhead. [Release notes](RELEASE_NOTES_v0.10.0.md)
 >
@@ -1724,6 +1726,7 @@ Only if you install the git post-commit hook with `neuralmind init-hook .`. Othe
 | **[Future-Proofing Plan](docs/FUTURE-PROOFING-PLAN.md)** | 8-initiative engineering plan for sustainability and scale |
 | **[Brain-like Learning](docs/brain_like_learning.md)** | Design rationale for the learning system |
 | **[Use Cases](docs/use-cases/README.md)** | Step-by-step walkthroughs: Claude Code, cost optimization, any-LLM, offline/regulated, growing monorepo, multi-agent (new in v0.6.0) |
+| **[Release Notes v0.12.0](RELEASE_NOTES_v0.12.0.md)** | Install Doctor — `neuralmind doctor` health checks (graph, index, synapses, MCP, hooks, memory), `--json` output, friendlier "graph not built" error |
 | **[Release Notes v0.11.0](RELEASE_NOTES_v0.11.0.md)** | Directional Synapses — `synapse_transitions` table, `next_likely()` API, `neuralmind next` CLI, `neuralmind_next_likely` MCP tool |
 | **[Release Notes v0.10.0](RELEASE_NOTES_v0.10.0.md)** | Agent Ergonomics — content-aware compression footer, `neuralmind last` recovery cache, small-failure passthrough |
 | **[Release Notes v0.9.0](RELEASE_NOTES_v0.9.0.md)** | Enterprise-Ready — GHCR auto-build, CycloneDX SBOM, air-gapped install walkthrough, compliance one-pager |

--- a/RELEASE_NOTES_v0.12.0.md
+++ b/RELEASE_NOTES_v0.12.0.md
@@ -1,0 +1,97 @@
+# NeuralMind v0.12.0 — install doctor + friendlier first run
+
+**Release Date:** June 2026
+
+## TL;DR
+
+NeuralMind has grown a lot of moving parts — a code graph, a semantic
+index, a synapse memory db, Claude Code hooks, an MCP server, and a
+query-memory consent flag. When one of them isn't wired up, the symptom
+used to be a cryptic stack trace or silent no-ops. v0.12.0 makes the
+setup legible:
+
+- **`neuralmind doctor`.** One command that inspects an install and
+  reports each piece with a status and an exact fix:
+
+  ```
+  NeuralMind doctor — /path/to/project
+  ============================================================
+    [ ok ] Code graph: 1240 nodes at /path/to/project/graphify-out/graph.json
+    [ ok ] Semantic index: 1240 nodes embedded (chromadb backend)
+    [warn] Synapse memory: no synapses.db yet (nothing learned)
+           -> It populates automatically as you query and edit the codebase.
+    [ ok ] MCP server: MCP SDK importable (neuralmind-mcp ready)
+    [warn] Claude Code hooks: not installed
+           -> Install them: neuralmind install-hooks
+    [ ok ] Query memory: enabled (logging queries for learning)
+  ============================================================
+  ```
+
+  It exits non-zero when a check **fails** (graph/index missing), so you
+  can gate CI or an agent's setup step on it. `--json` emits a stable
+  machine-readable form for scripting and agent consumption.
+
+- **Friendlier "graph not built" error.** Querying a project before its
+  code graph exists used to surface an opaque `AttributeError`. It now
+  raises a clear, actionable message naming the two commands to run
+  (`graphify update`, then `neuralmind build`) and points you at
+  `neuralmind doctor`.
+
+No migration, no new dependencies, no behavior change for already-working
+installs. `doctor` is read-only — it never builds, writes, or mutates
+state.
+
+---
+
+## What the agent actually sees, post-install
+
+A coding agent (or a human) dropped into a fresh clone can now run a
+single command to learn exactly what's missing and how to fix it, instead
+of discovering it one failed query at a time. For agents that provision
+their own environment, `neuralmind doctor --json` is a pre-flight check:
+
+```json
+{
+  "status": "fail",
+  "checks": [
+    {"name": "Code graph", "status": "fail",
+     "detail": "not found at /repo/graphify-out/graph.json",
+     "fix": "Generate it: graphify update /repo"},
+    {"name": "Semantic index", "status": "fail",
+     "detail": "no nodes embedded (chromadb backend)",
+     "fix": "Build it: neuralmind build"}
+  ]
+}
+```
+
+### Per-agent expectations
+
+| Agent | What changes |
+|-------|--------------|
+| **Claude Code** | `neuralmind doctor` confirms hooks are registered in `.claude/settings.json` and that `SYNAPSE_MEMORY.md` will load; a failed query now reads as a setup hint, not a trace. |
+| **Cursor / Cline** | Same diagnostics via the CLI; the MCP-server check confirms `neuralmind-mcp` is importable for the MCP integration. |
+| **Generic MCP client** | `doctor --json` gives a stable, parseable health snapshot to gate on before issuing tool calls. |
+
+---
+
+## Checks performed
+
+| Check | OK when | Fix on failure |
+|-------|---------|----------------|
+| Code graph | `graphify-out/graph.json` present and parseable | `graphify update .` |
+| Semantic index | nodes embedded in the active backend | `neuralmind build` |
+| Synapse memory | `synapses.db` present (WARN if not — it's learned over time) | populates automatically |
+| MCP server | MCP SDK importable | reinstall with the `mcp` extra |
+| Claude Code hooks | a neuralmind hook block in project or global `settings.json` | `neuralmind install-hooks` |
+| Query memory | `NEURALMIND_MEMORY` logging enabled | `NEURALMIND_MEMORY=1` |
+
+---
+
+## Upgrade
+
+```bash
+pip install --upgrade neuralmind
+neuralmind doctor .
+```
+
+Nothing else to do.

--- a/docs/about.html
+++ b/docs/about.html
@@ -4,8 +4,25 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="About NeuralMind: Open-source semantic code intelligence with a brain-like synapse layer that learns associations between code from how you actually use it — both undirected co-activation and directional next-file transitions — plus an Obsidian-style graph view that makes the index inspectable, and PostToolUse hooks that compress tool output and recover dropped content without re-running. 100% local, NIST AI RMF compliant, enterprise-ready.">
-    <meta name="keywords" content="NeuralMind, semantic code search, AI agents, token optimization, local-first, open-source, NIST AI RMF, brain-like learning, hebbian learning, synapse layer, directional transitions, transition matrix, next-file prediction, claude code memory, graph view, neuralmind serve, Obsidian-style code graph, force-directed graph, MCP server, code visualization, tool output recovery, bash output cache, agent ergonomics, claude code hooks">
+    <meta name="keywords" content="NeuralMind, semantic code search, AI agents, token optimization, local-first, open-source, NIST AI RMF, brain-like learning, hebbian learning, synapse layer, directional transitions, transition matrix, next-file prediction, claude code memory, graph view, neuralmind serve, Obsidian-style code graph, force-directed graph, MCP server, code visualization, tool output recovery, bash output cache, agent ergonomics, claude code hooks, install doctor, health check, agent onboarding">
     <title>About NeuralMind - Semantic Code Intelligence with Brain-like Memory</title>
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Article",
+      "headline": "About NeuralMind — Semantic Code Intelligence with Brain-like Memory",
+      "description": "How NeuralMind gives AI coding agents persistent memory: a brain-like synapse layer that learns associations from how you use the codebase, progressive context disclosure for 40–70× token reduction, an Obsidian-style graph view, an MCP server, and a built-in install doctor.",
+      "author": { "@type": "Person", "name": "Darren Frost" },
+      "about": "AI coding agents, semantic code intelligence, token optimization",
+      "url": "https://dfrostar.github.io/neuralmind/about.html",
+      "isPartOf": {
+        "@type": "SoftwareApplication",
+        "name": "NeuralMind",
+        "applicationCategory": "DeveloperApplication",
+        "softwareVersion": "0.12.0"
+      }
+    }
+    </script>
     <style>
         * { margin: 0; padding: 0; box-sizing: border-box; }
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Arial, sans-serif; line-height: 1.8; color: #333; background: #fff; }
@@ -44,6 +61,22 @@
             <p>Open-source semantic code intelligence for AI agents. Built for cost efficiency, security, and compliance.</p>
         </div>
     </header>
+
+    <section>
+        <div class="container" id="whats-new-v0120">
+            <h2>What's New in v0.12.0 — install doctor</h2>
+            <p><strong>One command tells you exactly what's wired up and what isn't.</strong> NeuralMind has accumulated moving parts — a code graph, a semantic index, a synapse memory db, Claude Code hooks, an MCP server, a query-memory consent flag. When one isn't in place, the old symptom was a stack trace or a silent no-op. v0.12.0 makes the setup legible.</p>
+            <h3>What ships</h3>
+            <ul>
+                <li><strong><code>neuralmind doctor</code>.</strong> Inspects the install and reports each piece with a status (<code>ok</code> / <code>warn</code> / <code>fail</code>) and the exact command to fix it. Read-only — it never builds or mutates state. Exits non-zero when a check <em>fails</em> (graph/index missing) so you can gate a CI step or an agent's provisioning on it.</li>
+                <li><strong><code>--json</code> output.</strong> A stable, machine-readable snapshot of every check, for scripting and agent consumption. An agent provisioning its own environment can run <code>neuralmind doctor --json</code> as a pre-flight check before issuing queries.</li>
+                <li><strong>Friendlier "graph not built" error.</strong> Querying a project before its code graph exists used to raise an opaque <code>AttributeError</code>. It now raises a clear, actionable message naming the two commands to run (<code>graphify update</code>, then <code>neuralmind build</code>) and points you at <code>neuralmind doctor</code>.</li>
+            </ul>
+            <h3>Why this matters</h3>
+            <p>Most NeuralMind support friction is setup friction: a piece isn't installed, and the failure doesn't say which one. <code>doctor</code> turns "it doesn't work" into a checklist with fixes — for the human dropped into a fresh clone, and for the agent that has to verify its own environment before relying on the tool. No new dependencies, no behavior change for working installs.</p>
+            <p><a href="https://github.com/dfrostar/neuralmind/blob/main/RELEASE_NOTES_v0.12.0.md">Full v0.12.0 release notes →</a></p>
+        </div>
+    </section>
 
     <section>
         <div class="container" id="whats-new-v0110">

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,10 +4,28 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="NeuralMind: Semantic code intelligence for AI agents. Reduce token costs 40–70× with local code indexing, a brain-like synapse layer that learns from co-activation and directional file-to-file transitions, an Obsidian-style graph view, and PostToolUse hooks that compress tool output and let agents recover dropped middle content without re-running. NIST AI RMF compliant.">
-    <meta name="keywords" content="semantic code search, AI coding agents, token optimization, code intelligence, local-first, NIST AI RMF, Claude, Cursor, MCP server, graph view, neuralmind serve, Obsidian-style code graph, force-directed graph, synapse layer, Hebbian learning, directional transitions, transition matrix, next-file prediction, code visualization, tool output recovery, bash output cache, agent ergonomics, claude code hooks">
+    <meta name="keywords" content="semantic code search, AI coding agents, token optimization, code intelligence, local-first, NIST AI RMF, Claude, Cursor, MCP server, graph view, neuralmind serve, Obsidian-style code graph, force-directed graph, synapse layer, Hebbian learning, directional transitions, transition matrix, next-file prediction, code visualization, tool output recovery, bash output cache, agent ergonomics, claude code hooks, install doctor, health check, agent onboarding">
     <title>NeuralMind - Semantic Code Intelligence for AI Agents | 40–70× Token Reduction</title>
     <meta property="og:title" content="NeuralMind - Semantic Code Intelligence for AI Agents">
     <meta property="og:description" content="Local-first code indexing with 40–70× per-query token reduction (50K → ~800 tokens). Zero data exfiltration, 100% offline, enterprise-ready.">
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "SoftwareApplication",
+      "name": "NeuralMind",
+      "applicationCategory": "DeveloperApplication",
+      "operatingSystem": "Linux, macOS, Windows",
+      "description": "Persistent memory and semantic code intelligence for AI coding agents. Local-first code indexing with 40–70× per-query token reduction, a brain-like synapse layer that learns associations from how you use the codebase, an Obsidian-style graph view, an MCP server, and a built-in install doctor. Works with Claude Code, Cursor, Cline, Continue, and any MCP-compatible agent.",
+      "url": "https://dfrostar.github.io/neuralmind/",
+      "downloadUrl": "https://pypi.org/project/neuralmind/",
+      "softwareVersion": "0.12.0",
+      "license": "https://opensource.org/licenses/MIT",
+      "programmingLanguage": "Python",
+      "operatingSystemRequirements": "Python 3.10+",
+      "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
+      "author": { "@type": "Person", "name": "Darren Frost" }
+    }
+    </script>
     <style>
         * { margin: 0; padding: 0; box-sizing: border-box; }
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Arial, sans-serif; line-height: 1.6; color: #333; background: #fff; }
@@ -62,10 +80,10 @@
             <h1>🧠 NeuralMind</h1>
             <p>Semantic code intelligence for AI agents.<br/>40–70× token reduction. Zero data exfiltration. Enterprise-ready.</p>
             <p style="font-size: 1rem; opacity: 0.85; margin-top: 0.5rem;">
-                <strong>🆕 v0.11.0 — Directional Synapses.</strong> The brain-like layer now learns <em>what comes next</em>, not just what goes together. New <code>synapse_transitions</code> table records ordered <code>(from, to)</code> observations; <code>neuralmind next &lt;file&gt;</code> returns a probability distribution over likely successors. <a href="https://github.com/dfrostar/neuralmind/blob/main/RELEASE_NOTES_v0.11.0.md" style="color: white; text-decoration: underline;">Release notes →</a> · <a href="about.html#whats-new-v0110" style="color: white; text-decoration: underline;">Summary →</a>
+                <strong>🆕 v0.12.0 — Install Doctor.</strong> One command — <code>neuralmind doctor</code> — inspects your setup (code graph, semantic index, synapse memory, MCP server, Claude Code hooks, query memory) and prints each piece with a status and the exact fix. Exits non-zero on a real failure (gate CI on it); <code>--json</code> for agents. Querying before the graph exists now reads as a setup hint, not a stack trace. <a href="https://github.com/dfrostar/neuralmind/blob/main/RELEASE_NOTES_v0.12.0.md" style="color: white; text-decoration: underline;">Release notes →</a> · <a href="about.html#whats-new-v0120" style="color: white; text-decoration: underline;">Summary →</a>
             </p>
             <p style="font-size: 0.9rem; opacity: 0.75; margin-top: 0.25rem;">
-                Earlier: <a href="https://github.com/dfrostar/neuralmind/blob/main/RELEASE_NOTES_v0.10.0.md" style="color: white; text-decoration: underline;">v0.10.0 agent ergonomics (categorized footer + <code>neuralmind last</code>)</a> · <a href="https://github.com/dfrostar/neuralmind/blob/main/RELEASE_NOTES_v0.9.0.md" style="color: white; text-decoration: underline;">v0.9.0 enterprise-ready (GHCR/SBOM/air-gapped)</a> · <a href="https://github.com/dfrostar/neuralmind/blob/main/RELEASE_NOTES_v0.8.0.md" style="color: white; text-decoration: underline;">v0.8.0 always-on (systemd/launchd/healthz)</a> · <a href="https://github.com/dfrostar/neuralmind/blob/main/RELEASE_NOTES_v0.7.0.md" style="color: white; text-decoration: underline;">v0.7.0 install anywhere</a> · <a href="https://github.com/dfrostar/neuralmind/blob/main/RELEASE_NOTES_v0.4.0.md" style="color: white; text-decoration: underline;">v0.4.0 brain-like synapse layer</a>.
+                Earlier: <a href="https://github.com/dfrostar/neuralmind/blob/main/RELEASE_NOTES_v0.11.0.md" style="color: white; text-decoration: underline;">v0.11.0 directional synapses (<code>neuralmind next</code>)</a> · <a href="https://github.com/dfrostar/neuralmind/blob/main/RELEASE_NOTES_v0.10.0.md" style="color: white; text-decoration: underline;">v0.10.0 agent ergonomics (categorized footer + <code>neuralmind last</code>)</a> · <a href="https://github.com/dfrostar/neuralmind/blob/main/RELEASE_NOTES_v0.9.0.md" style="color: white; text-decoration: underline;">v0.9.0 enterprise-ready (GHCR/SBOM/air-gapped)</a> · <a href="https://github.com/dfrostar/neuralmind/blob/main/RELEASE_NOTES_v0.8.0.md" style="color: white; text-decoration: underline;">v0.8.0 always-on (systemd/launchd/healthz)</a> · <a href="https://github.com/dfrostar/neuralmind/blob/main/RELEASE_NOTES_v0.7.0.md" style="color: white; text-decoration: underline;">v0.7.0 install anywhere</a>.
             </p>
             <div>
                 <a href="wiki/Setup-Guide" class="btn btn-primary">Get Started in 5 Minutes</a>

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -61,6 +61,16 @@
     <priority>0.6</priority>
   </url>
   <url>
+    <loc>https://github.com/dfrostar/neuralmind/blob/main/RELEASE_NOTES_v0.12.0.md</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://dfrostar.github.io/neuralmind/about.html#whats-new-v0120</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
     <loc>https://github.com/dfrostar/neuralmind/blob/main/RELEASE_NOTES_v0.11.0.md</loc>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>

--- a/docs/use-cases/install-paths.md
+++ b/docs/use-cases/install-paths.md
@@ -141,6 +141,19 @@ For pipx (no shared Python env), drop the `python -c` line and run
 just `neuralmind --version` once that subcommand ships, or
 `neuralmind --help`.
 
+Then, from inside a project, run the **install doctor** (v0.12.0+) to
+confirm every piece is wired up — code graph, semantic index, synapse
+memory, MCP server, Claude Code hooks, query memory — and get the exact
+fix for anything that isn't:
+
+```bash
+neuralmind doctor .
+```
+
+It exits non-zero when a check fails, so a provisioning script or CI step
+can gate on it (`neuralmind doctor . && neuralmind wakeup .`). Add
+`--json` for a machine-readable snapshot an agent can parse.
+
 ---
 
 ## Which one should *you* pick?

--- a/docs/wiki/CLI-Reference.md
+++ b/docs/wiki/CLI-Reference.md
@@ -13,6 +13,7 @@ Complete command-line interface documentation for NeuralMind.
   - [search](#search)
   - [benchmark](#benchmark)
   - [stats](#stats)
+  - [doctor](#doctor-v0120)
   - [learn](#learn)
   - [next](#next-v0110)
   - [skeleton](#skeleton)
@@ -436,6 +437,66 @@ DB Path: /path/to/project/graphify-out/neuralmind_db
 - Last Build: 2024-01-15 14:30:22
 - Build Duration: 8.3s
 - Embedding Model: all-MiniLM-L6-v2
+```
+
+---
+
+### doctor *(v0.12.0+)*
+
+Diagnose a project's NeuralMind setup and print an actionable fix for
+anything that isn't wired up. Read-only — it never builds or mutates
+state.
+
+```bash
+neuralmind doctor [project_path] [--json]
+```
+
+**Arguments:**
+
+| Argument | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `project_path` | No | `.` | Project root to inspect |
+| `--json`, `-j` | No | `false` | Emit machine-readable JSON |
+
+**Checks:** code graph, semantic index, synapse memory, MCP server,
+Claude Code hooks, and query-memory consent. Each reports `ok`, `warn`
+(optional/learned-over-time), or `fail` (setup incomplete).
+
+**Exit codes:** `0` when no check failed (warnings allowed), `1` when any
+check **failed** — so you can gate a CI step or an agent's provisioning on
+`neuralmind doctor`.
+
+**Example:**
+
+```bash
+neuralmind doctor .
+```
+
+```
+NeuralMind doctor — /path/to/project
+============================================================
+  [ ok ] Code graph: 1240 nodes at /path/to/project/graphify-out/graph.json
+  [ ok ] Semantic index: 1240 nodes embedded (chromadb backend)
+  [warn] Synapse memory: no synapses.db yet (nothing learned)
+         -> It populates automatically as you query and edit the codebase.
+  [ ok ] MCP server: MCP SDK importable (neuralmind-mcp ready)
+  [warn] Claude Code hooks: not installed
+         -> Install them: neuralmind install-hooks
+  [ ok ] Query memory: enabled (logging queries for learning)
+============================================================
+```
+
+JSON output (`--json`) is stable for scripting and agent consumption:
+
+```json
+{
+  "status": "fail",
+  "checks": [
+    {"name": "Code graph", "status": "fail",
+     "detail": "not found at /repo/graphify-out/graph.json",
+     "fix": "Generate it: graphify update /repo"}
+  ]
+}
 ```
 
 ---

--- a/neuralmind/cli.py
+++ b/neuralmind/cli.py
@@ -11,7 +11,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from neuralmind import memory
-from neuralmind.core import NeuralMind, create_mind
+from neuralmind.core import GraphNotBuiltError, NeuralMind, create_mind
 
 
 def cmd_build(args):
@@ -281,6 +281,40 @@ def cmd_stats(args):
         print(f"Built: {stats.get('built')}")
         if stats.get("built"):
             print(f"Nodes: {stats.get('total_nodes', 0)}")
+
+
+def cmd_doctor(args):
+    """Diagnose a project's NeuralMind setup and print actionable fixes."""
+    from neuralmind import doctor
+
+    checks = doctor.run_diagnostics(args.project_path)
+    status = doctor.overall_status(checks)
+
+    if args.json:
+        print(
+            json.dumps(
+                {"status": status, "checks": [c.to_dict() for c in checks]},
+                indent=2,
+            )
+        )
+    else:
+        markers = {doctor.OK: "[ ok ]", doctor.WARN: "[warn]", doctor.FAIL: "[FAIL]"}
+        print(f"NeuralMind doctor — {Path(args.project_path).resolve()}")
+        print("=" * 60)
+        for c in checks:
+            print(f"  {markers.get(c.status, '[ ?? ]')} {c.name}: {c.detail}")
+            if c.fix and c.status != doctor.OK:
+                print(f"         -> {c.fix}")
+        print("=" * 60)
+        summary = {
+            doctor.OK: "All checks passed.",
+            doctor.WARN: "Up and running; optional pieces are missing (see above).",
+            doctor.FAIL: "Setup incomplete — run the fixes above, then re-check.",
+        }
+        print(summary.get(status, ""))
+
+    if status == doctor.FAIL:
+        sys.exit(1)
 
 
 def cmd_next(args):
@@ -799,6 +833,14 @@ def main():
     search_p.add_argument("--json", "-j", action="store_true")
     search_p.set_defaults(func=cmd_search)
 
+    doctor_p = subparsers.add_parser(
+        "doctor",
+        help="Diagnose install health (graph, index, hooks, MCP, synapses)",
+    )
+    doctor_p.add_argument("project_path", nargs="?", default=".")
+    doctor_p.add_argument("--json", "-j", action="store_true")
+    doctor_p.set_defaults(func=cmd_doctor)
+
     stats_p = subparsers.add_parser("stats", help="Show index statistics")
     stats_p.add_argument("project_path")
     stats_p.add_argument("--json", "-j", action="store_true")
@@ -1000,7 +1042,14 @@ def main():
     if args.command is None:
         parser.print_help()
         sys.exit(1)
-    args.func(args)
+    try:
+        args.func(args)
+    except GraphNotBuiltError as e:
+        # Turn the "no graph yet" failure into a readable setup hint instead
+        # of a stack trace. `neuralmind doctor` gives the full picture.
+        print(f"\n{e}\n", file=sys.stderr)
+        print("Run `neuralmind doctor` to check your setup.", file=sys.stderr)
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/neuralmind/core.py
+++ b/neuralmind/core.py
@@ -36,6 +36,15 @@ from .synapses import SynapseStore, default_db_path
 DEFAULT_HYBRID_HIGHLIGHT_COUNT = 3
 
 
+class GraphNotBuiltError(RuntimeError):
+    """Raised when a query is attempted before the code graph/index exists.
+
+    Carries an actionable, multi-line message naming the exact commands to
+    run, so the failure reads as a setup hint instead of an opaque
+    ``AttributeError`` from a half-initialised instance.
+    """
+
+
 class NeuralMind:
     """
     Adaptive Neural Knowledge System.
@@ -260,9 +269,28 @@ class NeuralMind:
         return self._build_stats
 
     def _ensure_built(self):
-        """Ensure the system is built before queries."""
+        """Ensure the system is built before queries.
+
+        Raises GraphNotBuiltError with an actionable message when the build
+        can't produce a usable selector — almost always a missing code
+        graph on a fresh project.
+        """
         if not self._built or self.selector is None:
-            self.build()
+            result = self.build()
+            if self.selector is None:
+                graph_path = self.project_path / "graphify-out" / "graph.json"
+                if not graph_path.exists():
+                    raise GraphNotBuiltError(
+                        f"No code graph found at {graph_path}.\n"
+                        f"Generate it, then build the index:\n"
+                        f"  graphify update {self.project_path}\n"
+                        f"  neuralmind build {self.project_path}"
+                    )
+                raise GraphNotBuiltError(
+                    result.get("error", "Failed to build the NeuralMind index.")
+                    if isinstance(result, dict)
+                    else "Failed to build the NeuralMind index."
+                )
 
     def wakeup(self) -> ContextResult:
         """

--- a/neuralmind/doctor.py
+++ b/neuralmind/doctor.py
@@ -1,0 +1,206 @@
+"""doctor.py — install/health diagnostics for ``neuralmind doctor``.
+
+Inspects a project's NeuralMind setup *without building anything*, so it
+works as a first-run troubleshooter: which pieces are in place, which
+aren't, and the exact command to fix each gap.
+
+Each check is computed defensively — a failure to inspect one subsystem
+(e.g. a corrupt synapse db) never blocks the rest of the report. The
+machine-readable form (``--json``) is stable so agents and CI can gate on
+it; the human form prints an ASCII status marker plus a next-step fix.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+# Status levels, worst-last so ``overall_status`` can pick the max.
+OK = "ok"
+WARN = "warn"
+FAIL = "fail"
+
+_RANK = {OK: 0, WARN: 1, FAIL: 2}
+
+
+@dataclass
+class Check:
+    """One diagnostic result.
+
+    ``fix`` is the actionable next step shown when the check isn't OK.
+    """
+
+    name: str
+    status: str
+    detail: str
+    fix: str = ""
+
+    def to_dict(self) -> dict:
+        return {
+            "name": self.name,
+            "status": self.status,
+            "detail": self.detail,
+            "fix": self.fix,
+        }
+
+
+def _check_graph(project: Path) -> Check:
+    graph = project / "graphify-out" / "graph.json"
+    if not graph.exists():
+        return Check(
+            "Code graph",
+            FAIL,
+            f"not found at {graph}",
+            fix=f"Generate it: graphify update {project}",
+        )
+    try:
+        nodes = len(json.loads(graph.read_text(encoding="utf-8")).get("nodes", []))
+    except Exception as e:  # corrupt / truncated graph.json
+        return Check(
+            "Code graph",
+            FAIL,
+            f"unreadable ({e})",
+            fix=f"Regenerate it: graphify update {project}",
+        )
+    return Check("Code graph", OK, f"{nodes} nodes at {graph}")
+
+
+def _check_index(project: Path) -> Check:
+    try:
+        from neuralmind.core import NeuralMind
+
+        mind = NeuralMind(str(project))
+        stats = mind.embedder.get_stats()
+        backend = mind.backend_name
+    except Exception as e:
+        return Check(
+            "Semantic index",
+            FAIL,
+            f"could not read index ({e})",
+            fix="Build it: neuralmind build",
+        )
+    total = int(stats.get("total_nodes", 0) or 0)
+    if total > 0:
+        return Check("Semantic index", OK, f"{total} nodes embedded ({backend} backend)")
+    return Check(
+        "Semantic index",
+        FAIL,
+        f"no nodes embedded ({backend} backend)",
+        fix="Build it: neuralmind build",
+    )
+
+
+def _check_synapses(project: Path) -> Check:
+    try:
+        from neuralmind.synapses import SynapseStore, default_db_path
+
+        db = Path(default_db_path(project))
+        if not db.exists():
+            return Check(
+                "Synapse memory",
+                WARN,
+                "no synapses.db yet (nothing learned)",
+                fix="It populates automatically as you query and edit the codebase.",
+            )
+        s = SynapseStore(db).stats()
+    except Exception as e:
+        return Check("Synapse memory", WARN, f"could not read synapses ({e})")
+    return Check(
+        "Synapse memory",
+        OK,
+        f"{s.get('edges', 0)} edges, {s.get('transitions', 0)} transitions",
+    )
+
+
+def _check_mcp() -> Check:
+    try:
+        from neuralmind.mcp_server import MCP_AVAILABLE
+    except Exception as e:
+        return Check("MCP server", WARN, f"could not check MCP ({e})")
+    if MCP_AVAILABLE:
+        return Check("MCP server", OK, "MCP SDK importable (neuralmind-mcp ready)")
+    return Check(
+        "MCP server",
+        WARN,
+        "MCP SDK not importable",
+        fix="Reinstall with the MCP extra: pip install 'neuralmind[mcp]'",
+    )
+
+
+def _check_hooks(project: Path) -> Check:
+    try:
+        from neuralmind.hooks import _is_neuralmind_block, _settings_path
+    except Exception as e:
+        return Check("Claude Code hooks", WARN, f"could not check hooks ({e})")
+
+    scopes: list[tuple[str, Path]] = []
+    try:
+        scopes.append(("project", _settings_path("project", str(project))))
+    except Exception:
+        pass
+    try:
+        scopes.append(("global", _settings_path("global")))
+    except Exception:
+        pass
+
+    installed = []
+    for label, path in scopes:
+        if not path.exists():
+            continue
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except Exception:
+            continue
+        blocks = [
+            block
+            for event_blocks in (data.get("hooks") or {}).values()
+            if isinstance(event_blocks, list)
+            for block in event_blocks
+        ]
+        if any(_is_neuralmind_block(b) for b in blocks):
+            installed.append(label)
+
+    if installed:
+        return Check("Claude Code hooks", OK, f"installed ({', '.join(installed)})")
+    return Check(
+        "Claude Code hooks",
+        WARN,
+        "not installed",
+        fix="Install them: neuralmind install-hooks",
+    )
+
+
+def _check_memory() -> Check:
+    try:
+        from neuralmind.memory import is_memory_logging_enabled
+
+        enabled = bool(is_memory_logging_enabled())
+    except Exception as e:
+        return Check("Query memory", WARN, f"could not check ({e})")
+    if enabled:
+        return Check("Query memory", OK, "enabled (logging queries for learning)")
+    return Check(
+        "Query memory",
+        WARN,
+        "disabled (no query logging)",
+        fix="Enable with NEURALMIND_MEMORY=1, or accept the prompt on first query.",
+    )
+
+
+def run_diagnostics(project_path: str) -> list[Check]:
+    """Run every check against ``project_path`` and return the results."""
+    project = Path(project_path).resolve()
+    return [
+        _check_graph(project),
+        _check_index(project),
+        _check_synapses(project),
+        _check_mcp(),
+        _check_hooks(project),
+        _check_memory(),
+    ]
+
+
+def overall_status(checks: list[Check]) -> str:
+    """The worst status across all checks (FAIL > WARN > OK)."""
+    return max((c.status for c in checks), key=lambda s: _RANK.get(s, 0), default=OK)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,10 @@ keywords = [
     "agent-ergonomics",
     "directional-transitions",
     "next-file-prediction",
-    "associative-memory"
+    "associative-memory",
+    "health-check",
+    "install-doctor",
+    "agent-onboarding"
 ]
 classifiers = [
     "Development Status :: 4 - Beta",

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -1,0 +1,159 @@
+"""Tests for the `neuralmind doctor` diagnostics module."""
+
+import json
+
+import pytest
+
+from neuralmind import doctor
+from neuralmind.core import GraphNotBuiltError, NeuralMind
+
+
+def test_overall_status_picks_worst():
+    assert doctor.overall_status([]) == doctor.OK
+    assert (
+        doctor.overall_status(
+            [doctor.Check("a", doctor.OK, ""), doctor.Check("b", doctor.WARN, "")]
+        )
+        == doctor.WARN
+    )
+    assert (
+        doctor.overall_status(
+            [
+                doctor.Check("a", doctor.OK, ""),
+                doctor.Check("b", doctor.WARN, ""),
+                doctor.Check("c", doctor.FAIL, ""),
+            ]
+        )
+        == doctor.FAIL
+    )
+
+
+def test_check_to_dict_shape():
+    c = doctor.Check("Code graph", doctor.FAIL, "missing", fix="run it")
+    assert c.to_dict() == {
+        "name": "Code graph",
+        "status": doctor.FAIL,
+        "detail": "missing",
+        "fix": "run it",
+    }
+
+
+def test_graph_check_ok_when_present(temp_project):
+    check = doctor._check_graph(temp_project)
+    assert check.status == doctor.OK
+    assert "nodes" in check.detail
+
+
+def test_graph_check_fail_when_missing(empty_project):
+    check = doctor._check_graph(empty_project)
+    assert check.status == doctor.FAIL
+    assert "graphify update" in check.fix
+
+
+def test_graph_check_fail_when_corrupt(empty_project):
+    out = empty_project / "graphify-out"
+    out.mkdir(parents=True)
+    (out / "graph.json").write_text("{ not valid json", encoding="utf-8")
+    check = doctor._check_graph(empty_project)
+    assert check.status == doctor.FAIL
+    assert "graphify update" in check.fix
+
+
+def test_index_check_fail_when_not_built(temp_project):
+    # Graph exists but nothing embedded yet -> actionable build hint.
+    check = doctor._check_index(temp_project)
+    assert check.status == doctor.FAIL
+    assert "neuralmind build" in check.fix
+
+
+def test_synapses_check_warns_when_absent(temp_project):
+    check = doctor._check_synapses(temp_project)
+    assert check.status == doctor.WARN
+    assert "nothing learned" in check.detail
+
+
+def test_synapses_check_ok_when_present(temp_project):
+    from neuralmind.synapses import SynapseStore, default_db_path
+
+    store = SynapseStore(default_db_path(temp_project))
+    store.reinforce(["a", "b"], strength=1.0)
+    check = doctor._check_synapses(temp_project)
+    assert check.status == doctor.OK
+    assert "edges" in check.detail
+
+
+def test_mcp_check(monkeypatch):
+    monkeypatch.setattr("neuralmind.mcp_server.MCP_AVAILABLE", True, raising=False)
+    assert doctor._check_mcp().status == doctor.OK
+
+
+def test_hooks_check_warn_when_none(tmp_path, monkeypatch, empty_project):
+    # Isolate the global ~/.claude/settings.json lookup.
+    monkeypatch.setenv("HOME", str(tmp_path))
+    check = doctor._check_hooks(empty_project)
+    assert check.status == doctor.WARN
+    assert "install-hooks" in check.fix
+
+
+def test_hooks_check_ok_when_installed(tmp_path, monkeypatch, empty_project):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    settings_dir = empty_project / ".claude"
+    settings_dir.mkdir(parents=True)
+    (settings_dir / "settings.json").write_text(
+        json.dumps(
+            {
+                "hooks": {
+                    "PostToolUse": [
+                        {
+                            "matcher": "Read",
+                            "hooks": [
+                                {"type": "command", "command": "neuralmind _hook compress-read"}
+                            ],
+                        }
+                    ]
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    check = doctor._check_hooks(empty_project)
+    assert check.status == doctor.OK
+    assert "project" in check.detail
+
+
+def test_memory_check_reflects_flag(monkeypatch):
+    monkeypatch.setattr("neuralmind.memory.is_memory_logging_enabled", lambda: True)
+    assert doctor._check_memory().status == doctor.OK
+    monkeypatch.setattr("neuralmind.memory.is_memory_logging_enabled", lambda: False)
+    off = doctor._check_memory()
+    assert off.status == doctor.WARN
+    assert "NEURALMIND_MEMORY" in off.fix
+
+
+def test_run_diagnostics_returns_all_checks(temp_project):
+    checks = doctor.run_diagnostics(str(temp_project))
+    names = {c.name for c in checks}
+    assert names == {
+        "Code graph",
+        "Semantic index",
+        "Synapse memory",
+        "MCP server",
+        "Claude Code hooks",
+        "Query memory",
+    }
+
+
+def test_run_diagnostics_json_serialisable(empty_project):
+    checks = doctor.run_diagnostics(str(empty_project))
+    payload = {"status": doctor.overall_status(checks), "checks": [c.to_dict() for c in checks]}
+    # Must round-trip through JSON for the --json output / agent consumption.
+    assert json.loads(json.dumps(payload))["status"] in {doctor.OK, doctor.WARN, doctor.FAIL}
+
+
+def test_query_without_graph_raises_friendly_error(empty_project):
+    mind = NeuralMind(str(empty_project), backend_type="in_memory")
+    with pytest.raises(GraphNotBuiltError) as exc:
+        mind.query("anything")
+    msg = str(exc.value)
+    assert "graphify update" in msg
+    assert "neuralmind build" in msg


### PR DESCRIPTION
## Summary

Adds **`neuralmind doctor`** — an install/health diagnostic — plus a friendlier error when a project is queried before its code graph exists. Ships with the full docs/SEO propagation and closes the standing schema.org JSON-LD gap.

## What's new

### `neuralmind doctor [path] [--json]`
Read-only command that inspects an install and prints each piece with a status and an actionable fix:

```
NeuralMind doctor — /path/to/project
============================================================
  [ ok ] Code graph: 1240 nodes at .../graphify-out/graph.json
  [ ok ] Semantic index: 1240 nodes embedded (chromadb backend)
  [warn] Synapse memory: no synapses.db yet (nothing learned)
         -> It populates automatically as you query and edit the codebase.
  [ ok ] MCP server: MCP SDK importable (neuralmind-mcp ready)
  [warn] Claude Code hooks: not installed
         -> Install them: neuralmind install-hooks
  [ ok ] Query memory: enabled (logging queries for learning)
============================================================
```

- Checks: **code graph, semantic index, synapse memory, MCP server, Claude Code hooks, query-memory consent**.
- **Exits non-zero on a real failure** (graph/index missing) → gate a CI step or an agent's provisioning on it.
- **`--json`** emits a stable machine-readable snapshot for scripting/agent consumption.

### Friendlier "graph not built" error
Querying before the graph exists raised an opaque `AttributeError`. Now raises `GraphNotBuiltError` with the exact commands to run (`graphify update`, then `neuralmind build`) and points at `neuralmind doctor`.

## Tests
`tests/test_doctor.py` (15 cases): each check, status aggregation, JSON serialisability, hooks detection (project/global isolation), and the friendly error. **Full suite: 481 passed, 9 skipped, 0 failed** locally. Black + Ruff clean.

## Docs / SEO (per CLAUDE.md checklist)
- `RELEASE_NOTES_v0.12.0.md` (with per-agent expectations table)
- `README.md` banner + release-notes row (v0.11.0 demoted)
- `docs/index.html` banner + meta + earlier-releases trail
- `docs/about.html` "What's New in v0.12.0" section
- `docs/wiki/CLI-Reference.md` doctor entry + ToC
- `docs/use-cases/install-paths.md` verify step
- `docs/sitemap.xml` + `pyproject.toml` keywords (`health-check`, `install-doctor`, `agent-onboarding`)
- **schema.org JSON-LD** added (`SoftwareApplication` on index, `Article` on about) — closes the gap CLAUDE.md flagged as of v0.10.0

## Notes
- `version`/`CHANGELOG` intentionally **not** bumped — release-please owns those and will cut v0.12.0 from the `feat:` commit.

https://claude.ai/code/session_01K8frVGpMStWK4o94ChiWgG

---
_Generated by [Claude Code](https://claude.ai/code/session_01K8frVGpMStWK4o94ChiWgG)_