### PR TITLE
docs: establish a standard documentation process

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -31,6 +31,21 @@ Please describe the tests that you ran to verify your changes.
 * **Operating System**: 
 * **Test command**: `pytest tests/ -v`
 
+## Documentation & discoverability
+
+Per the [Documentation Process](../docs/DOCUMENTATION-PROCESS.md). Required when
+this PR adds/changes a CLI command, MCP tool, hook, env var, agent-visible
+behavior, or a visible fix. Tick **N/A** for pure internal refactors.
+
+- [ ] N/A — internal-only change, no user-facing surface
+- [ ] Docs answer *"what does the user/agent now see?"* (not just what the code does)
+- [ ] `README.md` updated (banner/sections) if user-facing
+- [ ] `docs/index.html` + `docs/about.html` updated if user-facing (incl. the **Status & Future** block — keep "Current/Next" honest)
+- [ ] `docs/wiki/*.md` (e.g. `CLI-Reference.md`) updated for new commands/env vars — syncs to the live wiki automatically
+- [ ] Use-case walkthrough updated/added if a workflow was unlocked
+- [ ] SEO refreshed (keywords / meta / sitemap) if a new noun entered the product surface
+- [ ] I did **not** edit `CHANGELOG.md` or hand-bump the `pyproject.toml` version (release-please owns these)
+
 ## Checklist
 
 - [ ] My code follows the style guidelines of this project

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -33,7 +33,7 @@ Please describe the tests that you ran to verify your changes.
 
 ## Documentation & discoverability
 
-Per the [Documentation Process](../docs/DOCUMENTATION-PROCESS.md). Required when
+Per the [Documentation Process](/dfrostar/neuralmind/blob/main/docs/DOCUMENTATION-PROCESS.md). Required when
 this PR adds/changes a CLI command, MCP tool, hook, env var, agent-visible
 behavior, or a visible fix. Tick **N/A** for pure internal refactors.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -328,6 +328,13 @@ class TestNeuralMindQuery:
 - Keep examples working
 - Add type hints
 
