### PR TITLE
feat(evals): faithfulness eval foundation — query+gold-fact set + offline judge skeleton (E1.1)

### DIFF
--- a/evals/faithfulness/README.md
+++ b/evals/faithfulness/README.md
@@ -1,0 +1,85 @@
+# Faithfulness eval harness
+
+Measures whether an agent's answer to a code question gets **better** with
+NeuralMind context, not just shorter — the fitness function the v0.13
+"Measure" release is built around.
+
+> **Status: E1.1 foundation only.** This directory currently ships the
+> query + gold-fact set, the format/scoring spec, and a pure-Python runner
+> skeleton with the offline expected-fact-recall scorer. Answer generation,
+> the full judge, the report, and the onboarding-lift eval are follow-on
+> tasks (see [Roadmap](#roadmap)). Tracking issue:
+> [#172](https://github.com/dfrostar/neuralmind/issues/172);
+> plan: `docs/NEXT-RELEASE-PLAN.md` §3 Epic E1.
+
+## Why this exists
+
+`docs/HONEST-ASSESSMENT.md` concedes faithfulness is unmeasured: *"Does the
+agent's answer get better with NeuralMind context, or just shorter? We have
+anecdotes, not measurements."* This harness turns that into a number.
+
+## Design: offline judge is the default and the CI gate
+
+The headline NeuralMind promise is **100% local**. A faithfulness judge
+usually wants a strong LLM — which conflicts with that promise. The
+resolution, baked into the design:
+
+- **Offline heuristic judge — DEFAULT, and the CI gating signal. Zero
+  network.** Scores expected-fact recall, citation/grounding rate, and a
+  contradiction check using only the gold facts in `queries.json` and
+  string/heuristic matching. This is the judge that gates PRs. It never
+  phones home. It is the product.
+- **LLM-as-judge — OPT-IN ONLY, and clearly labelled as leaving the
+  machine.** Enabled solely via the `NEURALMIND_EVAL_LLM_JUDGE=1` env var
+  (the API key comes from the standard provider env var). When enabled the
+  runner must print a one-line notice that answers + gold facts are sent to
+  a third-party API. It is **never** the default and **never** the CI gate
+  — a power-user convenience for nuanced scoring, nothing more.
+
+If neither the env var is set nor a key is present, the harness runs fully
+offline. The eval must not quietly phone home; doing so would contradict
+the headline claim.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `queries.json` | Versioned query + gold-fact set (≥15 queries) derived from `tests/fixtures/sample_project/`. |
+| `schema.md` | The `queries.json` format contract + the three scoring dimensions. |
+| `runner.py` | Pure-Python skeleton: loads the query set, defines the scoring interface, implements the offline expected-fact-recall scorer. Answerer + API judge are marked TODO. |
+| `README.md` | This file. |
+
+`runner.py` imports **standard library only** at module load — no
+chromadb / graphify / heavy deps — so it loads and is unit-testable in a
+minimal environment. Heavy machinery (the real answerer wired to
+`neuralmind.core`) is imported lazily inside the functions that need it,
+added in E1.2.
+
+## Running it
+
+```bash
+# Offline (default) — once E1.2 lands an answerer this prints the report.
+python -m evals.faithfulness.runner
+
+# Today (E1.1): inspect the loaded query set and self-check the scorer.
+python evals/faithfulness/runner.py --selfcheck
+```
+
+Unit tests (stdlib `unittest`, no pytest required):
+
+```bash
+python tests/test_eval_faithfulness.py
+```
+
+## Roadmap (issue #172)
+
+| Task | What it adds | Status |
+|---|---|---|
+| **E1.1** | Query + gold-fact set, schema, runner skeleton + offline recall scorer. | **this PR** |
+| E1.2 | A/B answer generation: with-NeuralMind-context vs naive baseline, via a pluggable deterministic answerer. | follow-on |
+| E1.3 | Full judges: offline (recall + grounding + contradiction) as default/gate, opt-in LLM-as-judge behind the env var. | follow-on |
+| E1.4 | `neuralmind eval` report — faithfulness delta (with vs without), grounding rate, per-query breakdown, `--json`. | follow-on |
+| E1.5 | Onboarding-lift eval — cold agent + team baseline vs cold agent alone; gates shared-memory build (#175). | follow-on |
+
+CI gating (Epic E3) consumes the offline judge's output once E1.4 exists,
+mirroring how `ci-benchmark.yml` gates token reduction today.

--- a/evals/faithfulness/queries.json
+++ b/evals/faithfulness/queries.json
@@ -1,0 +1,203 @@
+{
+  "schema_version": 1,
+  "_comment": "Faithfulness eval query + gold-fact set for issue #172 (E1.1). Each entry pairs a natural-language query with the KEY FACTS a correct answer must contain (expected_facts), not just the gold modules. Facts are derived directly from the code in tests/fixtures/sample_project/ — read that fixture before editing facts here. expected_modules are retained for grounding/citation scoring (E1.3); fact `aliases` give the offline judge synonym surface so heuristic recall is not brittle to exact wording. See schema.md for the format contract and README.md for the harness design.",
+  "fixture": "tests/fixtures/sample_project",
+  "queries": [
+    {
+      "id": "auth-flow",
+      "question": "How does authentication work in this codebase?",
+      "shape": "cross-file",
+      "expected_modules": ["auth/handlers.py", "auth/jwt_utils.py", "users/crud.py"],
+      "expected_facts": [
+        {"id": "auth-lookup-by-email", "fact": "the user is looked up by email", "aliases": ["get_user_by_email", "lookup by email", "find user by email"]},
+        {"id": "auth-verify-password", "fact": "the password hash is verified", "aliases": ["verify_password", "password hash", "check password", "compare_digest"]},
+        {"id": "auth-issues-jwt-pair", "fact": "a JWT access token and refresh token pair is issued on success", "aliases": ["access_token", "refresh_token", "access and refresh", "token pair", "encode_token"]},
+        {"id": "auth-invalid-credentials", "fact": "InvalidCredentialsError is raised when email or password do not match", "aliases": ["InvalidCredentialsError", "bad password", "unknown email"]}
+      ]
+    },
+    {
+      "id": "jwt-verify",
+      "question": "How does JWT signature verification work?",
+      "shape": "focused",
+      "expected_modules": ["auth/jwt_utils.py"],
+      "expected_facts": [
+        {"id": "jwt-hs256", "fact": "tokens are signed with HMAC-SHA256 (HS256)", "aliases": ["HS256", "HMAC", "hmac.new", "sha256", "hashlib.sha256"]},
+        {"id": "jwt-three-segments", "fact": "the token is split into three dot-separated segments: header, payload, signature", "aliases": ["3 segments", "three segments", "header.payload.signature", "split"]},
+        {"id": "jwt-constant-time", "fact": "the signature is compared in constant time with hmac.compare_digest", "aliases": ["compare_digest", "constant time", "constant-time"]},
+        {"id": "jwt-invalid-signature", "fact": "InvalidSignatureError is raised on a signature mismatch", "aliases": ["InvalidSignatureError", "signature mismatch"]},
+        {"id": "jwt-expiry-check", "fact": "the exp claim is checked and TokenExpiredError is raised when expired", "aliases": ["TokenExpiredError", "exp", "expired", "expiry"]}
+      ]
+    },
+    {
+      "id": "jwt-secret",
+      "question": "What secret and algorithm are used to sign JWTs?",
+      "shape": "identity",
+      "expected_modules": ["auth/jwt_utils.py"],
+      "expected_facts": [
+        {"id": "jwt-secret-symmetric", "fact": "signing uses a symmetric shared secret (JWT_SECRET)", "aliases": ["JWT_SECRET", "shared secret", "symmetric", "change-me-in-prod"]},
+        {"id": "jwt-alg-hs256", "fact": "the algorithm is HS256", "aliases": ["HS256", "ALGORITHM"]}
+      ]
+    },
+    {
+      "id": "token-refresh",
+      "question": "How is a refresh token exchanged for a new access token?",
+      "shape": "focused",
+      "expected_modules": ["auth/handlers.py", "auth/jwt_utils.py"],
+      "expected_facts": [
+        {"id": "refresh-decode", "fact": "the refresh token is decoded and its signature/expiry verified", "aliases": ["decode_token", "decode", "verify"]},
+        {"id": "refresh-kind-check", "fact": "the token must carry kind=refresh or InvalidTokenError is raised", "aliases": ["kind", "refresh", "InvalidTokenError", "not a refresh token"]},
+        {"id": "refresh-new-access", "fact": "a new short-lived access token is encoded and returned", "aliases": ["encode_token", "new access", "access_token", "SESSION_TTL"]}
+      ]
+    },
+    {
+      "id": "session-ttl",
+      "question": "How long are access and refresh tokens valid for?",
+      "shape": "identity",
+      "expected_modules": ["auth/handlers.py"],
+      "expected_facts": [
+        {"id": "ttl-access-1h", "fact": "the access/session token lives for 1 hour", "aliases": ["SESSION_TTL", "1 hour", "hours=1", "one hour"]},
+        {"id": "ttl-refresh-30d", "fact": "the refresh token lives for 30 days", "aliases": ["REFRESH_TTL", "30 days", "days=30", "thirty days"]}
+      ]
+    },
+    {
+      "id": "logout-revoke",
+      "question": "How is a session revoked on logout?",
+      "shape": "focused",
+      "expected_modules": ["auth/handlers.py"],
+      "expected_facts": [
+        {"id": "logout-revocation-list", "fact": "logout writes the refresh token to a revoked_tokens revocation list", "aliases": ["revoked_tokens", "revocation list", "revoke", "INSERT INTO revoked_tokens"]}
+      ]
+    },
+    {
+      "id": "api-endpoints",
+      "question": "What are the main API endpoints?",
+      "shape": "focused",
+      "expected_modules": ["api/routes.py"],
+      "expected_facts": [
+        {"id": "api-auth-routes", "fact": "there are auth routes for login, refresh, and logout", "aliases": ["/api/auth/login", "/api/auth/refresh", "/api/auth/logout", "login", "logout"]},
+        {"id": "api-user-routes", "fact": "there are user routes to create a user and read/delete the current user", "aliases": ["/api/users", "/api/users/me", "create user", "get_me", "delete_me"]},
+        {"id": "api-billing-routes", "fact": "there are billing routes for charge, refund, and invoices", "aliases": ["/api/billing/charge", "/api/billing/refund", "/api/billing/invoices", "charge", "refund", "invoices"]},
+        {"id": "api-webhook-route", "fact": "there is a Stripe webhook endpoint", "aliases": ["/webhooks/stripe", "webhook", "stripe webhook"]}
+      ]
+    },
+    {
+      "id": "route-decorator",
+      "question": "How are routes registered in the API layer?",
+      "shape": "focused",
+      "expected_modules": ["api/routes.py"],
+      "expected_facts": [
+        {"id": "route-decorator-registers", "fact": "a @route(method, path) decorator records a (method, path, handler) tuple", "aliases": ["@route", "route decorator", "decorator", "method, path, handler", "tuple"]},
+        {"id": "route-registry", "fact": "registered routes are appended to a module-level ROUTES list", "aliases": ["ROUTES", "ROUTES list", "append"]}
+      ]
+    },
+    {
+      "id": "protected-endpoints",
+      "question": "How do protected endpoints authenticate the caller?",
+      "shape": "cross-file",
+      "expected_modules": ["api/routes.py", "auth/handlers.py"],
+      "expected_facts": [
+        {"id": "protected-bearer", "fact": "the caller passes a bearer token in the Authorization header", "aliases": ["Authorization", "Bearer", "bearer token", "Authorization header"]},
+        {"id": "protected-verify-session", "fact": "verify_session validates the access token and returns the user id", "aliases": ["verify_session", "user id", "user_id", "validate token"]}
+      ]
+    },
+    {
+      "id": "create-user",
+      "question": "How do I create a new user?",
+      "shape": "cross-file",
+      "expected_modules": ["users/crud.py", "api/routes.py"],
+      "expected_facts": [
+        {"id": "create-user-endpoint", "fact": "POST /api/users is the sign-up endpoint", "aliases": ["/api/users", "POST /api/users", "sign-up", "signup"]},
+        {"id": "create-user-insert", "fact": "create_user inserts a row into the users table and returns the User record", "aliases": ["create_user", "INSERT INTO users", "User", "returns user"]},
+        {"id": "create-user-stores-hash", "fact": "the user is stored with email and a password_hash", "aliases": ["password_hash", "email", "hash"]}
+      ]
+    },
+    {
+      "id": "user-storage",
+      "question": "How are users stored in the database?",
+      "shape": "cross-file",
+      "expected_modules": ["users/crud.py", "db/connection.py"],
+      "expected_facts": [
+        {"id": "user-table", "fact": "users are stored in a users table", "aliases": ["users table", "CREATE TABLE", "users"]},
+        {"id": "user-columns", "fact": "the user record has id, email, password_hash, created_at, last_login, and is_active fields", "aliases": ["password_hash", "is_active", "last_login", "created_at", "email", "id"]},
+        {"id": "user-soft-delete", "fact": "users are soft-deleted by flipping the is_active flag rather than being removed", "aliases": ["soft-delete", "soft delete", "is_active", "deactivate_user"]}
+      ]
+    },
+    {
+      "id": "db-choice",
+      "question": "What database does this project use?",
+      "shape": "identity",
+      "expected_modules": ["db/connection.py"],
+      "expected_facts": [
+        {"id": "db-sqlite", "fact": "the fixture uses SQLite", "aliases": ["sqlite", "sqlite3", "SQLite"]},
+        {"id": "db-thread-local", "fact": "connections are thread-local", "aliases": ["thread-local", "threading.local", "thread local"]},
+        {"id": "db-lazy-schema", "fact": "the schema is created lazily on first connection", "aliases": ["lazily", "lazy", "_ensure_schema", "CREATE TABLE IF NOT EXISTS", "first access"]}
+      ]
+    },
+    {
+      "id": "billing-flow",
+      "question": "Explain the billing flow when a user is charged.",
+      "shape": "cross-file",
+      "expected_modules": ["billing/stripe_client.py", "billing/invoices.py", "users/crud.py"],
+      "expected_facts": [
+        {"id": "charge-validate-user", "fact": "the user is validated and must be active before charging", "aliases": ["get_user", "is_active", "not chargeable", "validate user", "BillingError"]},
+        {"id": "charge-stripe", "fact": "a charge is created via the Stripe API", "aliases": ["stripe", "Charge.create", "charge_customer", "_fake_stripe_charge"]},
+        {"id": "charge-record", "fact": "the charge is mirrored into a local charges table", "aliases": ["charges table", "INSERT INTO charges", "billing record", "charges"]},
+        {"id": "charge-invoice", "fact": "an invoice is created on a successful charge", "aliases": ["create_invoice", "invoice", "invoices"]}
+      ]
+    },
+    {
+      "id": "refund",
+      "question": "Show me the refund logic.",
+      "shape": "focused",
+      "expected_modules": ["billing/stripe_client.py"],
+      "expected_facts": [
+        {"id": "refund-lookup", "fact": "the charge is looked up by its stripe id", "aliases": ["stripe_id", "SELECT", "charges WHERE", "look up charge"]},
+        {"id": "refund-double-guard", "fact": "an already-refunded charge raises BillingError to prevent double refunds", "aliases": ["already refunded", "BillingError", "double refund", "refunded"]},
+        {"id": "refund-status-update", "fact": "the charge status is updated to refunded and a refunds row is written", "aliases": ["status = 'refunded'", "UPDATE charges", "INSERT INTO refunds", "refunds table"]}
+      ]
+    },
+    {
+      "id": "stripe-webhook",
+      "question": "What happens when a Stripe webhook fires?",
+      "shape": "cross-file",
+      "expected_modules": ["billing/stripe_client.py", "api/routes.py"],
+      "expected_facts": [
+        {"id": "webhook-verify-sig", "fact": "the webhook signature is verified before processing", "aliases": ["verify_webhook", "signature", "Stripe-Signature", "verify"]},
+        {"id": "webhook-tolerance", "fact": "the signature timestamp must be within a tolerance window (replay protection)", "aliases": ["WEBHOOK_TOLERANCE_SEC", "tolerance", "timestamp", "300", "replay"]},
+        {"id": "webhook-dispatch", "fact": "verified events are dispatched by type (charge.succeeded/failed/refunded) to update charge status", "aliases": ["handle_webhook_event", "charge.succeeded", "charge.failed", "charge.refunded", "dispatch", "event type"]}
+      ]
+    },
+    {
+      "id": "webhook-signature-detail",
+      "question": "How is the Stripe webhook signature validated?",
+      "shape": "focused",
+      "expected_modules": ["billing/stripe_client.py"],
+      "expected_facts": [
+        {"id": "wsig-header-format", "fact": "the Stripe-Signature header is parsed for a timestamp (t) and signature (v1)", "aliases": ["Stripe-Signature", "t=", "v1=", "timestamp", "signature header"]},
+        {"id": "wsig-hmac", "fact": "an HMAC-SHA256 of 'timestamp.payload' is computed with the webhook secret", "aliases": ["hmac", "sha256", "STRIPE_WEBHOOK_SECRET", "signed_payload", "hexdigest"]},
+        {"id": "wsig-error", "fact": "a mismatch raises WebhookVerificationError", "aliases": ["WebhookVerificationError", "signature mismatch", "outside tolerance"]}
+      ]
+    },
+    {
+      "id": "invoice-send",
+      "question": "How are invoices sent to users?",
+      "shape": "cross-file",
+      "expected_modules": ["billing/invoices.py", "users/crud.py"],
+      "expected_facts": [
+        {"id": "invoice-lookup", "fact": "the invoice is loaded by id and the recipient user is fetched", "aliases": ["send_invoice_email", "SELECT", "get_user", "load invoice", "invoice id"]},
+        {"id": "invoice-not-found", "fact": "a missing invoice or user raises InvoiceNotFoundError", "aliases": ["InvoiceNotFoundError", "not found", "missing"]},
+        {"id": "invoice-mark-sent", "fact": "the invoice is queued to the mail transport and stamped with sent_at", "aliases": ["sent_at", "_render_and_queue", "mail", "UPDATE invoices", "mark sent"]}
+      ]
+    },
+    {
+      "id": "list-invoices",
+      "question": "How do I list a user's invoices?",
+      "shape": "focused",
+      "expected_modules": ["billing/invoices.py"],
+      "expected_facts": [
+        {"id": "list-by-user", "fact": "list_user_invoices selects invoices filtered by user_id", "aliases": ["list_user_invoices", "WHERE user_id", "by user", "user_id"]},
+        {"id": "list-order", "fact": "results are ordered newest first", "aliases": ["ORDER BY created_at DESC", "newest first", "DESC", "newest"]}
+      ]
+    }
+  ]
+}

--- a/evals/faithfulness/queries.json
+++ b/evals/faithfulness/queries.json
@@ -22,7 +22,7 @@
       "expected_modules": ["auth/jwt_utils.py"],
       "expected_facts": [
         {"id": "jwt-hs256", "fact": "tokens are signed with HMAC-SHA256 (HS256)", "aliases": ["HS256", "HMAC", "hmac.new", "sha256", "hashlib.sha256"]},
-        {"id": "jwt-three-segments", "fact": "the token is split into three dot-separated segments: header, payload, signature", "aliases": ["3 segments", "three segments", "header.payload.signature", "split"]},
+        {"id": "jwt-three-segments", "fact": "the token is split into three dot-separated segments: header, payload, signature", "aliases": ["3 segments", "three segments", "header.payload.signature"]},
         {"id": "jwt-constant-time", "fact": "the signature is compared in constant time with hmac.compare_digest", "aliases": ["compare_digest", "constant time", "constant-time"]},
         {"id": "jwt-invalid-signature", "fact": "InvalidSignatureError is raised on a signature mismatch", "aliases": ["InvalidSignatureError", "signature mismatch"]},
         {"id": "jwt-expiry-check", "fact": "the exp claim is checked and TokenExpiredError is raised when expired", "aliases": ["TokenExpiredError", "exp", "expired", "expiry"]}
@@ -86,7 +86,7 @@
       "shape": "focused",
       "expected_modules": ["api/routes.py"],
       "expected_facts": [
-        {"id": "route-decorator-registers", "fact": "a @route(method, path) decorator records a (method, path, handler) tuple", "aliases": ["@route", "route decorator", "decorator", "method, path, handler", "tuple"]},
+        {"id": "route-decorator-registers", "fact": "a @route(method, path) decorator records a (method, path, handler) tuple", "aliases": ["@route", "route decorator", "method, path, handler"]},
         {"id": "route-registry", "fact": "registered routes are appended to a module-level ROUTES list", "aliases": ["ROUTES", "ROUTES list", "append"]}
       ]
     },
@@ -118,7 +118,7 @@
       "expected_modules": ["users/crud.py", "db/connection.py"],
       "expected_facts": [
         {"id": "user-table", "fact": "users are stored in a users table", "aliases": ["users table", "CREATE TABLE", "users"]},
-        {"id": "user-columns", "fact": "the user record has id, email, password_hash, created_at, last_login, and is_active fields", "aliases": ["password_hash", "is_active", "last_login", "created_at", "email", "id"]},
+        {"id": "user-columns", "fact": "the user record has id, email, password_hash, created_at, last_login, and is_active fields", "aliases": ["password_hash", "is_active", "last_login", "created_at", "users.id", "users.email"]},
         {"id": "user-soft-delete", "fact": "users are soft-deleted by flipping the is_active flag rather than being removed", "aliases": ["soft-delete", "soft delete", "is_active", "deactivate_user"]}
       ]
     },
@@ -173,7 +173,7 @@
       "shape": "focused",
       "expected_modules": ["billing/stripe_client.py"],
       "expected_facts": [
-        {"id": "wsig-header-format", "fact": "the Stripe-Signature header is parsed for a timestamp (t) and signature (v1)", "aliases": ["Stripe-Signature", "t=", "v1=", "timestamp", "signature header"]},
+        {"id": "wsig-header-format", "fact": "the Stripe-Signature header is parsed for a timestamp (t) and signature (v1)", "aliases": ["Stripe-Signature", "v1=", "timestamp", "signature header"]},
         {"id": "wsig-hmac", "fact": "an HMAC-SHA256 of 'timestamp.payload' is computed with the webhook secret", "aliases": ["hmac", "sha256", "STRIPE_WEBHOOK_SECRET", "signed_payload", "hexdigest"]},
         {"id": "wsig-error", "fact": "a mismatch raises WebhookVerificationError", "aliases": ["WebhookVerificationError", "signature mismatch", "outside tolerance"]}
       ]

--- a/evals/faithfulness/runner.py
+++ b/evals/faithfulness/runner.py
@@ -28,9 +28,9 @@ import json
 import os
 import re
 import sys
+from collections.abc import Iterable
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Iterable
 
 SCHEMA_VERSION = 1
 

--- a/evals/faithfulness/runner.py
+++ b/evals/faithfulness/runner.py
@@ -1,0 +1,298 @@
+"""Faithfulness eval runner — E1.1 foundation skeleton.
+
+Pure standard library at import time: NO chromadb / graphify / neuralmind
+imports at module load, so this file loads and is unit-testable in a
+minimal environment. Heavy machinery (the real answerer wired to
+``neuralmind.core``) is imported lazily inside the functions that need it
+once E1.2 lands.
+
+What this module ships today (E1.1):
+  * ``load_query_set`` — parse + lightly validate ``queries.json``.
+  * ``OfflineJudge.fact_recall`` — the offline, zero-network
+    expected-fact-recall scorer. This is the default, CI-gating signal.
+
+What is intentionally left as TODO (later tasks of issue #172):
+  * E1.2 — answer generation (with-NeuralMind vs naive baseline).
+  * E1.3 — grounding-rate + contradiction scoring, and the opt-in
+    LLM-as-judge behind ``NEURALMIND_EVAL_LLM_JUDGE``.
+  * E1.4 — the ``neuralmind eval`` report (delta, per-query breakdown, JSON).
+
+See ``schema.md`` for the data contract and ``README.md`` for the design
+(offline judge = default + gate; API judge = opt-in, labelled as leaving
+the machine).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable
+
+SCHEMA_VERSION = 1
+
+# Opt-in, never the default and never the CI gate. Documented in README.md.
+LLM_JUDGE_ENV = "NEURALMIND_EVAL_LLM_JUDGE"
+
+_QUERIES_PATH = Path(__file__).resolve().parent / "queries.json"
+
+_WORD_RE = re.compile(r"[a-z0-9]+")
+
+
+# --------------------------------------------------------------------------- #
+# Data model
+# --------------------------------------------------------------------------- #
+@dataclass(frozen=True)
+class ExpectedFact:
+    """A single checkable claim a correct answer must contain."""
+
+    id: str
+    fact: str
+    aliases: tuple[str, ...] = ()
+
+    def surfaces(self) -> tuple[str, ...]:
+        """All strings that count as expressing this fact."""
+        return (self.fact, *self.aliases)
+
+
+@dataclass(frozen=True)
+class Query:
+    """One eval query with its rubric of expected facts."""
+
+    id: str
+    question: str
+    expected_facts: tuple[ExpectedFact, ...]
+    expected_modules: tuple[str, ...] = ()
+    shape: str = ""
+
+
+@dataclass
+class QuerySet:
+    """The loaded, validated query set."""
+
+    schema_version: int
+    fixture: str
+    queries: list[Query] = field(default_factory=list)
+
+    def __len__(self) -> int:
+        return len(self.queries)
+
+
+# --------------------------------------------------------------------------- #
+# Loading
+# --------------------------------------------------------------------------- #
+def load_query_set(path: str | os.PathLike[str] | None = None) -> QuerySet:
+    """Load and validate ``queries.json``.
+
+    Raises ``ValueError`` on a malformed file or an unsupported
+    ``schema_version`` so a bad gold set fails loudly rather than silently
+    scoring against nothing.
+    """
+    p = Path(path) if path is not None else _QUERIES_PATH
+    raw = json.loads(p.read_text(encoding="utf-8"))
+
+    version = raw.get("schema_version")
+    if version != SCHEMA_VERSION:
+        raise ValueError(
+            f"unsupported schema_version {version!r}; runner expects {SCHEMA_VERSION}"
+        )
+
+    queries: list[Query] = []
+    seen_ids: set[str] = set()
+    for entry in raw.get("queries", []):
+        qid = entry["id"]
+        if qid in seen_ids:
+            raise ValueError(f"duplicate query id: {qid!r}")
+        seen_ids.add(qid)
+
+        facts: list[ExpectedFact] = []
+        for f in entry.get("expected_facts", []):
+            facts.append(
+                ExpectedFact(
+                    id=f["id"],
+                    fact=f["fact"],
+                    aliases=tuple(f.get("aliases", [])),
+                )
+            )
+        if not facts:
+            raise ValueError(f"query {qid!r} has no expected_facts")
+
+        queries.append(
+            Query(
+                id=qid,
+                question=entry["question"],
+                expected_facts=tuple(facts),
+                expected_modules=tuple(entry.get("expected_modules", [])),
+                shape=entry.get("shape", ""),
+            )
+        )
+
+    if not queries:
+        raise ValueError("query set is empty")
+
+    return QuerySet(
+        schema_version=version,
+        fixture=raw.get("fixture", ""),
+        queries=queries,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Scoring interface
+# --------------------------------------------------------------------------- #
+def _normalize(text: str) -> str:
+    """Lowercase + collapse non-alphanumerics to single spaces.
+
+    Makes substring matching robust to punctuation/casing/whitespace so a
+    fact like ``hmac.compare_digest`` matches an answer that writes
+    ``hmac compare digest`` or ``HMAC.compare_digest()``.
+    """
+    return " ".join(_WORD_RE.findall(text.lower()))
+
+
+@dataclass
+class FactResult:
+    fact_id: str
+    matched: bool
+    matched_on: str = ""
+
+
+@dataclass
+class RecallResult:
+    """Per-query expected-fact-recall outcome."""
+
+    query_id: str
+    matched: int
+    total: int
+    facts: list[FactResult] = field(default_factory=list)
+
+    @property
+    def recall(self) -> float:
+        return self.matched / self.total if self.total else 0.0
+
+
+class OfflineJudge:
+    """Zero-network heuristic judge — the default and CI-gating signal.
+
+    E1.1 implements expected-fact recall. Grounding-rate and contradiction
+    scoring are E1.3 (stubbed below). This judge NEVER makes a network
+    call; the opt-in LLM-as-judge (``NEURALMIND_EVAL_LLM_JUDGE``) is a
+    separate path added in E1.3.
+    """
+
+    def fact_matched(self, fact: ExpectedFact, answer_norm: str) -> FactResult:
+        """Does ``answer_norm`` (already normalized) express ``fact``?"""
+        for surface in fact.surfaces():
+            needle = _normalize(surface)
+            if needle and needle in answer_norm:
+                return FactResult(fact.id, matched=True, matched_on=surface)
+        return FactResult(fact.id, matched=False)
+
+    def fact_recall(self, query: Query, answer: str) -> RecallResult:
+        """Fraction of ``query``'s expected facts present in ``answer``."""
+        answer_norm = _normalize(answer)
+        results = [self.fact_matched(f, answer_norm) for f in query.expected_facts]
+        matched = sum(1 for r in results if r.matched)
+        return RecallResult(
+            query_id=query.id,
+            matched=matched,
+            total=len(query.expected_facts),
+            facts=results,
+        )
+
+    def mean_recall(self, pairs: Iterable[tuple[Query, str]]) -> float:
+        """Mean per-query fact recall over (query, answer) pairs."""
+        results = [self.fact_recall(q, a) for q, a in pairs]
+        if not results:
+            return 0.0
+        return sum(r.recall for r in results) / len(results)
+
+    # -- E1.3 TODOs ------------------------------------------------------- #
+    def grounding_rate(self, query: Query, answer: str) -> float:
+        """TODO(E1.3): fraction of answer claims attributable to
+        ``query.expected_modules`` / retrieved context. Zero-network."""
+        raise NotImplementedError("grounding_rate lands in E1.3")
+
+    def contradiction_score(self, query: Query, answer: str) -> float:
+        """TODO(E1.3): detect statements that conflict with the gold facts
+        (e.g. PostgreSQL vs SQLite, RS256 vs HS256). Zero-network."""
+        raise NotImplementedError("contradiction_score lands in E1.3")
+
+
+# --------------------------------------------------------------------------- #
+# Answer generation — E1.2 TODO
+# --------------------------------------------------------------------------- #
+def generate_answer(query: Query, *, with_context: bool) -> str:  # noqa: ARG001
+    """TODO(E1.2): produce an answer for ``query``.
+
+    ``with_context=True`` should answer using NeuralMind-selected context
+    (lazy-import ``neuralmind.core`` here, NOT at module top, to keep this
+    file importable without heavy deps). ``with_context=False`` is the
+    naive baseline. Must be deterministic given a fixed answerer.
+    """
+    raise NotImplementedError("answer generation lands in E1.2")
+
+
+def _llm_judge_enabled() -> bool:
+    """Opt-in only. Never the default, never the CI gate (E1.3)."""
+    return os.environ.get(LLM_JUDGE_ENV, "") not in ("", "0", "false", "False")
+
+
+# --------------------------------------------------------------------------- #
+# CLI entry — selfcheck today; full report is E1.4
+# --------------------------------------------------------------------------- #
+def _selfcheck() -> int:
+    """Load the query set and sanity-check the offline scorer end to end.
+
+    No network, no heavy deps. Lets CI confirm the gold set parses and the
+    recall scorer behaves before E1.2/E1.4 wire up real answers.
+    """
+    qs = load_query_set()
+    print(f"loaded query set: schema v{qs.schema_version}, {len(qs)} queries")
+    print(f"fixture: {qs.fixture}")
+
+    judge = OfflineJudge()
+    total_facts = 0
+    for q in qs.queries:
+        total_facts += len(q.expected_facts)
+        # A "perfect" answer that names every fact should score recall 1.0.
+        perfect = " ".join(f.fact for f in q.expected_facts)
+        r = judge.fact_recall(q, perfect)
+        status = "ok" if r.recall == 1.0 else "WARN"
+        print(f"  [{status}] {q.id}: {r.matched}/{r.total} facts on a perfect answer")
+        if r.recall != 1.0:
+            return 1
+
+    # An empty answer must score 0 everywhere.
+    empty_mean = judge.mean_recall((q, "") for q in qs.queries)
+    print(f"total expected facts: {total_facts}")
+    print(f"mean recall on empty answers: {empty_mean:.3f} (expected 0.000)")
+    return 0 if empty_mean == 0.0 else 1
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = sys.argv[1:] if argv is None else argv
+    if "--selfcheck" in argv:
+        return _selfcheck()
+
+    if _llm_judge_enabled():
+        # Honest, loud notice — answers + gold facts would leave the machine.
+        print(
+            f"[{LLM_JUDGE_ENV}=on] LLM-as-judge mode requested: answers and gold "
+            "facts would be sent to a third-party API (NOT local).",
+            file=sys.stderr,
+        )
+
+    # The full report (answer A/B + delta + per-query breakdown + --json)
+    # is E1.4. Until then, point the user at the selfcheck.
+    print("Faithfulness eval (E1.1 skeleton).")
+    print("Answer generation (E1.2) and the report (E1.4) are not implemented yet.")
+    print("Run with --selfcheck to validate the gold set + offline scorer.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/evals/faithfulness/runner.py
+++ b/evals/faithfulness/runner.py
@@ -96,9 +96,7 @@ def load_query_set(path: str | os.PathLike[str] | None = None) -> QuerySet:
 
     version = raw.get("schema_version")
     if version != SCHEMA_VERSION:
-        raise ValueError(
-            f"unsupported schema_version {version!r}; runner expects {SCHEMA_VERSION}"
-        )
+        raise ValueError(f"unsupported schema_version {version!r}; runner expects {SCHEMA_VERSION}")
 
     queries: list[Query] = []
     seen_ids: set[str] = set()

--- a/evals/faithfulness/runner.py
+++ b/evals/faithfulness/runner.py
@@ -98,32 +98,57 @@ def load_query_set(path: str | os.PathLike[str] | None = None) -> QuerySet:
     if version != SCHEMA_VERSION:
         raise ValueError(f"unsupported schema_version {version!r}; runner expects {SCHEMA_VERSION}")
 
+    fixture = raw.get("fixture")
+    if not isinstance(fixture, str) or not fixture.strip():
+        raise ValueError(
+            "query set is missing a non-empty 'fixture' (path to the gold-fact source)"
+        )
+
+    raw_queries = raw.get("queries")
+    if not isinstance(raw_queries, list):
+        raise ValueError("'queries' must be a list")
+
     queries: list[Query] = []
     seen_ids: set[str] = set()
-    for entry in raw.get("queries", []):
-        qid = entry["id"]
+    for i, entry in enumerate(raw_queries):
+        if not isinstance(entry, dict):
+            raise ValueError(f"queries[{i}] must be an object, got {type(entry).__name__}")
+
+        qid = entry.get("id")
+        if not isinstance(qid, str) or not qid.strip():
+            raise ValueError(f"queries[{i}] is missing a non-empty string 'id'")
         if qid in seen_ids:
             raise ValueError(f"duplicate query id: {qid!r}")
         seen_ids.add(qid)
 
+        question = entry.get("question")
+        if not isinstance(question, str) or not question.strip():
+            raise ValueError(f"query {qid!r} is missing a non-empty 'question'")
+
+        modules = entry.get("expected_modules")
+        if not isinstance(modules, list) or not modules:
+            raise ValueError(f"query {qid!r} needs a non-empty 'expected_modules' list")
+
         facts: list[ExpectedFact] = []
         for f in entry.get("expected_facts", []):
-            facts.append(
-                ExpectedFact(
-                    id=f["id"],
-                    fact=f["fact"],
-                    aliases=tuple(f.get("aliases", [])),
-                )
-            )
+            if not isinstance(f, dict):
+                raise ValueError(f"query {qid!r} has a non-object entry in 'expected_facts'")
+            fid = f.get("id")
+            ftext = f.get("fact")
+            if not isinstance(fid, str) or not fid.strip():
+                raise ValueError(f"query {qid!r} has an expected_fact missing a non-empty 'id'")
+            if not isinstance(ftext, str) or not ftext.strip():
+                raise ValueError(f"fact {fid!r} in query {qid!r} is missing non-empty 'fact' text")
+            facts.append(ExpectedFact(id=fid, fact=ftext, aliases=tuple(f.get("aliases", []))))
         if not facts:
             raise ValueError(f"query {qid!r} has no expected_facts")
 
         queries.append(
             Query(
                 id=qid,
-                question=entry["question"],
+                question=question,
                 expected_facts=tuple(facts),
-                expected_modules=tuple(entry.get("expected_modules", [])),
+                expected_modules=tuple(modules),
                 shape=entry.get("shape", ""),
             )
         )
@@ -133,7 +158,7 @@ def load_query_set(path: str | os.PathLike[str] | None = None) -> QuerySet:
 
     return QuerySet(
         schema_version=version,
-        fixture=raw.get("fixture", ""),
+        fixture=fixture,
         queries=queries,
     )
 
@@ -149,6 +174,20 @@ def _normalize(text: str) -> str:
     ``hmac compare digest`` or ``HMAC.compare_digest()``.
     """
     return " ".join(_WORD_RE.findall(text.lower()))
+
+
+def _phrase_in(answer_norm: str, needle_norm: str) -> bool:
+    """Whole-word/phrase containment over already-normalized token strings.
+
+    Both arguments are space-delimited normalized tokens. Padding with
+    spaces makes the check token-boundary aware so a short needle like
+    ``id`` or ``t`` can't match *inside* an unrelated word (``valid``,
+    ``not``) and silently inflate the CI-gating recall score. Multi-word
+    needles still match as a contiguous phrase.
+    """
+    if not needle_norm:
+        return False
+    return f" {needle_norm} " in f" {answer_norm} "
 
 
 @dataclass
@@ -182,10 +221,21 @@ class OfflineJudge:
     """
 
     def fact_matched(self, fact: ExpectedFact, answer_norm: str) -> FactResult:
-        """Does ``answer_norm`` (already normalized) express ``fact``?"""
+        """Does ``answer_norm`` (already normalized) express ``fact``?
+
+        Matching is token/phrase-boundary aware (see ``_phrase_in``) and
+        rejects needles that collapse to a single ultra-short token (e.g.
+        an alias like ``t=`` → ``t``), which are too noisy to trust as the
+        CI-gating recall signal.
+        """
         for surface in fact.surfaces():
             needle = _normalize(surface)
-            if needle and needle in answer_norm:
+            if not needle:
+                continue
+            tokens = needle.split()
+            if len(tokens) == 1 and len(tokens[0]) < 2:
+                continue
+            if _phrase_in(answer_norm, needle):
                 return FactResult(fact.id, matched=True, matched_on=surface)
         return FactResult(fact.id, matched=False)
 

--- a/evals/faithfulness/schema.md
+++ b/evals/faithfulness/schema.md
@@ -1,0 +1,73 @@
+# `queries.json` schema — faithfulness eval query + gold-fact set
+
+Versioned data contract for the faithfulness eval (issue
+[#172](https://github.com/dfrostar/neuralmind/issues/172), task **E1.1**).
+This file is the gold standard the offline judge scores answers against.
+
+## Top-level object
+
+| Field | Type | Required | Meaning |
+|---|---|---|---|
+| `schema_version` | int | yes | Bumped on any breaking change to this format. Currently `1`. |
+| `_comment` | string | no | Human note; ignored by the loader. |
+| `fixture` | string | yes | Repo-relative path to the code the gold facts are derived from (`tests/fixtures/sample_project`). |
+| `queries` | array | yes | The query set (see below). N ≥ 15. |
+
+## Query object
+
+| Field | Type | Required | Meaning |
+|---|---|---|---|
+| `id` | string | yes | Stable, unique slug. Used as the report key — **never renumber**; add new ids instead. |
+| `question` | string | yes | The natural-language query posed to the answerer. |
+| `shape` | string | no | Retrieval shape hint reused from `tests/fixtures/benchmark_queries.json`: `focused`, `cross-file`, or `identity`. |
+| `expected_modules` | string[] | yes | Repo-relative module paths a correct, grounded answer should cite. Feeds the citation/grounding-rate dimension (E1.3). |
+| `expected_facts` | object[] | yes | The rubric: key facts a correct answer must contain. Recall over these is the headline metric. |
+
+## Fact object (`expected_facts[]`)
+
+| Field | Type | Required | Meaning |
+|---|---|---|---|
+| `id` | string | yes | Stable, unique-within-query slug for the fact. Lets the per-fact breakdown be diffed across runs. |
+| `fact` | string | yes | Canonical natural-language statement of the fact. |
+| `aliases` | string[] | no | Synonyms / identifiers / code symbols that also count as expressing the fact. Keeps the offline heuristic judge from being brittle to exact wording. |
+
+### Authoring rules for facts
+
+- Facts must be **verifiable against the `fixture` code**, not against
+  general knowledge. Read the fixture before adding or editing a fact.
+- A fact is a single checkable claim ("the password hash is verified"),
+  not a paragraph. Prefer several small facts over one compound fact.
+- `aliases` should include the concrete code symbols (`verify_password`,
+  `JWT_SECRET`, `WEBHOOK_TOLERANCE_SEC`) a real answer would name, so a
+  grounded answer scores even if it paraphrases the prose.
+
+## Scoring dimensions (the judge contract, implemented across E1.1–E1.3)
+
+The query set is designed to be scored on three dimensions. E1.1 ships
+the data and the **expected-fact-recall** scorer; the other two are
+specified here and stubbed in `runner.py` for E1.3.
+
+1. **Expected-fact recall** *(E1.1, implemented).* Fraction of a query's
+   `expected_facts` that the answer expresses. The offline judge matches
+   a fact when the answer text contains the fact statement or any of its
+   `aliases` (case-insensitive, whitespace-normalised). This is the
+   headline, CI-gating number.
+2. **Citation / grounding rate** *(E1.3, stubbed).* Fraction of the
+   answer's claims that are attributable to one of `expected_modules`
+   (or, more strictly, to retrieved context). Measures whether the
+   answer is grounded in the codebase rather than the model's prior.
+3. **Contradiction check** *(E1.3, stubbed).* Detects statements that
+   conflict with the gold facts (e.g. claiming PostgreSQL when the
+   fixture uses SQLite, or RS256 when it is HS256). A negative signal:
+   an answer can have high recall yet still contradict the code.
+
+The faithfulness **delta** the release reports (E1.4) is the difference
+in these scores between an answer generated **with** NeuralMind context
+and a naive baseline **without** it.
+
+## Versioning policy
+
+- Additive changes (new query, new fact, new alias) do **not** bump
+  `schema_version`.
+- Renaming/removing a field, or changing a field's type/meaning, bumps
+  `schema_version` and requires updating `runner.py`'s loader + tests.

--- a/evals/faithfulness/schema.md
+++ b/evals/faithfulness/schema.md
@@ -20,7 +20,7 @@ This file is the gold standard the offline judge scores answers against.
 | `id` | string | yes | Stable, unique slug. Used as the report key — **never renumber**; add new ids instead. |
 | `question` | string | yes | The natural-language query posed to the answerer. |
 | `shape` | string | no | Retrieval shape hint reused from `tests/fixtures/benchmark_queries.json`: `focused`, `cross-file`, or `identity`. |
-| `expected_modules` | string[] | yes | Repo-relative module paths a correct, grounded answer should cite. Feeds the citation/grounding-rate dimension (E1.3). |
+| `expected_modules` | string[] | yes | Module paths a correct, grounded answer should cite, **relative to the `fixture` directory** (e.g. `auth/handlers.py`, i.e. `<fixture>/auth/handlers.py`) — matching how `tests/benchmark/run.py` extracts hits via `p.relative_to(FIXTURE_DIR)`. Feeds the citation/grounding-rate dimension (E1.3). |
 | `expected_facts` | object[] | yes | The rubric: key facts a correct answer must contain. Recall over these is the headline metric. |
 
 ## Fact object (`expected_facts[]`)

--- a/tests/test_eval_faithfulness.py
+++ b/tests/test_eval_faithfulness.py
@@ -59,6 +59,7 @@ class LoadQuerySetTests(unittest.TestCase):
 
     def test_unsupported_version_rejected(self) -> None:
         import json
+        import os
         import tempfile
 
         bad = {
@@ -76,8 +77,11 @@ class LoadQuerySetTests(unittest.TestCase):
         with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False, encoding="utf-8") as fh:
             json.dump(bad, fh)
             path = fh.name
-        with self.assertRaises(ValueError):
-            load_query_set(path)
+        try:
+            with self.assertRaises(ValueError):
+                load_query_set(path)
+        finally:
+            os.unlink(path)
 
 
 class OfflineRecallTests(unittest.TestCase):
@@ -131,6 +135,28 @@ class OfflineRecallTests(unittest.TestCase):
         half = "the fixture uses SQLite"
         mean = self.judge.mean_recall([(self.query, full), (self.query, half)])
         self.assertAlmostEqual(mean, 0.75)
+
+    def test_short_alias_does_not_match_inside_words(self) -> None:
+        # A two-letter alias must not match *inside* an unrelated word
+        # (e.g. "id" inside "valid") — that would inflate the CI-gate recall.
+        q = Query(
+            id="boundary",
+            question="?",
+            expected_facts=(ExpectedFact("f-id", "the record has an id column", ("id",)),),
+        )
+        self.assertEqual(self.judge.fact_recall(q, "the token is valid and invalid").matched, 0)
+        # but it still matches as a standalone token.
+        self.assertEqual(self.judge.fact_recall(q, "the record id is a primary key").matched, 1)
+
+    def test_ultra_short_alias_is_ignored(self) -> None:
+        # A single-character needle (e.g. an alias like "t=" → "t") is too
+        # noisy to be a reliable match and is skipped entirely.
+        q = Query(
+            id="tiny",
+            question="?",
+            expected_facts=(ExpectedFact("f-t", "the header carries a t field", ("t=",)),),
+        )
+        self.assertEqual(self.judge.fact_recall(q, "there is a t value here").matched, 0)
 
     def test_e1_3_methods_are_stubbed(self) -> None:
         with self.assertRaises(NotImplementedError):

--- a/tests/test_eval_faithfulness.py
+++ b/tests/test_eval_faithfulness.py
@@ -1,0 +1,159 @@
+"""Stdlib-only tests for the faithfulness eval foundation (issue #172, E1.1).
+
+These deliberately use ``unittest`` (no pytest) and import nothing heavy, so
+they run in a minimal environment that has neither pytest nor chromadb:
+
+    python tests/test_eval_faithfulness.py
+
+Covers: queries.json loading/validation and the offline expected-fact-recall
+scorer. Answer generation (E1.2) and the full judge (E1.3) are not tested
+here because they are not implemented yet.
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+# Make ``evals`` importable without installing the package.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from evals.faithfulness.runner import (  # noqa: E402
+    SCHEMA_VERSION,
+    ExpectedFact,
+    OfflineJudge,
+    Query,
+    load_query_set,
+)
+
+
+class LoadQuerySetTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.qs = load_query_set()
+
+    def test_schema_version_matches(self) -> None:
+        self.assertEqual(self.qs.schema_version, SCHEMA_VERSION)
+
+    def test_at_least_fifteen_queries(self) -> None:
+        self.assertGreaterEqual(len(self.qs), 15)
+
+    def test_query_ids_unique(self) -> None:
+        ids = [q.id for q in self.qs.queries]
+        self.assertEqual(len(ids), len(set(ids)))
+
+    def test_every_query_has_facts_and_modules(self) -> None:
+        for q in self.qs.queries:
+            with self.subTest(query=q.id):
+                self.assertTrue(q.expected_facts, "needs >=1 expected fact")
+                self.assertTrue(q.expected_modules, "needs >=1 expected module")
+                self.assertTrue(q.question.strip(), "needs a question")
+
+    def test_fact_ids_unique_within_query(self) -> None:
+        for q in self.qs.queries:
+            fact_ids = [f.id for f in q.expected_facts]
+            with self.subTest(query=q.id):
+                self.assertEqual(len(fact_ids), len(set(fact_ids)))
+
+    def test_unsupported_version_rejected(self) -> None:
+        import json
+        import tempfile
+
+        bad = {
+            "schema_version": 999,
+            "fixture": "x",
+            "queries": [
+                {
+                    "id": "q",
+                    "question": "?",
+                    "expected_modules": ["m"],
+                    "expected_facts": [{"id": "f", "fact": "x"}],
+                }
+            ],
+        }
+        with tempfile.NamedTemporaryFile(
+            "w", suffix=".json", delete=False, encoding="utf-8"
+        ) as fh:
+            json.dump(bad, fh)
+            path = fh.name
+        with self.assertRaises(ValueError):
+            load_query_set(path)
+
+
+class OfflineRecallTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.judge = OfflineJudge()
+        self.query = Query(
+            id="demo",
+            question="how does X work?",
+            expected_facts=(
+                ExpectedFact("f-sqlite", "the fixture uses SQLite", ("sqlite3",)),
+                ExpectedFact("f-hash", "the password hash is verified", ("verify_password",)),
+            ),
+        )
+
+    def test_perfect_answer_scores_full_recall(self) -> None:
+        answer = "The fixture uses SQLite and the password hash is verified."
+        result = self.judge.fact_recall(self.query, answer)
+        self.assertEqual(result.matched, 2)
+        self.assertEqual(result.total, 2)
+        self.assertEqual(result.recall, 1.0)
+
+    def test_empty_answer_scores_zero(self) -> None:
+        result = self.judge.fact_recall(self.query, "")
+        self.assertEqual(result.matched, 0)
+        self.assertEqual(result.recall, 0.0)
+
+    def test_alias_matches_when_canonical_absent(self) -> None:
+        # Names the code symbols, never the prose.
+        answer = "It calls sqlite3.connect and verify_password()."
+        result = self.judge.fact_recall(self.query, answer)
+        self.assertEqual(result.matched, 2)
+        self.assertEqual(result.recall, 1.0)
+
+    def test_partial_recall(self) -> None:
+        # Matches the SQLite fact (alias "sqlite3") but says nothing about the
+        # password hash, so recall is 1/2.
+        answer = "It stores data via sqlite3."
+        result = self.judge.fact_recall(self.query, answer)
+        self.assertEqual(result.matched, 1)
+        self.assertEqual(result.recall, 0.5)
+
+    def test_matching_ignores_case_and_punctuation(self) -> None:
+        # The alias "verify_password" must still match "VERIFY-PASSWORD"
+        # because normalisation lowercases and collapses punctuation.
+        answer = "the password hash is VERIFY-PASSWORD checked"
+        result = self.judge.fact_recall(self.query, answer)
+        self.assertTrue(any(f.fact_id == "f-hash" and f.matched for f in result.facts))
+
+    def test_mean_recall_averages_per_query(self) -> None:
+        full = "the fixture uses SQLite; the password hash is verified"
+        half = "the fixture uses SQLite"
+        mean = self.judge.mean_recall([(self.query, full), (self.query, half)])
+        self.assertAlmostEqual(mean, 0.75)
+
+    def test_e1_3_methods_are_stubbed(self) -> None:
+        with self.assertRaises(NotImplementedError):
+            self.judge.grounding_rate(self.query, "x")
+        with self.assertRaises(NotImplementedError):
+            self.judge.contradiction_score(self.query, "x")
+
+
+class GoldSetSanityTests(unittest.TestCase):
+    """A 'perfect' answer naming every fact should always score recall 1.0;
+    this guards against an alias/canonical typo silently breaking a fact."""
+
+    def test_perfect_answer_scores_full_on_real_gold_set(self) -> None:
+        qs = load_query_set()
+        judge = OfflineJudge()
+        for q in qs.queries:
+            perfect = " ".join(f.fact for f in q.expected_facts)
+            result = judge.fact_recall(q, perfect)
+            with self.subTest(query=q.id):
+                self.assertEqual(result.recall, 1.0)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_eval_faithfulness.py
+++ b/tests/test_eval_faithfulness.py
@@ -73,9 +73,7 @@ class LoadQuerySetTests(unittest.TestCase):
                 }
             ],
         }
-        with tempfile.NamedTemporaryFile(
-            "w", suffix=".json", delete=False, encoding="utf-8"
-        ) as fh:
+        with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False, encoding="utf-8") as fh:
             json.dump(bad, fh)
             path = fh.name
         with self.assertRaises(ValueError):


### PR DESCRIPTION
## What this is

The **first increment (E1.1)** of the v0.13 "Measure" faithfulness eval harness. Refs #172, plan `docs/NEXT-RELEASE-PLAN.md` §3 Epic E1.

This is **the foundation only** — the query + gold-fact data, the format/scoring spec, and a pure-Python runner skeleton with the offline expected-fact-recall scorer. It deliberately does **not** implement answer generation, the full judge, the report, or the onboarding-lift eval. Those are the follow-on tasks listed below.

## What it adds (`evals/faithfulness/`)

- **`queries.json`** — versioned set of **18 queries / 52 expected facts** derived directly from the code in `tests/fixtures/sample_project/` (auth/login, JWT HS256 + signature verify, session/refresh TTLs, logout revocation, API routes + `@route` decorator, bearer-token protected endpoints, user create/storage/soft-delete, SQLite + lazy schema, billing charge flow, refund double-guard, Stripe webhook verify + dispatch, invoice send/list). Each query carries **rubric-style `expected_facts`** (key facts a correct answer must contain) with code-symbol `aliases`, not just gold module names. Reuses query themes from `tests/fixtures/benchmark_queries.json` and adds the expected-fact dimension.
- **`schema.md`** — the `queries.json` format contract + the three scoring dimensions (expected-fact recall, citation/grounding rate, contradiction check).
- **`README.md`** — harness design: the **offline heuristic judge is the DEFAULT and the CI gating signal (zero network)**; an opt-in LLM-as-judge sits behind `NEURALMIND_EVAL_LLM_JUDGE`, clearly labelled as leaving the machine and never the default/gate. References #172 and lists E1.2–E1.5 as follow-on.
- **`runner.py`** — pure-stdlib skeleton (no chromadb/graphify/neuralmind imports at module load). Loads + validates the query set and implements `OfflineJudge.fact_recall` (the offline expected-fact-recall scorer). The answerer and the API judge are clearly-marked `TODO` for E1.2/E1.3.
- **`tests/test_eval_faithfulness.py`** — stdlib-only `unittest` (no pytest) so CI has something runnable in a minimal env.

## Verified ✅ (local, this environment)

- `python -m py_compile` clean on `runner.py` + the test.
- `queries.json` parses as valid JSON.
- `python evals/faithfulness/runner.py --selfcheck` green: 18 queries / 52 facts; a perfect answer scores recall 1.0 for every query; empty answers score 0.0.
- `python tests/test_eval_faithfulness.py` → **14/14 pass**.
- Default `main` prints the E1.1 status; `NEURALMIND_EVAL_LLM_JUDGE=1` prints the loud "would leave the machine" notice on stderr.

## NOT verified ⚠️ (out of scope / not possible here)

- No chromadb / graphify / pytest in this environment, so nothing touching the real retrieval pipeline or the project's pytest suite was run. By design `runner.py` imports none of those at load time.
- No answer generation, real grounding/contradiction scoring, report, or onboarding-lift — those are **E1.2–E1.5**, intentionally left as TODOs.
- Docs/SEO surfaces (README banner, `docs/*`, CLI reference, etc.) are **not** touched. There is no user-facing `neuralmind eval` command yet (that arrives with E1.4), so the CLAUDE.md docs+SEO checklist applies to the release that ships the command, not this foundation PR.

## Follow-on tasks (issue #172)

- E1.2 — A/B answer generation (with NeuralMind context vs naive baseline), pluggable deterministic answerer.
- E1.3 — full judges: offline (recall + grounding + contradiction) as default/gate; opt-in LLM-as-judge.
- E1.4 — `neuralmind eval` report (faithfulness delta, grounding rate, per-query breakdown, `--json`).
- E1.5 — onboarding-lift eval (gates shared-memory build #175).

Draft on purpose — E1.1 increment only; not for merge as-is.

Refs #172

https://claude.ai/code/session_016MZU3vW4yd4SJeA293foF3

---
_Generated by [Claude Code](https://claude.ai/code/session_016MZU3vW4yd4SJeA293foF3)_