### PR TITLE
docs: v0.13.0 launch pass — release notes, banners, SEO, wiki, sitemap

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@
 
 > Works with Claude Code, Cursor, Cline, Continue, and any MCP-compatible agent. 100% local — your code never leaves your machine. (Side effect: ~5–10× cheaper agent sessions because the agent stops re-loading context it already understood. [Benchmarks below ↓](#-benchmarks).)
 
-> **🆕 New in v0.12.0** — **Install Doctor.** One command — `neuralmind doctor` — inspects your setup (code graph, semantic index, synapse memory, MCP server, Claude Code hooks, query-memory consent) and prints each piece with a status and the exact command to fix it. Exits non-zero on a real failure so you can gate CI or an agent's setup step on it; `--json` gives a stable machine-readable snapshot. Querying before the graph exists now raises a clear setup hint instead of a stack trace. [Release notes](RELEASE_NOTES_v0.12.0.md)
+> **🆕 New in v0.13.0** — **Measurement foundation.** A foundation release that builds the scaffolding to *prove* the memory helps, not just claim it: a 100%-local **faithfulness eval** (a versioned query + gold-fact dataset and an offline expected-fact-recall scorer) plus **polyglot retrieval fixtures (TypeScript + Go)** so quality can be measured beyond Python — and a written **documentation process** so the docs stop drifting. No runtime change to your install; this is the fitness function the eval-first roadmap (v0.13→v0.16) builds on. [Release notes](RELEASE_NOTES_v0.13.0.md)
+>
+> **v0.12.0** — **Install Doctor.** One command — `neuralmind doctor` — inspects your setup (code graph, semantic index, synapse memory, MCP server, Claude Code hooks, query-memory consent) and prints each piece with a status and the exact command to fix it. Exits non-zero on a real failure so you can gate CI or an agent's setup step on it; `--json` gives a stable machine-readable snapshot. [Release notes](RELEASE_NOTES_v0.12.0.md)
 >
 > **v0.11.0** — **Directional Synapses.** The brain-like layer now learns *what comes next*, not just *what goes together*. A new `synapse_transitions` table records ordered `(from_node, to_node)` observations every time the watcher flushes a batch, so the agent can ask `neuralmind next <file>` (or call the `neuralmind_next_likely` MCP tool) and get a probability distribution over what's typically edited after that file. Additive — the existing undirected synapse graph keeps doing its job. [Release notes](RELEASE_NOTES_v0.11.0.md)
 >
@@ -1726,6 +1728,7 @@ Only if you install the git post-commit hook with `neuralmind init-hook .`. Othe
 | **[Future-Proofing Plan](docs/FUTURE-PROOFING-PLAN.md)** | 8-initiative engineering plan for sustainability and scale |
 | **[Brain-like Learning](docs/brain_like_learning.md)** | Design rationale for the learning system |
 | **[Use Cases](docs/use-cases/README.md)** | Step-by-step walkthroughs: Claude Code, cost optimization, any-LLM, offline/regulated, growing monorepo, multi-agent (new in v0.6.0) |
+| **[Release Notes v0.13.0](RELEASE_NOTES_v0.13.0.md)** | Measurement foundation — offline faithfulness eval (query + gold-fact dataset, expected-fact-recall scorer), polyglot retrieval fixtures (TypeScript + Go), and a standard documentation process |
 | **[Release Notes v0.12.0](RELEASE_NOTES_v0.12.0.md)** | Install Doctor — `neuralmind doctor` health checks (graph, index, synapses, MCP, hooks, memory), `--json` output, friendlier "graph not built" error |
 | **[Release Notes v0.11.0](RELEASE_NOTES_v0.11.0.md)** | Directional Synapses — `synapse_transitions` table, `next_likely()` API, `neuralmind next` CLI, `neuralmind_next_likely` MCP tool |
 | **[Release Notes v0.10.0](RELEASE_NOTES_v0.10.0.md)** | Agent Ergonomics — content-aware compression footer, `neuralmind last` recovery cache, small-failure passthrough |

--- a/RELEASE_NOTES_v0.13.0.md
+++ b/RELEASE_NOTES_v0.13.0.md
@@ -1,0 +1,147 @@
+# NeuralMind v0.13.0 — measurement foundation: faithfulness eval + polyglot fixtures + a docs process
+
+**Release Date:** June 2026
+
+## TL;DR
+
+v0.13.0 is a **foundation release**, not a new command. It doesn't change
+what your install does at runtime — it builds the scaffolding to *measure*
+whether NeuralMind's memory actually makes an agent's answers **better**
+(not just shorter), and to measure retrieval quality **beyond Python**.
+Plus a documentation process so the docs stop drifting.
+
+Three things land:
+
+- **Faithfulness eval foundation (offline, 100% local).** A versioned
+  query + gold-fact dataset and a pure-stdlib *expected-fact-recall*
+  scorer — the zero-network signal future CI gates will run on. This is
+  the dataset + scorer skeleton, **not** the full answer-generation /
+  report pipeline (those are the next increments).
+- **Polyglot retrieval-quality fixtures (TypeScript + Go).** Self-contained
+  sample projects that mirror the existing Python fixture domain-for-domain,
+  with per-language gold-module query sets — so retrieval hit-rate can be
+  measured per language instead of Python-only.
+- **A standard documentation process.** A written `DOCUMENTATION-PROCESS.md`,
+  a PR-template checklist, and a CONTRIBUTING link, so every user-facing
+  change ships its docs in the same PR and the landing-page version stops
+  going stale.
+
+**No migration, no new dependencies, no behavior change for existing
+installs.** If you just use NeuralMind, upgrading changes nothing you'll
+notice today. The point of this release is the credibility it buys the
+*next* ones: quality claims backed by numbers, in the open.
+
+---
+
+## What the agent actually sees, post-install
+
+**Honestly: nothing new at runtime.** There is no new `neuralmind` command,
+no new hook, and no change to how the synapse layer, graph view, or MCP
+tools behave. The eval harness is developer- and CI-facing — it lives under
+`evals/` and `tests/fixtures/`, and nothing imports it on the hot path.
+
+The one new toggle, `NEURALMIND_EVAL_LLM_JUDGE`, only affects the eval
+runner (a developer tool), is **opt-in**, is **never** the default or the
+CI gate, and prints a loud notice that turning it on would send text to a
+third-party API. The default judge is the offline heuristic — zero network.
+
+### Per-agent expectations
+
+| Agent | What changes in v0.13.0 |
+|-------|--------------------------|
+| **Claude Code** | Nothing at runtime. Hooks, `SYNAPSE_MEMORY.md`, and predictions behave exactly as in v0.12.0. |
+| **Cursor / Cline** | Nothing at runtime. Same MCP tools, same retrieval. |
+| **Generic MCP client** | Nothing at runtime. The eval harness is not exposed as an MCP tool. |
+| **Contributors / CI** | A runnable, dependency-light offline eval skeleton (`python evals/faithfulness/runner.py --selfcheck`) and TS/Go retrieval fixtures to measure against. |
+
+---
+
+## What ships
+
+### 1. Faithfulness eval foundation (Epic E1.1)
+
+Under `evals/faithfulness/`:
+
+- **`queries.json`** — a versioned set of **18 queries / 52 expected
+  facts** derived directly from the bundled sample project (auth/login,
+  JWT HS256 + signature verify, session/refresh TTLs, logout revocation,
+  API routes, user storage + soft-delete, SQLite, billing charge/refund,
+  Stripe webhook verify + dispatch, invoices). Each query carries
+  rubric-style *expected facts* with code-symbol aliases — not just gold
+  module names.
+- **`runner.py`** — a pure-stdlib loader + the offline
+  expected-fact-recall scorer (`OfflineJudge.fact_recall`). It imports no
+  chromadb / graphify / neuralmind at load time, so it runs in a minimal
+  environment. Alias matching is token/phrase-boundary aware so the recall
+  number can't be inflated by short substrings matching inside unrelated
+  words — important, because this is the signal CI will gate on.
+- **`schema.md`** — the data contract and the three intended scoring
+  dimensions (expected-fact recall, citation/grounding rate, contradiction
+  check).
+- **`NEURALMIND_EVAL_LLM_JUDGE`** — opt-in only, documented as leaving the
+  machine, never the default or the gate.
+
+**Deliberately not in this release:** answer generation (with-NeuralMind vs
+baseline), the grounding/contradiction scorers, the LLM-as-judge wiring,
+and the `neuralmind eval` report. Those are the E1.2–E1.4 increments.
+
+### 2. Polyglot retrieval-quality fixtures (Epics E2.2 / E2.3)
+
+Under `tests/fixtures/`:
+
+- **`sample_project_ts/`** (TypeScript) and **`sample_project_go/`** (Go) —
+  small apps mirroring the Python fixture domain-for-domain.
+- **`benchmark_queries_ts.json` / `benchmark_queries_go.json`** — per-language
+  gold-module query sets mirroring the Python set's ids, questions, shapes,
+  and learning seed, so per-language hit-rate compares like with like.
+- **`_gen_graph.py`** — a generator that emits a `graph.json` in graphify's
+  schema, deriving every symbol's line number — and every `calls`/`imports`
+  edge location — from the real source, so the fixtures stay faithful.
+- **`test_polyglot_fixtures.py`** — stdlib-only structural tests that keep
+  the graphs, sources, and query sets mutually consistent.
+
+### 3. A standard documentation process (PR #176)
+
+- **`docs/DOCUMENTATION-PROCESS.md`** — the operational standard: docs ship
+  in the same PR as the change, every doc answers *"what does the user/agent
+  now see?"*, the five surfaces, the SEO + discoverability rules, and a
+  three-loop cadence (per-PR → per-release → quarterly) that catches stale
+  "Current/Next" version drift.
+- **`.github/PULL_REQUEST_TEMPLATE.md`** — a "Documentation & discoverability"
+  checklist section (with an N/A escape for internal refactors).
+- **`CONTRIBUTING.md`** — links the process from the Documentation section.
+
+---
+
+## Why this matters
+
+NeuralMind's headline claims — *cheaper, and the memory makes answers
+better* — deserve to be **measured, not asserted**. v0.13.0 is the first
+brick: an honest, offline, reproducible way to score answer faithfulness,
+and fixtures that extend quality coverage past Python. None of it is
+marketing surface; all of it is the fitness function the rest of the
+eval-first roadmap (v0.13 → v0.16) builds on.
+
+---
+
+## What's next
+
+- **E1.2** — A/B answer generation (with NeuralMind context vs a naive baseline).
+- **E1.3** — the full offline judge (recall + grounding + contradiction); opt-in LLM-as-judge.
+- **E1.4** — `neuralmind eval` report: faithfulness delta, grounding rate, per-query breakdown, `--json`.
+- **E2.4** — the per-language retrieval hit-rate report built on the new TS/Go fixtures.
+
+---
+
+## Upgrade
+
+```bash
+pip install --upgrade neuralmind
+```
+
+Nothing else to do — no migration, no config changes. Contributors can
+sanity-check the new eval skeleton with:
+
+```bash
+python evals/faithfulness/runner.py --selfcheck
+```

--- a/docs/about.html
+++ b/docs/about.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="About NeuralMind: Open-source semantic code intelligence with a brain-like synapse layer that learns associations between code from how you actually use it — both undirected co-activation and directional next-file transitions — plus an Obsidian-style graph view that makes the index inspectable, and PostToolUse hooks that compress tool output and recover dropped content without re-running. 100% local, NIST AI RMF compliant, enterprise-ready.">
-    <meta name="keywords" content="NeuralMind, semantic code search, AI agents, token optimization, local-first, open-source, NIST AI RMF, brain-like learning, hebbian learning, synapse layer, directional transitions, transition matrix, next-file prediction, claude code memory, graph view, neuralmind serve, Obsidian-style code graph, force-directed graph, MCP server, code visualization, tool output recovery, bash output cache, agent ergonomics, claude code hooks, install doctor, health check, agent onboarding">
+    <meta name="description" content="About NeuralMind: Open-source semantic code intelligence with a brain-like synapse layer that learns associations between code from how you actually use it — both undirected co-activation and directional next-file transitions — plus an Obsidian-style graph view that makes the index inspectable, and PostToolUse hooks that compress tool output and recover dropped content without re-running. Now building a 100%-local faithfulness-evaluation harness and polyglot (TypeScript + Go) retrieval fixtures. 100% local, NIST AI RMF compliant, enterprise-ready.">
+    <meta name="keywords" content="NeuralMind, semantic code search, AI agents, token optimization, local-first, open-source, NIST AI RMF, brain-like learning, hebbian learning, synapse layer, directional transitions, transition matrix, next-file prediction, claude code memory, graph view, neuralmind serve, Obsidian-style code graph, force-directed graph, MCP server, code visualization, tool output recovery, bash output cache, agent ergonomics, claude code hooks, install doctor, health check, agent onboarding, faithfulness eval, retrieval quality evaluation, offline llm eval, polyglot code fixtures, typescript code graph, go code graph">
     <title>About NeuralMind - Semantic Code Intelligence with Brain-like Memory</title>
     <script type="application/ld+json">
     {
@@ -19,7 +19,7 @@
         "@type": "SoftwareApplication",
         "name": "NeuralMind",
         "applicationCategory": "DeveloperApplication",
-        "softwareVersion": "0.12.0"
+        "softwareVersion": "0.13.0"
       }
     }
     </script>
@@ -65,10 +65,10 @@
     <section>
         <div class="container" id="whats-next">
             <h2>Where NeuralMind is going next — the eval-first roadmap</h2>
-            <p><strong>A staged plan, not yet shipped.</strong> After the v0.10→v0.12 ergonomics + diagnostics work, the next arc is about proving and future-proofing the core. The spine is simple: <em>measure, then change, then measure again.</em></p>
+            <p><strong>A staged plan — the first increment (v0.13.0) has shipped.</strong> After the v0.10→v0.12 ergonomics + diagnostics work, the current arc is about proving and future-proofing the core. The spine is simple: <em>measure, then change, then measure again.</em></p>
             <h3>The arc (v0.13 → v0.16)</h3>
             <ul>
-                <li><strong>v0.13 — Measure.</strong> A CI-gated evaluation harness that answers the question we've been honest about not yet measuring: does the memory make the agent's answers <em>better</em>, not just shorter? Faithfulness + retrieval-quality scoring, with a 100%-local offline judge by default (an LLM-as-judge mode is strictly opt-in). Polyglot TypeScript + Go fixtures so quality claims stop being Python-only.</li>
+                <li><strong>v0.13 — Measure <em>(foundation shipped in v0.13.0)</em>.</strong> A CI-gated evaluation harness that answers the question we've been honest about not yet measuring: does the memory make the agent's answers <em>better</em>, not just shorter? The foundation is now in <code>main</code> — a versioned query + gold-fact dataset, a 100%-local offline expected-fact-recall scorer, and polyglot TypeScript + Go fixtures so quality claims stop being Python-only. A/B answer generation, the full judge (recall + grounding + contradiction), and the <code>neuralmind eval</code> report are the remaining increments; the LLM-as-judge mode stays strictly opt-in.</li>
                 <li><strong>v0.14 — Decouple.</strong> A graph-source adapter so tree-sitter / LSP / SCIP can feed the pipeline, proven at parity by the v0.13 harness — reducing the single dependency on one graph backend and widening language coverage.</li>
                 <li><strong>v0.15 — Endure.</strong> A host-capabilities adapter plus integration-contract tests that pin NeuralMind against the behaviour it relies on (Claude Code hooks, the MCP spec), so an upstream change is a one-adapter swap, not a rewrite.</li>
                 <li><strong>v0.16 — Anticipate.</strong> Promote directional "what you edit next" recall to a first-class agent surface, and ship a portable memory format so one learned map serves Claude Code, Cursor, Cline, and Continue.</li>
@@ -76,6 +76,22 @@
             <h3>A decision we've made for the team story</h3>
             <p>Committable, opt-in <strong>team/shared memory</strong> is approved in principle: a reviewed team baseline that travels in your git repo (no SaaS, no exfiltration), overlaid by each developer's private personal layer. Its day-one onboarding lift will be <em>measured</em> by the v0.13 harness before the design is locked — we sign off on data, not assertion.</p>
             <p><a href="https://github.com/dfrostar/neuralmind/blob/main/docs/NEXT-RELEASE-PLAN.md">Read the full next-release plan &amp; feature map →</a> · <a href="https://github.com/dfrostar/neuralmind/blob/main/ROADMAP.md">Roadmap →</a></p>
+        </div>
+    </section>
+
+    <section>
+        <div class="container" id="whats-new-v0130">
+            <h2>What's New in v0.13.0 — measurement foundation</h2>
+            <p><strong>A foundation release: the scaffolding to <em>prove</em> the memory helps, not just claim it.</strong> v0.13.0 doesn't change what your install does at runtime — it builds the machinery to measure whether NeuralMind makes an agent's answers <em>better</em> (faithfulness), and to measure retrieval quality beyond Python. Plus a documentation process so the docs stop drifting.</p>
+            <h3>What ships</h3>
+            <ul>
+                <li><strong>Faithfulness eval (offline, 100% local).</strong> A versioned query + gold-fact dataset (18 queries / 52 expected facts derived from the bundled sample project) and a pure-stdlib <em>expected-fact-recall</em> scorer — the zero-network signal future CI gates run on. This ships the dataset + scorer skeleton; A/B answer generation and the report pipeline are the next increments. The opt-in <code>NEURALMIND_EVAL_LLM_JUDGE</code> mode is clearly labelled as leaving the machine and is never the default or the gate.</li>
+                <li><strong>Polyglot retrieval fixtures (TypeScript + Go).</strong> Self-contained sample projects mirroring the Python fixture domain-for-domain, with per-language gold-module query sets — so retrieval hit-rate can be measured per language instead of Python-only.</li>
+                <li><strong>A standard documentation process.</strong> A written <code>DOCUMENTATION-PROCESS.md</code>, a PR-template checklist, and a CONTRIBUTING link, so every user-facing change ships its docs in the same PR and the landing-page version stops going stale.</li>
+            </ul>
+            <h3>Why this matters</h3>
+            <p>NeuralMind's headline claims — cheaper, and the memory makes answers better — deserve to be <em>measured, not asserted</em>. v0.13.0 is the first brick: an honest, offline, reproducible way to score answer faithfulness, and fixtures that extend quality coverage past Python. Nothing here is a runtime feature; all of it is the fitness function the rest of the eval-first roadmap builds on. No migration, no new dependencies, no behavior change for existing installs.</p>
+            <p><a href="https://github.com/dfrostar/neuralmind/blob/main/RELEASE_NOTES_v0.13.0.md">Full v0.13.0 release notes →</a></p>
         </div>
     </section>
 
@@ -316,17 +332,17 @@
     <section>
         <div class="container">
             <h2>Status & Roadmap</h2>
-            <h3>Current Release: v0.6.0 — Live Activity Feed</h3>
-            <p>Builds on v0.5.4's graph view. <code>neuralmind serve</code> now streams synapse + file events to the canvas in real time over SSE — affected nodes pulse, a sidebar log shows the most recent ~80 events. A cross-process JSONL bridge means a separate <code>neuralmind watch</code> daemon, or a hook-driven Claude Code session, feeds the same live feed via <code>&lt;project&gt;/.neuralmind/events.jsonl</code>. Pin UX, Cmd/Ctrl-K quick-switch, a 1–3-hop depth slider, replay-last-query overlay, edge tooltips, and a min-weight synapse slider round out the release. No migration — same index, same <code>synapses.db</code>, same hooks. See the <a href="https://github.com/dfrostar/neuralmind/blob/main/RELEASE_NOTES_v0.6.0.md">v0.6.0 release notes</a>.</p>
+            <h3>Current Release: v0.13.0 — Measurement foundation</h3>
+            <p>The latest release lays the measurement foundation: a 100%-local <strong>faithfulness eval</strong> (a versioned query + gold-fact dataset and an offline expected-fact-recall scorer) and <strong>polyglot TypeScript + Go retrieval fixtures</strong> so quality is measured beyond Python, plus a standard documentation process. No runtime change — same index, same <code>synapses.db</code>, same hooks. See the <a href="https://github.com/dfrostar/neuralmind/blob/main/RELEASE_NOTES_v0.13.0.md">v0.13.0 release notes</a> or the <a href="#whats-new-v0130">summary above</a>.</p>
 
             <h3>Future Releases</h3>
             <ul>
-                <li><strong>v0.7 (next)</strong> — Saved named graph views (Obsidian-style filter/zoom/depth combos, localStorage-backed), right-click context menu on nodes, PNG/SVG canvas export, time-based edge filter (complements v0.6.0's min-weight slider), and unifying the <code>neuralmind watch</code> daemon with the in-process bus so a single-process serve+watch stays unified without the JSONL bridge.</li>
-                <li><strong>Later</strong> — Synapse import/export so teams can share a learned brain (<a href="https://github.com/dfrostar/neuralmind/issues/79">#79</a>); benchmarks measuring retrieval quality with vs without synapses (<a href="https://github.com/dfrostar/neuralmind/issues/80">#80</a>); PostgreSQL pgvector scale testing; expanded backend ecosystem.</li>
+                <li><strong>Next — finish the eval harness</strong> — A/B answer generation (with NeuralMind context vs a naive baseline), the full offline judge (recall + grounding + contradiction), and a <code>neuralmind eval</code> report (faithfulness delta, grounding rate, per-query breakdown). Built straight on the v0.13.0 foundation.</li>
+                <li><strong>v0.14 → v0.16</strong> — Decouple the graph backend (tree-sitter / LSP / SCIP adapters), harden against host/API drift, then promote directional "what you edit next" recall and a portable cross-agent memory format — including opt-in, git-committed team memory. See the <a href="#whats-next">eval-first roadmap above</a>.</li>
                 <li><strong>v1.0.0 (Target Q1 2027)</strong> — Stable API guarantee, 2-year LTS support, commercial support options.</li>
             </ul>
 
-            <p><a href="../docs/FUTURE-PROOFING-PLAN.md">See the full roadmap →</a></p>
+            <p><a href="https://github.com/dfrostar/neuralmind/blob/main/docs/NEXT-RELEASE-PLAN.md">See the next-release plan →</a> · <a href="https://github.com/dfrostar/neuralmind/blob/main/ROADMAP.md">Roadmap →</a></p>
         </div>
     </section>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="NeuralMind: Semantic code intelligence for AI agents. Reduce token costs 40–70× with local code indexing, a brain-like synapse layer that learns from co-activation and directional file-to-file transitions, an Obsidian-style graph view, and PostToolUse hooks that compress tool output and let agents recover dropped middle content without re-running. NIST AI RMF compliant.">
-    <meta name="keywords" content="semantic code search, AI coding agents, token optimization, code intelligence, local-first, NIST AI RMF, Claude, Cursor, MCP server, graph view, neuralmind serve, Obsidian-style code graph, force-directed graph, synapse layer, Hebbian learning, directional transitions, transition matrix, next-file prediction, code visualization, tool output recovery, bash output cache, agent ergonomics, claude code hooks, install doctor, health check, agent onboarding">
+    <meta name="description" content="NeuralMind: Semantic code intelligence for AI agents. Reduce token costs 40–70× with local code indexing, a brain-like synapse layer that learns from co-activation and directional file-to-file transitions, an Obsidian-style graph view, and PostToolUse hooks that compress tool output and let agents recover dropped middle content without re-running. Now with a 100%-local faithfulness-evaluation harness and polyglot (TypeScript + Go) retrieval fixtures. NIST AI RMF compliant.">
+    <meta name="keywords" content="semantic code search, AI coding agents, token optimization, code intelligence, local-first, NIST AI RMF, Claude, Cursor, MCP server, graph view, neuralmind serve, Obsidian-style code graph, force-directed graph, synapse layer, Hebbian learning, directional transitions, transition matrix, next-file prediction, code visualization, tool output recovery, bash output cache, agent ergonomics, claude code hooks, install doctor, health check, agent onboarding, faithfulness eval, retrieval quality evaluation, offline llm eval, polyglot code fixtures, typescript code graph, go code graph">
     <title>NeuralMind - Semantic Code Intelligence for AI Agents | 40–70× Token Reduction</title>
     <meta property="og:title" content="NeuralMind - Semantic Code Intelligence for AI Agents">
     <meta property="og:description" content="Local-first code indexing with 40–70× per-query token reduction (50K → ~800 tokens). Zero data exfiltration, 100% offline, enterprise-ready.">
@@ -18,7 +18,7 @@
       "description": "Persistent memory and semantic code intelligence for AI coding agents. Local-first code indexing with 40–70× per-query token reduction, a brain-like synapse layer that learns associations from how you use the codebase, an Obsidian-style graph view, an MCP server, and a built-in install doctor. Works with Claude Code, Cursor, Cline, Continue, and any MCP-compatible agent.",
       "url": "https://dfrostar.github.io/neuralmind/",
       "downloadUrl": "https://pypi.org/project/neuralmind/",
-      "softwareVersion": "0.12.0",
+      "softwareVersion": "0.13.0",
       "license": "https://opensource.org/licenses/MIT",
       "programmingLanguage": "Python",
       "operatingSystemRequirements": "Python 3.10+",
@@ -80,10 +80,10 @@
             <h1>🧠 NeuralMind</h1>
             <p>Semantic code intelligence for AI agents.<br/>40–70× token reduction. Zero data exfiltration. Enterprise-ready.</p>
             <p style="font-size: 1rem; opacity: 0.85; margin-top: 0.5rem;">
-                <strong>🆕 v0.12.0 — Install Doctor.</strong> One command — <code>neuralmind doctor</code> — inspects your setup (code graph, semantic index, synapse memory, MCP server, Claude Code hooks, query memory) and prints each piece with a status and the exact fix. Exits non-zero on a real failure (gate CI on it); <code>--json</code> for agents. Querying before the graph exists now reads as a setup hint, not a stack trace. <a href="https://github.com/dfrostar/neuralmind/blob/main/RELEASE_NOTES_v0.12.0.md" style="color: white; text-decoration: underline;">Release notes →</a> · <a href="about.html#whats-new-v0120" style="color: white; text-decoration: underline;">Summary →</a>
+                <strong>🆕 v0.13.0 — Measurement foundation.</strong> The scaffolding to <em>prove</em> the memory helps, not just claim it: a 100%-local <strong>faithfulness eval</strong> (a query + gold-fact dataset and an offline expected-fact-recall scorer) and <strong>polyglot retrieval fixtures (TypeScript + Go)</strong> so quality is measured beyond Python — plus a written documentation process. No runtime change to your install. <a href="https://github.com/dfrostar/neuralmind/blob/main/RELEASE_NOTES_v0.13.0.md" style="color: white; text-decoration: underline;">Release notes →</a> · <a href="about.html#whats-new-v0130" style="color: white; text-decoration: underline;">Summary →</a>
             </p>
             <p style="font-size: 0.9rem; opacity: 0.75; margin-top: 0.25rem;">
-                Earlier: <a href="https://github.com/dfrostar/neuralmind/blob/main/RELEASE_NOTES_v0.11.0.md" style="color: white; text-decoration: underline;">v0.11.0 directional synapses (<code>neuralmind next</code>)</a> · <a href="https://github.com/dfrostar/neuralmind/blob/main/RELEASE_NOTES_v0.10.0.md" style="color: white; text-decoration: underline;">v0.10.0 agent ergonomics (categorized footer + <code>neuralmind last</code>)</a> · <a href="https://github.com/dfrostar/neuralmind/blob/main/RELEASE_NOTES_v0.9.0.md" style="color: white; text-decoration: underline;">v0.9.0 enterprise-ready (GHCR/SBOM/air-gapped)</a> · <a href="https://github.com/dfrostar/neuralmind/blob/main/RELEASE_NOTES_v0.8.0.md" style="color: white; text-decoration: underline;">v0.8.0 always-on (systemd/launchd/healthz)</a> · <a href="https://github.com/dfrostar/neuralmind/blob/main/RELEASE_NOTES_v0.7.0.md" style="color: white; text-decoration: underline;">v0.7.0 install anywhere</a>.
+                Earlier: <a href="https://github.com/dfrostar/neuralmind/blob/main/RELEASE_NOTES_v0.12.0.md" style="color: white; text-decoration: underline;">v0.12.0 install doctor</a> · <a href="https://github.com/dfrostar/neuralmind/blob/main/RELEASE_NOTES_v0.11.0.md" style="color: white; text-decoration: underline;">v0.11.0 directional synapses (<code>neuralmind next</code>)</a> ·<a href="https://github.com/dfrostar/neuralmind/blob/main/RELEASE_NOTES_v0.10.0.md" style="color: white; text-decoration: underline;">v0.10.0 agent ergonomics (categorized footer + <code>neuralmind last</code>)</a> · <a href="https://github.com/dfrostar/neuralmind/blob/main/RELEASE_NOTES_v0.9.0.md" style="color: white; text-decoration: underline;">v0.9.0 enterprise-ready (GHCR/SBOM/air-gapped)</a> · <a href="https://github.com/dfrostar/neuralmind/blob/main/RELEASE_NOTES_v0.8.0.md" style="color: white; text-decoration: underline;">v0.8.0 always-on (systemd/launchd/healthz)</a> · <a href="https://github.com/dfrostar/neuralmind/blob/main/RELEASE_NOTES_v0.7.0.md" style="color: white; text-decoration: underline;">v0.7.0 install anywhere</a>.
             </p>
             <div>
                 <a href="wiki/Setup-Guide" class="btn btn-primary">Get Started in 5 Minutes</a>
@@ -320,12 +320,12 @@ neuralmind stats .</code></pre>
             <h2>Status & Future</h2>
             <div class="highlight-grid">
                 <div class="highlight-item">
-                    <strong>✅ v0.12.0 (Current)</strong>
-                    <p><code>neuralmind doctor</code> — one command inspects your install (code graph, semantic index, synapse memory, MCP server, Claude Code hooks) and prints each piece with a status and the exact fix. Stacks on v0.11's directional synapses, v0.10's agent ergonomics, and the v0.6 graph view.</p>
+                    <strong>✅ v0.13.0 (Current) — Measure (foundation)</strong>
+                    <p>The measurement foundation: a 100%-local <strong>faithfulness eval</strong> (a query + gold-fact dataset and an offline expected-fact-recall scorer) and <strong>polyglot TypeScript + Go retrieval fixtures</strong>, plus a written documentation process. The full <code>neuralmind eval</code> report is the next increment — this ships the dataset and the scorer it runs on.</p>
                 </div>
                 <div class="highlight-item">
-                    <strong>📋 v0.13 (Next) — Measure</strong>
-                    <p>A CI-gated evaluation harness that proves the memory makes answers <em>better</em>, not just shorter: faithfulness + retrieval-quality scoring with a 100%-local offline judge, plus polyglot TypeScript + Go fixtures. The fitness function the rest of the roadmap builds on.</p>
+                    <strong>📋 Next — finish the eval harness</strong>
+                    <p>A/B answer generation (with NeuralMind context vs a naive baseline), the full offline judge (recall + grounding + contradiction), and a <code>neuralmind eval</code> report: faithfulness delta, grounding rate, and a per-query breakdown. Builds straight on v0.13.0's foundation. (v0.12.0 shipped <code>neuralmind doctor</code>.)</p>
                 </div>
                 <div class="highlight-item">
                     <strong>🎯 v0.14 → v0.16</strong>

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -61,6 +61,16 @@
     <priority>0.6</priority>
   </url>
   <url>
+    <loc>https://github.com/dfrostar/neuralmind/blob/main/RELEASE_NOTES_v0.13.0.md</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://dfrostar.github.io/neuralmind/about.html#whats-new-v0130</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
     <loc>https://github.com/dfrostar/neuralmind/blob/main/RELEASE_NOTES_v0.12.0.md</loc>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>

--- a/docs/wiki/CLI-Reference.md
+++ b/docs/wiki/CLI-Reference.md
@@ -926,6 +926,7 @@ Behaviour:
 | `NEURALMIND_BASH_SMALL` | `500` | *(v0.10.0+)* Threshold below which failing Bash outputs pass through verbatim (no compression marker). Tunable to suit your noise tolerance. |
 | `NEURALMIND_BASH_MAX_CHARS` | `3000` | Threshold above which successful Bash outputs get compressed. |
 | `NEURALMIND_BASH_TAIL` | `3` | Number of tail lines always kept verbatim in compressed Bash output. |
+| `NEURALMIND_EVAL_LLM_JUDGE` | `0` | *(v0.13.0+)* Opt-in LLM-as-judge mode for the offline faithfulness eval harness (`evals/faithfulness/`). Off by default and **never** the CI gate; when set, the runner prints a notice that answers + gold facts would be sent to a third-party API. The default judge is the zero-network offline expected-fact-recall scorer. |
 
 ---
 

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -6,6 +6,22 @@ Welcome — this wiki is the in-depth reference. For the fastest orientation, us
 
 ## What's New
 
+### v0.13.0 — Measurement foundation
+
+The scaffolding to *prove* the memory helps, not just claim it: a 100%-local **faithfulness eval** (a versioned query + gold-fact dataset and an offline expected-fact-recall scorer), **polyglot retrieval fixtures (TypeScript + Go)** so quality is measured beyond Python, and a written documentation process. No runtime change to your install — this is the fitness function the eval-first roadmap (v0.13→v0.16) builds on. The full `neuralmind eval` report is the next increment. Full details: [v0.13.0 release notes](../blob/main/RELEASE_NOTES_v0.13.0.md).
+
+### v0.12.0 — Install Doctor
+
+`neuralmind doctor` inspects an install (code graph, semantic index, synapse memory, MCP server, Claude Code hooks, query memory) and reports each piece with a status and the exact fix; `--json` for agents, non-zero exit to gate CI. Full details: [v0.12.0 release notes](../blob/main/RELEASE_NOTES_v0.12.0.md).
+
+### v0.11.0 — Directional Synapses
+
+The synapse layer now learns *what comes next*, not just *what goes together*: a `synapse_transitions` table, a `next_likely()` API, the `neuralmind next` CLI, and the `neuralmind_next_likely` MCP tool. Full details: [v0.11.0 release notes](../blob/main/RELEASE_NOTES_v0.11.0.md).
+
+### v0.10.0 — Agent Ergonomics
+
+A content-aware PostToolUse compression footer (categorized line counts + repeated-line detection) and `neuralmind last` to recover dropped middle output without re-running the command. Full details: [v0.10.0 release notes](../blob/main/RELEASE_NOTES_v0.10.0.md).
+
 ### v0.9.0 — Enterprise-Ready
 
 Phase 3 of the release arc. Every tagged release now auto-publishes a multi-platform container image to GHCR (`ghcr.io/dfrostar/neuralmind:vX.Y.Z` and `:latest`, `linux/amd64` + `linux/arm64`) and attaches a CycloneDX JSON SBOM to the GitHub Release. New [`docs/use-cases/air-gapped.md`](../blob/main/docs/use-cases/air-gapped.md) walkthrough covers the strictest deployment posture — no outbound network at install, build, runtime, or query. New [`docs/COMPLIANCE-SUMMARY.md`](../blob/main/docs/COMPLIANCE-SUMMARY.md) consolidates NIST AI RMF + SOC 2 + GDPR claims previously scattered across `SECURITY-GUIDE.md` and `ENTERPRISE.md`, with a "how to verify yourself" command for every claim.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,12 @@ keywords = [
     "associative-memory",
     "health-check",
     "install-doctor",
-    "agent-onboarding"
+    "agent-onboarding",
+    "evaluation",
+    "faithfulness-eval",
+    "retrieval-quality",
+    "polyglot-fixtures",
+    "offline-eval"
 ]
 classifiers = [
     "Development Status :: 4 - Beta",


### PR DESCRIPTION
## What this is

The post-release documentation + SEO pass for **v0.13.0** (already tagged and published to PyPI), propagated across every surface per `docs/DOCUMENTATION-PROCESS.md`.

### Honest framing (important)
v0.13.0 is a **measurement-foundation / trust** release, **not** a new end-user feature. It ships:
- the **faithfulness eval foundation** (a query + gold-fact dataset and a 100%-local offline expected-fact-recall scorer — *not* the full `neuralmind eval` report, which is a later increment),
- **polyglot retrieval fixtures** (TypeScript + Go),
- a **documentation process**.

So the copy deliberately says *"nothing changes at runtime"* and frames the value as **credibility/roadmap progress** (measured quality, beyond Python), not invented capabilities. The one new toggle, `NEURALMIND_EVAL_LLM_JUDGE`, is documented as opt-in and never the CI gate.

## Surfaces updated
- **`RELEASE_NOTES_v0.13.0.md`** — canonical notes, "what the agent actually sees post-install" angle (honestly: nothing new at runtime) + per-agent expectations table.
- **`README.md`** — v0.13.0 banner, v0.12.0 demoted into the trail, new release-notes table row.
- **`docs/index.html`** — banner + earlier-releases trail, `<meta>` description/keywords, schema.org `softwareVersion` → 0.13.0, "Status & Future" (v0.13.0 now Current).
- **`docs/about.html`** — new "What's New in v0.13.0" section, schema.org version, meta description/keywords, roadmap section updated (v0.13 foundation shipped), **and fixed a stale `Current Release: v0.6.0` block** — the exact drift this process exists to catch.
- **`docs/wiki/Home.md`** — closed the What's-New gap (v0.10 → v0.13).
- **`docs/wiki/CLI-Reference.md`** — documented `NEURALMIND_EVAL_LLM_JUDGE`.
- **`docs/sitemap.xml`** — v0.13.0 release-notes + about-anchor URLs.
- **`pyproject.toml`** — SEO keywords (`evaluation`, `faithfulness-eval`, `retrieval-quality`, `polyglot-fixtures`, `offline-eval`). No version touched.

## Self-tested ✅
- `python evals/faithfulness/runner.py --selfcheck` green (52 facts; perfect→1.0, empty→0.0)
- `python tests/test_eval_faithfulness.py` → 16/16 pass
- `sitemap.xml` well-formed; both JSON-LD blocks valid JSON at 0.13.0; `pyproject.toml` parses; HTML `<section>`/`<div>` tag balance verified.

Docs-only; no code, no version bump (release-please owns versioning).

https://claude.ai/code/session_016MZU3vW4yd4SJeA293foF3

---
_Generated by [Claude Code](https://claude.ai/code/session_016MZU3vW4yd4SJeA293foF3)_