+> **Standard process.** For any user-facing change (a CLI command, MCP tool,
+> hook, env var, agent-visible behavior, or visible fix), follow the
+> [Documentation Process](docs/DOCUMENTATION-PROCESS.md): docs ship in the
+> *same PR* as the change, propagated across all five surfaces, and every doc
+> answers *"what does the user/agent now see?"*. The PR template's
+> "Documentation & discoverability" checklist operationalizes it.
+
 ## Release Process
 
 Releases are managed with [release-please](https://github.com/googleapis/release-please). The process is fully automated once commits land on `main`.

--- a/docs/DOCUMENTATION-PROCESS.md
+++ b/docs/DOCUMENTATION-PROCESS.md
@@ -1,0 +1,113 @@
+# Documentation Process
+
+How NeuralMind keeps its docs current, consistent, and **interesting to
+potential users** — as a repeatable standard, not tribal habit. This is the
+operational companion to the "Shipping a feature — docs + SEO checklist" in
+`CLAUDE.md`: that file says *what* surfaces exist; this file says *when*,
+*who*, and *how we keep them honest over time*.
+
+> **Why this exists.** Docs drift silently. A real example caught in June 2026:
+> `docs/index.html`'s "Status & Future" block still advertised "v0.5.4
+> (Current) / v0.5.5 (Next)" while the project was on v0.12 — a visitor's first
+> impression was a project frozen seven releases ago. The cost of stale docs is
+> paid entirely by the people we most want to reach: first-time visitors. This
+> process makes that failure mode hard to repeat.
+
+---
+
+## The one rule
+
+**Every user-facing change ships its documentation in the *same PR*, and every
+doc answers one question: _"What does the user (or the agent) now see?"_**
+
+Not "what does the code do" — what *changes in the experience*. That framing is
+what makes docs interesting rather than a changelog. A new command isn't a
+feature; it's a workflow someone is already searching for.
+
+A change is **user-facing** if it adds or changes any of: a CLI command, an MCP
+tool, a hook, an env var, agent-visible behavior, or a visible bug fix. Pure
+internal refactors are exempt (note that in the PR).
+
+---
+
+## The five surfaces (propagate to all that apply)
+
+| # | Surface | What to update | Notes |
+|---|---|---|---|
+| 1 | **`RELEASE_NOTES_v<X.Y.Z>.md`** | Canonical notes, written from the *"what the agent/user sees post-install"* angle. Include a per-agent expectations table (Claude Code / Cursor / Cline / generic MCP) when integrations are affected. | One per release. |
+| 2 | **`README.md`** | Bump the top banner; demote the previous version into the history trail; add a row to the release-notes table; update any in-context sections the change touches. | Show what the agent sees, not just what the code does. |
+| 3 | **`docs/index.html`** | Top banner block + earlier-releases trail + the **Status & Future** block (keep "Current/Next" honest). | Landing page — highest first-impression value. |
+| 4 | **`docs/about.html`** | New "What's New in v<X.Y.Z>" section *above* the prior one. Never delete old sections — demote them. | Forward-looking direction goes in the "Where NeuralMind is going next" section. |
+| 5 | **`docs/wiki/*.md` + `docs/use-cases/*.md`** | New commands/env vars in `CLI-Reference.md`; update touched use-cases AND add a new walkthrough if the change unlocks a new workflow. | **The wiki auto-syncs** from `docs/wiki/**` to the live GitHub Wiki via `sync-wiki.yml` on merge to `main` — edit the source, never the live wiki. |
+
+**Do NOT edit `CHANGELOG.md`** — release-please owns it and writes it from the
+`feat:`/`fix:` commit body. Do NOT hand-bump `pyproject.toml` /
+`.release-please-manifest.json` versions.
+
+---
+
+## SEO (every release that adds a new noun to the product surface)
+
+- **`pyproject.toml` keywords** — add 2–3 terms specific to the new surface so
+  PyPI search picks them up.
+- **`docs/index.html`** `<meta name="description">` / `<meta name="keywords">`
+  — broaden when the positioning shifts.
+- **`docs/about.html`** page-level `<meta>` — refresh if the feature is a
+  positioning anchor.
+- **`docs/sitemap.xml`** — add discoverable new URLs (release notes, new
+  use-case walkthroughs). Only add URLs that resolve to a real page.
+- **schema.org JSON-LD** (`SoftwareApplication` / `Article`) — consider for
+  richer Google results (known gap).
+
+---
+
+## Discoverability — frame for the searcher
+
+A feature mentioned in release notes should link to (or trigger creation of) a
+**use-case walkthrough**, because that's what people actually search for.
+
+- Describe both the *existing* use case the feature improves **and** the
+  *potential* new use case it unlocks.
+- Cross-link release notes ↔ use-case ↔ wiki.
+- Title walkthroughs as workflows ("Prove retrieval quality on your repo"), not
+  feature names ("The eval command").
+
+---
+
+## Cadence — three loops
+
+1. **Per-PR (the default).** Docs for a user-facing change ship in the same PR.
+   Enforced by the documentation section of the PR template. The reviewer blocks
+   the PR if a user-facing change has no doc updates.
+2. **Per-release.** Before merging the release-please PR, run the
+   **release docs audit** below. The PM/maintainer owns this gate.
+3. **Quarterly freshness sweep.** Catch slow drift the per-PR loop misses
+   (stale "Current/Next", dead links, outdated screenshots, comparison pages
+   that no longer match competitors). The PM agent owns scheduling this.
+
+---
+
+## Release docs audit (run before merging a release PR)
+
+- [ ] `RELEASE_NOTES_v<X.Y.Z>.md` exists and is written from the user/agent-sees angle.
+- [ ] README banner shows the new version; previous version demoted; release table row added.
+- [ ] `docs/index.html` banner **and Status & Future block** reflect the new version (no stale "Current/Next").
+- [ ] `docs/about.html` has a new "What's New" section above the prior one.
+- [ ] `docs/wiki/CLI-Reference.md` documents any new command/env var; touched use-cases updated; new walkthrough added if a workflow was unlocked.
+- [ ] SEO: keywords / meta / sitemap updated if a new noun entered the product surface.
+- [ ] No manual edits to `CHANGELOG.md`, `pyproject.toml` version, or the release manifest.
+- [ ] All doc links resolve (no 404s to renamed files).
+
+> **Recommended automation (open).** A lightweight CI guard that fails when the
+> latest `RELEASE_NOTES_v*.md` version is *not* referenced in `README.md`,
+> `docs/index.html`, and `docs/about.html` would catch the stale-surface failure
+> mode mechanically. Tracked as a future docs-tooling task.
+
+---
+
+## Quick reference
+
+- **Where the canonical checklist lives:** `CLAUDE.md` → "Shipping a feature — docs + SEO checklist".
+- **Wiki:** edit `docs/wiki/*.md`; it syncs to the live wiki automatically on merge to `main`.
+- **Versioning:** release-please, driven by `feat:`/`fix:` commits — see `CONTRIBUTING.md` → Release Process and `docs/VERSION-STRATEGY.md`.
+- **Forward-looking roadmap:** `ROADMAP.md` + `docs/NEXT-RELEASE-PLAN.md`.

--- a/docs/DOCUMENTATION-PROCESS.md
+++ b/docs/DOCUMENTATION-PROCESS.md
@@ -38,11 +38,11 @@ internal refactors are exempt (note that in the PR).
 | 2 | **`README.md`** | Bump the top banner; demote the previous version into the history trail; add a row to the release-notes table; update any in-context sections the change touches. | Show what the agent sees, not just what the code does. |
 | 3 | **`docs/index.html`** | Top banner block + earlier-releases trail + the **Status & Future** block (keep "Current/Next" honest). | Landing page — highest first-impression value. |
 | 4 | **`docs/about.html`** | New "What's New in v<X.Y.Z>" section *above* the prior one. Never delete old sections — demote them. | Forward-looking direction goes in the "Where NeuralMind is going next" section. |
-| 5 | **`docs/wiki/*.md` + `docs/use-cases/*.md`** | New commands/env vars in `CLI-Reference.md`; update touched use-cases AND add a new walkthrough if the change unlocks a new workflow. | **The wiki auto-syncs** from `docs/wiki/**` to the live GitHub Wiki via `sync-wiki.yml` on merge to `main` — edit the source, never the live wiki. |
+| 5 | **`docs/wiki/*.md` + `docs/use-cases/*.md`** | New commands/env vars in `CLI-Reference.md`; update touched use-cases AND add a new walkthrough if the change unlocks a new workflow. | **The wiki auto-syncs** from `docs/wiki/**` to the live GitHub Wiki via `.github/workflows/sync-wiki.yml` on merge to `main` — edit the source, never the live wiki. |
 
-**Do NOT edit `CHANGELOG.md`** — release-please owns it and writes it from the
-`feat:`/`fix:` commit body. Do NOT hand-bump `pyproject.toml` /
-`.release-please-manifest.json` versions.
+**Do NOT edit `CHANGELOG.md`** — release-please owns it and generates each
+entry from the `feat:`/`fix:` Conventional Commit *subject line*. Do NOT
+hand-bump `pyproject.toml` / `.release-please-manifest.json` versions.
 
 ---
 


### PR DESCRIPTION
## Why
Docs drift silently, and the cost is paid by first-time visitors. Concrete trigger: `docs/index.html`'s "Status & Future" block still advertised **v0.5.4 (Current) / v0.5.5 (Next)** while the project was on v0.12 (fixed in #170). There was a docs checklist buried in `CLAUDE.md`, but no repeatable *process* and no per-PR enforcement.

## What this adds
- **`docs/DOCUMENTATION-PROCESS.md`** — the operational standard:
  - **The one rule:** every user-facing change ships its docs in the *same PR*, and every doc answers *"what does the user/agent now see?"* (the framing that makes docs interesting to users, not just a changelog).
  - The **five surfaces** (release notes, README, index.html, about.html, wiki + use-cases), noting the wiki **auto-syncs** from `docs/wiki/**` via `sync-wiki.yml`.
  - **SEO** + **discoverability** (frame features as workflows people search for; cross-link release notes ↔ use-case ↔ wiki).
  - A **three-loop cadence**: per-PR (default) → per-release audit → quarterly freshness sweep (the loop that catches the stale-"Current/Next" failure).
  - A **release docs audit** checklist, and a noted **open automation**: a CI guard that fails when the latest `RELEASE_NOTES_v*` version isn't referenced across README/index/about.
- **`.github/PULL_REQUEST_TEMPLATE.md`** — a new **"Documentation & discoverability"** section that operationalizes the process per-PR (with an N/A escape for internal refactors).
- **`CONTRIBUTING.md`** — links the process from the Documentation section.

Docs-only; no code, no version bump. Complements `CLAUDE.md` (the *what*) by adding the *when/who/how-we-stay-honest*.

https://claude.ai/code/session_016MZU3vW4yd4SJeA293foF3

---
_Generated by [Claude Code](https://claude.ai/code/session_016MZU3vW4yd4SJeA293foF3)_