### PR TITLE
feat(evals): faithfulness A/B harness + report — turn the eval into a number (E1.2–E1.4)

### DIFF
--- a/docs/wiki/CLI-Reference.md
+++ b/docs/wiki/CLI-Reference.md
@@ -14,6 +14,7 @@ Complete command-line interface documentation for NeuralMind.
   - [benchmark](#benchmark)
   - [stats](#stats)
   - [doctor](#doctor-v0120)
+  - [eval](#eval-v0140)
   - [learn](#learn)
   - [next](#next-v0110)
   - [skeleton](#skeleton)
@@ -498,6 +499,41 @@ JSON output (`--json`) is stable for scripting and agent consumption:
   ]
 }
 ```
+
+---
+
+### eval *(v0.14.0+)*
+
+Run the **faithfulness eval**: does NeuralMind's selected context contain
+more gold facts than a *matched-budget* naive baseline? It self-evaluates
+against the committed reference fixture + gold-fact set (which ship with the
+source repository), so — like `neuralmind benchmark` — it's a quality
+self-test, not a per-repo command.
+
+```bash
+neuralmind eval [project_path] [--json] [--selfcheck]
+```
+
+**Arguments:**
+
+| Argument | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `project_path` | No | the gold-set fixture | Project to evaluate |
+| `--json`, `-j` | No | `false` | Emit the report as JSON |
+| `--selfcheck` | No | `false` | Validate the gold set + offline scorer only (no retrieval deps) |
+
+**What it reports:** the **faithfulness delta** — mean expected-fact recall of
+NeuralMind's context minus the naive baseline's, at a matched per-query token
+budget — plus grounding rate, contradiction rate, and a per-query breakdown.
+A positive delta means smart selection beats dumb truncation at equal token
+cost. The default judge is 100% offline; an opt-in LLM-as-judge sits behind
+`NEURALMIND_EVAL_LLM_JUDGE=1` and is never the default or the CI gate.
+
+**Requirements:** the A/B needs the retrieval stack (chromadb) and a built
+index; without them it degrades with an actionable message. `--selfcheck`
+needs neither. From an installed wheel (where the `evals/` package isn't
+bundled), run it from a source checkout instead:
+`python -m evals.faithfulness.runner --run`.
 
 ---
 

--- a/evals/faithfulness/README.md
+++ b/evals/faithfulness/README.md
@@ -4,11 +4,11 @@ Measures whether an agent's answer to a code question gets **better** with
 NeuralMind context, not just shorter — the fitness function the v0.13
 "Measure" release is built around.
 
-> **Status: E1.1 foundation only.** This directory currently ships the
-> query + gold-fact set, the format/scoring spec, and a pure-Python runner
-> skeleton with the offline expected-fact-recall scorer. Answer generation,
-> the full judge, the report, and the onboarding-lift eval are follow-on
-> tasks (see [Roadmap](#roadmap)). Tracking issue:
+> **Status: E1.2–E1.4 implemented.** This directory ships the query +
+> gold-fact set, the three-dimension offline judge (expected-fact recall,
+> grounding, contradiction), and the A/B harness + report that turns it into
+> a number: NeuralMind's selected context vs a matched-budget naive baseline.
+> The onboarding-lift eval (E1.5) is the remaining follow-on. Tracking issue:
 > [#172](https://github.com/dfrostar/neuralmind/issues/172);
 > plan: `docs/NEXT-RELEASE-PLAN.md` §3 Epic E1.
 
@@ -40,30 +40,61 @@ If neither the env var is set nor a key is present, the harness runs fully
 offline. The eval must not quietly phone home; doing so would contradict
 the headline claim.
 
+## The number: faithfulness delta at a matched token budget
+
+The headline metric is **expected-fact recall of the answer**, compared
+**at the same token budget**:
+
+- The default answerer is deterministic and offline — the "answer" *is* the
+  context handed to the model (retrieval-as-answer), so recall measures
+  whether the *selected context* actually contains each gold fact.
+- The baseline is naive truncation of the repo to the **same per-query token
+  budget** as NeuralMind's context. So a positive delta means smart selection
+  beats dumb truncation **at equal cost** — not the dishonest "small context
+  vs the whole 50k-token repo" comparison (the whole repo trivially contains
+  every fact at ~1.0 recall while costing 40–70× the tokens).
+
+`faithfulness_delta = mean(nm_recall) − mean(naive_recall)`. The report also
+carries grounding rate (are the right modules cited?) and contradiction rate
+(does the answer assert a choice that conflicts with the gold facts?).
+
 ## Files
 
 | File | Purpose |
 |---|---|
 | `queries.json` | Versioned query + gold-fact set (≥15 queries) derived from `tests/fixtures/sample_project/`. |
 | `schema.md` | The `queries.json` format contract + the three scoring dimensions. |
-| `runner.py` | Pure-Python skeleton: loads the query set, defines the scoring interface, implements the offline expected-fact-recall scorer. Answerer + API judge are marked TODO. |
+| `runner.py` | Stdlib-only: loads the query set and implements the three-dimension offline judge (recall + grounding + contradiction). Also the `--selfcheck` / `--run` CLI. |
+| `harness.py` | The A/B harness: the deterministic answerer, the matched-budget naive baseline, the NeuralMind context provider (lazy-imported), and the report (`--json` / Markdown). |
 | `README.md` | This file. |
 
 `runner.py` imports **standard library only** at module load — no
 chromadb / graphify / heavy deps — so it loads and is unit-testable in a
-minimal environment. Heavy machinery (the real answerer wired to
-`neuralmind.core`) is imported lazily inside the functions that need it,
-added in E1.2.
+minimal environment. `harness.py` lazy-imports `tiktoken` and
+`neuralmind.core` only inside the functions that need them, so the offline
+judge and its tests still run without the retrieval stack.
 
 ## Running it
 
 ```bash
-# Offline (default) — once E1.2 lands an answerer this prints the report.
-python -m evals.faithfulness.runner
+# Dependency-free: validate the gold set + offline scorer (the CI gate).
+python -m evals.faithfulness.runner --selfcheck
 
-# Today (E1.1): inspect the loaded query set and self-check the scorer.
-python evals/faithfulness/runner.py --selfcheck
+# The real A/B + report (needs the retrieval stack + a built index):
+graphify update tests/fixtures/sample_project
+neuralmind build tests/fixtures/sample_project --force
+python -m evals.faithfulness.runner --run          # Markdown report
+python -m evals.faithfulness.runner --run --json   # machine-readable
+
+# Same thing through the CLI (from a source checkout):
+neuralmind eval            # report
+neuralmind eval --json     # JSON
+neuralmind eval --selfcheck
 ```
+
+When the retrieval deps or a built graph are missing, `--run` / `neuralmind
+eval` degrade with an actionable message and point you at `--selfcheck`,
+which never needs them.
 
 Unit tests (stdlib `unittest`, no pytest required):
 
@@ -75,10 +106,10 @@ python tests/test_eval_faithfulness.py
 
 | Task | What it adds | Status |
 |---|---|---|
-| **E1.1** | Query + gold-fact set, schema, runner skeleton + offline recall scorer. | **this PR** |
-| E1.2 | A/B answer generation: with-NeuralMind-context vs naive baseline, via a pluggable deterministic answerer. | follow-on |
-| E1.3 | Full judges: offline (recall + grounding + contradiction) as default/gate, opt-in LLM-as-judge behind the env var. | follow-on |
-| E1.4 | `neuralmind eval` report — faithfulness delta (with vs without), grounding rate, per-query breakdown, `--json`. | follow-on |
+| **E1.1** | Query + gold-fact set, schema, runner skeleton + offline recall scorer. | ✅ done |
+| **E1.2** | A/B answer generation: with-NeuralMind-context vs matched-budget naive baseline, via a deterministic answerer. | ✅ done |
+| **E1.3** | Full offline judge: recall + grounding + contradiction (default/gate); opt-in LLM-as-judge behind the env var. | ✅ done |
+| **E1.4** | `neuralmind eval` report — faithfulness delta, grounding rate, per-query breakdown, `--json`. | ✅ done |
 | E1.5 | Onboarding-lift eval — cold agent + team baseline vs cold agent alone; gates shared-memory build (#175). | follow-on |
 
 CI gating (Epic E3) consumes the offline judge's output once E1.4 exists,

--- a/evals/faithfulness/harness.py
+++ b/evals/faithfulness/harness.py
@@ -1,0 +1,362 @@
+"""Faithfulness A/B harness + report (E1.2 + E1.4).
+
+This turns the E1.1 foundation (gold-fact dataset + offline recall scorer in
+``runner.py``) into an actual *number*: for every query it scores a
+NeuralMind-selected context against a **matched-budget naive baseline** and
+reports the faithfulness delta.
+
+Design (see ``README.md``):
+  * The default answerer is deterministic and offline — the "answer" *is* the
+    context provided to the model (retrieval-as-answer). So expected-fact
+    recall over that text measures whether the *selected context* actually
+    contains the gold facts. No LLM, no network → safe as a CI gate.
+  * The baseline is naive truncation to the **same token budget** as the
+    NeuralMind context. That makes it an honest fight: "does smart selection
+    beat dumb truncation at equal tokens?" — not "does a 800-token context
+    beat the whole 50k-token repo?" (which the whole repo trivially wins on
+    recall while costing 40-70x the tokens).
+
+Import-safe: only the standard library and ``.runner`` are imported at module
+load. ``tiktoken`` and ``neuralmind.core`` are imported lazily inside the
+functions that need them, so this module — and its unit tests — run in a
+minimal environment without the heavy retrieval dependencies.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from .runner import OfflineJudge, Query, QuerySet, load_query_set
+
+# Source file extensions that make up a fixture's "whole repo" baseline.
+_SOURCE_GLOBS = ("*.py", "*.ts", "*.go", "*.js")
+
+# Repo root = three levels up from this file (evals/faithfulness/harness.py).
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+# --------------------------------------------------------------------------- #
+# Tokenisation
+# --------------------------------------------------------------------------- #
+def count_tokens(text: str) -> int:
+    """Token count via ``tiktoken`` when available, else a ~4-chars/token
+    approximation.
+
+    The approximation is rough but the A/B stays fair because both the
+    NeuralMind and naive sides are measured with the same function. Mirrors
+    the fallback chain in ``tests/benchmark/run.py``.
+    """
+    try:
+        import tiktoken
+    except Exception:
+        return max(1, len(text) // 4)
+    for name in ("o200k_base", "cl100k_base"):
+        try:
+            enc = tiktoken.get_encoding(name)
+            return len(enc.encode(text))
+        except Exception:  # noqa: PERF203 - tiny fixed loop
+            continue
+    return max(1, len(text) // 4)
+
+
+def _truncate_to_tokens(text: str, budget: int) -> str:
+    """Head-truncate ``text`` to approximately ``budget`` tokens.
+
+    Word-granular and deterministic; binary-searches the word count so the
+    result lands at or just under the budget regardless of which tokenizer
+    ``count_tokens`` resolved to.
+    """
+    if budget <= 0 or not text:
+        return ""
+    words = text.split()
+    if count_tokens(text) <= budget:
+        return text
+    lo, hi = 0, len(words)
+    while hi - lo > 1:
+        mid = (lo + hi) // 2
+        if count_tokens(" ".join(words[:mid])) <= budget:
+            lo = mid
+        else:
+            hi = mid
+    return " ".join(words[:lo])
+
+
+# --------------------------------------------------------------------------- #
+# Context providers
+# --------------------------------------------------------------------------- #
+def _fixture_source_text(fixture_dir: Path) -> str:
+    """Concatenate every source file in the fixture, each under a ``# path``
+    header so module references survive into the naive baseline (fair: both
+    sides label their files)."""
+    parts: list[str] = []
+    for pattern in _SOURCE_GLOBS:
+        for f in sorted(fixture_dir.rglob(pattern)):
+            if "__pycache__" in f.parts or f.name == "__init__.py":
+                continue
+            rel = f.relative_to(fixture_dir).as_posix()
+            parts.append(f"# {rel}\n{f.read_text(encoding='utf-8')}")
+    return "\n\n".join(parts)
+
+
+def naive_context(fixture_dir: Path, budget_tokens: int) -> str:
+    """The matched-budget naive baseline: the concatenated repo, head-truncated
+    to ``budget_tokens``. Deterministic, dependency-free, relevance-blind."""
+    return _truncate_to_tokens(_fixture_source_text(fixture_dir), budget_tokens)
+
+
+def neuralmind_context_provider(project_path: str) -> Callable[[Query], str]:
+    """Build a context provider backed by the real NeuralMind pipeline.
+
+    Lazily imports ``neuralmind`` (chromadb etc.) and constructs the index
+    once, returning a ``query -> context`` callable. Raises ``RuntimeError``
+    with an actionable message if the deps or the built graph are missing —
+    the CLI turns that into a graceful degrade.
+    """
+    try:
+        from neuralmind import NeuralMind
+        from neuralmind.core import GraphNotBuiltError
+    except Exception as exc:  # pragma: no cover - exercised only without deps
+        raise RuntimeError(
+            "the faithfulness A/B needs the retrieval stack (chromadb etc.); "
+            f"install neuralmind with its deps to run it ({exc})"
+        ) from exc
+
+    nm = NeuralMind(project_path)
+
+    def provide(query: Query) -> str:
+        try:
+            return nm.query(query.question).context
+        except GraphNotBuiltError as exc:  # pragma: no cover - needs real env
+            raise RuntimeError(
+                f"no code graph for {project_path!r}; run `graphify update` then "
+                f"`neuralmind build` first ({exc})"
+            ) from exc
+
+    return provide
+
+
+# --------------------------------------------------------------------------- #
+# Answerer
+# --------------------------------------------------------------------------- #
+class ContextAnswerer:
+    """Deterministic, offline answerer: the answer *is* the provided context.
+
+    Scoring this with the offline expected-fact-recall judge measures whether
+    the selected context contains the gold facts — the question the eval cares
+    about. A real LLM answerer is the opt-in path (``NEURALMIND_EVAL_LLM_JUDGE``)
+    and is never the default or the CI gate.
+    """
+
+    def answer(self, query: Query, context: str) -> str:  # noqa: ARG002
+        return context
+
+
+# --------------------------------------------------------------------------- #
+# A/B run
+# --------------------------------------------------------------------------- #
+@dataclass
+class ABResult:
+    """One query's with-NeuralMind vs matched-budget-naive outcome."""
+
+    query_id: str
+    nm_recall: float
+    naive_recall: float
+    nm_tokens: int
+    naive_tokens: int
+    nm_grounding: float
+    naive_grounding: float
+    nm_contradiction: float
+
+    @property
+    def recall_delta(self) -> float:
+        return self.nm_recall - self.naive_recall
+
+    def to_dict(self) -> dict:
+        return {
+            "query_id": self.query_id,
+            "nm_recall": round(self.nm_recall, 4),
+            "naive_recall": round(self.naive_recall, 4),
+            "recall_delta": round(self.recall_delta, 4),
+            "nm_tokens": self.nm_tokens,
+            "naive_tokens": self.naive_tokens,
+            "nm_grounding": round(self.nm_grounding, 4),
+            "naive_grounding": round(self.naive_grounding, 4),
+            "nm_contradiction": round(self.nm_contradiction, 4),
+        }
+
+
+def run_ab(
+    query_set: QuerySet,
+    project_path: str | None = None,
+    *,
+    context_provider: Callable[[Query], str] | None = None,
+    naive_provider: Callable[[int], str] | None = None,
+    answerer: ContextAnswerer | None = None,
+    judge: OfflineJudge | None = None,
+) -> list[ABResult]:
+    """Run the faithfulness A/B over every query in ``query_set``.
+
+    ``context_provider`` and ``naive_provider`` are injectable so the harness
+    is unit-testable without the retrieval stack; by default they resolve to
+    the real NeuralMind pipeline and the fixture-truncation baseline.
+    """
+    answerer = answerer or ContextAnswerer()
+    judge = judge or OfflineJudge()
+
+    # The fixture defaults to the gold set's own ``fixture`` (resolved against
+    # the repo root) when no explicit project is given, so a bare ``--run``
+    # self-evaluates the reference fixture.
+    fixture_dir = _resolve_fixture(query_set, project_path)
+
+    if context_provider is None:
+        context_provider = neuralmind_context_provider(str(fixture_dir))
+    if naive_provider is None:
+        naive_provider = lambda budget: naive_context(fixture_dir, budget)  # noqa: E731
+
+    results: list[ABResult] = []
+    for q in query_set.queries:
+        nm_ctx = context_provider(q)
+        budget = count_tokens(nm_ctx)
+        naive_ctx = naive_provider(budget)
+
+        nm_ans = answerer.answer(q, nm_ctx)
+        naive_ans = answerer.answer(q, naive_ctx)
+        results.append(
+            ABResult(
+                query_id=q.id,
+                nm_recall=judge.fact_recall(q, nm_ans).recall,
+                naive_recall=judge.fact_recall(q, naive_ans).recall,
+                nm_tokens=budget,
+                naive_tokens=count_tokens(naive_ctx),
+                nm_grounding=judge.grounding_rate(q, nm_ans),
+                naive_grounding=judge.grounding_rate(q, naive_ans),
+                nm_contradiction=judge.contradiction_score(q, nm_ans),
+            )
+        )
+    return results
+
+
+def _resolve_fixture(query_set: QuerySet, project_path: str | None) -> Path:
+    """Pick the directory the naive baseline reads from: an explicit
+    ``project_path`` wins, else the query set's ``fixture`` resolved against
+    the repo root."""
+    if project_path is not None:
+        return Path(project_path)
+    return (_REPO_ROOT / query_set.fixture).resolve()
+
+
+# --------------------------------------------------------------------------- #
+# Report
+# --------------------------------------------------------------------------- #
+@dataclass
+class EvalReport:
+    """Aggregated faithfulness report (the E1.4 deliverable)."""
+
+    fixture: str
+    n_queries: int
+    nm_mean_recall: float
+    naive_mean_recall: float
+    nm_mean_grounding: float
+    naive_mean_grounding: float
+    nm_mean_contradiction: float
+    nm_total_tokens: int
+    naive_total_tokens: int
+    per_query: list[ABResult] = field(default_factory=list)
+
+    @property
+    def faithfulness_delta(self) -> float:
+        """The headline number: mean fact-recall gain of NeuralMind's selected
+        context over the matched-budget naive baseline."""
+        return self.nm_mean_recall - self.naive_mean_recall
+
+    def to_dict(self) -> dict:
+        return {
+            "fixture": self.fixture,
+            "n_queries": self.n_queries,
+            "faithfulness_delta": round(self.faithfulness_delta, 4),
+            "nm_mean_recall": round(self.nm_mean_recall, 4),
+            "naive_mean_recall": round(self.naive_mean_recall, 4),
+            "nm_mean_grounding": round(self.nm_mean_grounding, 4),
+            "naive_mean_grounding": round(self.naive_mean_grounding, 4),
+            "nm_mean_contradiction": round(self.nm_mean_contradiction, 4),
+            "nm_total_tokens": self.nm_total_tokens,
+            "naive_total_tokens": self.naive_total_tokens,
+            "per_query": [r.to_dict() for r in self.per_query],
+        }
+
+
+def _mean(values: list[float]) -> float:
+    return sum(values) / len(values) if values else 0.0
+
+
+def build_report(query_set: QuerySet, results: list[ABResult]) -> EvalReport:
+    return EvalReport(
+        fixture=query_set.fixture,
+        n_queries=len(results),
+        nm_mean_recall=_mean([r.nm_recall for r in results]),
+        naive_mean_recall=_mean([r.naive_recall for r in results]),
+        nm_mean_grounding=_mean([r.nm_grounding for r in results]),
+        naive_mean_grounding=_mean([r.naive_grounding for r in results]),
+        nm_mean_contradiction=_mean([r.nm_contradiction for r in results]),
+        nm_total_tokens=sum(r.nm_tokens for r in results),
+        naive_total_tokens=sum(r.naive_tokens for r in results),
+        per_query=results,
+    )
+
+
+def render_json(report: EvalReport) -> str:
+    return json.dumps(report.to_dict(), indent=2)
+
+
+def render_markdown(report: EvalReport) -> str:
+    """Human-readable report — the same shape the benchmark report uses."""
+    delta_pts = report.faithfulness_delta * 100
+    lines = [
+        "## NeuralMind faithfulness eval",
+        "",
+        f"**Fixture:** `{report.fixture}` — {report.n_queries} queries.",
+        "",
+        f"- **Faithfulness delta: {delta_pts:+.1f} points** "
+        f"(NeuralMind {report.nm_mean_recall * 100:.1f}% vs "
+        f"naive {report.naive_mean_recall * 100:.1f}% expected-fact recall, "
+        "at a matched token budget)",
+        f"- Grounding rate: **{report.nm_mean_grounding * 100:.1f}%** "
+        f"(naive {report.naive_mean_grounding * 100:.1f}%)",
+        f"- Contradiction rate: **{report.nm_mean_contradiction * 100:.1f}%** "
+        "(lower is better; 0% = no gold-fact conflicts detected)",
+        f"- Token budget: `{report.nm_total_tokens:,}` NeuralMind / "
+        f"`{report.naive_total_tokens:,}` naive (matched per query)",
+        "",
+        "| Query | NM recall | Naive recall | Δ | Grounding | Contra | Tokens |",
+        "|-------|----------:|-------------:|--:|----------:|-------:|-------:|",
+    ]
+    for r in report.per_query:
+        lines.append(
+            f"| `{r.query_id}` | {r.nm_recall * 100:.0f}% | {r.naive_recall * 100:.0f}% | "
+            f"{r.recall_delta * 100:+.0f} | {r.nm_grounding * 100:.0f}% | "
+            f"{r.nm_contradiction * 100:.0f}% | {r.nm_tokens:,} |"
+        )
+    lines += [
+        "",
+        "Faithfulness = expected-fact recall of the answer; the deterministic "
+        "offline judge scores whether the *selected context* contains each gold "
+        "fact. The baseline is naive truncation to the same per-query token "
+        "budget, so a positive delta means smart selection beats dumb "
+        "truncation at equal cost.",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def run_and_report(
+    project_path: str | None = None,
+    query_set: QuerySet | None = None,
+    **run_kwargs,
+) -> EvalReport:
+    """Convenience: load the gold set (if not supplied), run the A/B, aggregate."""
+    qs = query_set or load_query_set()
+    results = run_ab(qs, project_path, **run_kwargs)
+    return build_report(qs, results)

--- a/evals/faithfulness/runner.py
+++ b/evals/faithfulness/runner.py
@@ -1,25 +1,24 @@
-"""Faithfulness eval runner — E1.1 foundation skeleton.
+"""Faithfulness eval runner — gold-fact dataset + offline judge.
 
 Pure standard library at import time: NO chromadb / graphify / neuralmind
 imports at module load, so this file loads and is unit-testable in a
-minimal environment. Heavy machinery (the real answerer wired to
-``neuralmind.core``) is imported lazily inside the functions that need it
-once E1.2 lands.
+minimal environment. The heavy A/B machinery (the real answerer wired to
+``neuralmind.core``) lives in ``harness.py`` and is imported lazily by the
+``--run`` path.
 
-What this module ships today (E1.1):
+What this module ships:
   * ``load_query_set`` — parse + lightly validate ``queries.json``.
-  * ``OfflineJudge.fact_recall`` — the offline, zero-network
-    expected-fact-recall scorer. This is the default, CI-gating signal.
+  * ``OfflineJudge`` — the offline, zero-network judge. Three dimensions:
+    ``fact_recall`` (the headline + CI-gating signal), ``grounding_rate``,
+    and ``contradiction_score``. None of them make a network call.
+  * CLI: ``--selfcheck`` (dependency-free gate) and ``--run`` (the
+    with-NeuralMind vs matched-budget-naive faithfulness A/B + report;
+    ``--json`` for machines), which delegates to ``harness.py``.
 
-What is intentionally left as TODO (later tasks of issue #172):
-  * E1.2 — answer generation (with-NeuralMind vs naive baseline).
-  * E1.3 — grounding-rate + contradiction scoring, and the opt-in
-    LLM-as-judge behind ``NEURALMIND_EVAL_LLM_JUDGE``.
-  * E1.4 — the ``neuralmind eval`` report (delta, per-query breakdown, JSON).
+The opt-in LLM-as-judge (``NEURALMIND_EVAL_LLM_JUDGE``) is the only path
+that would leave the machine, and is never the default or the CI gate.
 
-See ``schema.md`` for the data contract and ``README.md`` for the design
-(offline judge = default + gate; API judge = opt-in, labelled as leaving
-the machine).
+See ``schema.md`` for the data contract and ``README.md`` for the design.
 """
 
 from __future__ import annotations
@@ -190,6 +189,29 @@ def _phrase_in(answer_norm: str, needle_norm: str) -> bool:
     return f" {needle_norm} " in f" {answer_norm} "
 
 
+def _module_cited(module: str, answer: str) -> bool:
+    """Is ``module`` (a fixture-relative path like ``auth/handlers.py``)
+    referenced in ``answer``? Matches the full path or a distinctive basename."""
+    a = answer.lower()
+    m = module.lower()
+    if m in a:
+        return True
+    base = m.rsplit("/", 1)[-1]
+    return len(base) > 3 and base in a
+
+
+# Mutually-exclusive technical choices in the fixture domain. If a query's gold
+# facts pick exactly one option from a group and the answer asserts a *different*
+# one, that's a contradiction. Conservative on purpose — only well-known,
+# unambiguous pairs, so the CI gate isn't tripped by false positives.
+_CONTRADICTION_GROUPS: tuple[tuple[str, ...], ...] = (
+    ("sqlite", "postgresql", "postgres", "mysql", "mongodb", "redis"),
+    ("hs256", "rs256", "es256"),
+    ("symmetric", "asymmetric"),
+    ("bcrypt", "scrypt", "argon2", "pbkdf2"),
+)
+
+
 @dataclass
 class FactResult:
     fact_id: str
@@ -258,30 +280,43 @@ class OfflineJudge:
             return 0.0
         return sum(r.recall for r in results) / len(results)
 
-    # -- E1.3 TODOs ------------------------------------------------------- #
     def grounding_rate(self, query: Query, answer: str) -> float:
-        """TODO(E1.3): fraction of answer claims attributable to
-        ``query.expected_modules`` / retrieved context. Zero-network."""
-        raise NotImplementedError("grounding_rate lands in E1.3")
+        """Fraction of the query's ``expected_modules`` referenced in ``answer``.
+
+        An offline proxy for "is the answer drawn from the right sources?": the
+        deterministic answer is the selected context, which labels each snippet
+        with its file path, so this measures whether the gold modules actually
+        made it into the context. Zero-network.
+        """
+        modules = query.expected_modules
+        if not modules:
+            return 0.0
+        cited = sum(1 for m in modules if _module_cited(m, answer))
+        return cited / len(modules)
 
     def contradiction_score(self, query: Query, answer: str) -> float:
-        """TODO(E1.3): detect statements that conflict with the gold facts
-        (e.g. PostgreSQL vs SQLite, RS256 vs HS256). Zero-network."""
-        raise NotImplementedError("contradiction_score lands in E1.3")
+        """Rate of statements in ``answer`` that conflict with the gold facts.
 
-
-# --------------------------------------------------------------------------- #
-# Answer generation — E1.2 TODO
-# --------------------------------------------------------------------------- #
-def generate_answer(query: Query, *, with_context: bool) -> str:  # noqa: ARG001
-    """TODO(E1.2): produce an answer for ``query``.
-
-    ``with_context=True`` should answer using NeuralMind-selected context
-    (lazy-import ``neuralmind.core`` here, NOT at module top, to keep this
-    file importable without heavy deps). ``with_context=False`` is the
-    naive baseline. Must be deterministic given a fixed answerer.
-    """
-    raise NotImplementedError("answer generation lands in E1.2")
+        Conservative and offline: for each group of mutually-exclusive choices
+        (e.g. SQLite vs PostgreSQL, HS256 vs RS256), if the gold facts pick
+        exactly one side and the answer asserts a *different* side, that's a
+        contradiction. Returns contradictions / applicable-groups — ``0.0``
+        means none detected (lower is better).
+        """
+        gold_norm = _normalize(" ".join(s for f in query.expected_facts for s in f.surfaces()))
+        answer_norm = _normalize(answer)
+        applicable = 0
+        contradicted = 0
+        for group in _CONTRADICTION_GROUPS:
+            gold_side = {opt for opt in group if _phrase_in(gold_norm, _normalize(opt))}
+            if len(gold_side) != 1:
+                continue  # group not unambiguously relevant to this query
+            applicable += 1
+            if any(
+                _phrase_in(answer_norm, _normalize(opt)) for opt in group if opt not in gold_side
+            ):
+                contradicted += 1
+        return contradicted / applicable if applicable else 0.0
 
 
 def _llm_judge_enabled() -> bool:
@@ -321,24 +356,62 @@ def _selfcheck() -> int:
     return 0 if empty_mean == 0.0 else 1
 
 
+def _arg_value(argv: list[str], flag: str) -> str | None:
+    """Return the value following ``flag`` in ``argv``, or None."""
+    if flag in argv:
+        i = argv.index(flag)
+        if i + 1 < len(argv):
+            return argv[i + 1]
+    return None
+
+
+def _run(argv: list[str]) -> int:
+    """Run the faithfulness A/B and print the report (E1.2 + E1.4).
+
+    Requires the retrieval stack (chromadb) and a built index for the fixture;
+    degrades with a clear, actionable message when they're absent so a minimal
+    environment falls back to ``--selfcheck`` instead of crashing.
+    """
+    if _llm_judge_enabled():
+        print(
+            f"[{LLM_JUDGE_ENV}=on] LLM-as-judge mode requested: answers and gold "
+            "facts would be sent to a third-party API (NOT local). The offline "
+            "judge remains the default and the gate.",
+            file=sys.stderr,
+        )
+    try:
+        from . import harness
+    except ImportError:
+        # Allow running as a plain script (python evals/faithfulness/runner.py):
+        # put the repo root on the path and import the package absolutely.
+        sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+        from evals.faithfulness import harness  # type: ignore[no-redef]
+
+    try:
+        report = harness.run_and_report(_arg_value(argv, "--project"))
+    except RuntimeError as exc:
+        print(f"faithfulness A/B unavailable: {exc}", file=sys.stderr)
+        print(
+            "Run with --selfcheck to validate the gold set + offline scorer "
+            "without the retrieval stack.",
+            file=sys.stderr,
+        )
+        return 2
+    print(harness.render_json(report) if "--json" in argv else harness.render_markdown(report))
+    return 0
+
+
 def main(argv: list[str] | None = None) -> int:
     argv = sys.argv[1:] if argv is None else argv
     if "--selfcheck" in argv:
         return _selfcheck()
+    if "--run" in argv:
+        return _run(argv)
 
-    if _llm_judge_enabled():
-        # Honest, loud notice — answers + gold facts would leave the machine.
-        print(
-            f"[{LLM_JUDGE_ENV}=on] LLM-as-judge mode requested: answers and gold "
-            "facts would be sent to a third-party API (NOT local).",
-            file=sys.stderr,
-        )
-
-    # The full report (answer A/B + delta + per-query breakdown + --json)
-    # is E1.4. Until then, point the user at the selfcheck.
-    print("Faithfulness eval (E1.1 skeleton).")
-    print("Answer generation (E1.2) and the report (E1.4) are not implemented yet.")
-    print("Run with --selfcheck to validate the gold set + offline scorer.")
+    print("Faithfulness eval. Usage:")
+    print("  --selfcheck            validate the gold set + offline scorer (no deps)")
+    print("  --run [--project P]    run the with-NeuralMind vs naive A/B + report")
+    print("  --run --json           emit the report as JSON")
     return 0
 
 

--- a/evals/faithfulness/schema.md
+++ b/evals/faithfulness/schema.md
@@ -41,25 +41,25 @@ This file is the gold standard the offline judge scores answers against.
   `JWT_SECRET`, `WEBHOOK_TOLERANCE_SEC`) a real answer would name, so a
   grounded answer scores even if it paraphrases the prose.
 
-## Scoring dimensions (the judge contract, implemented across E1.1–E1.3)
+## Scoring dimensions (the judge contract)
 
-The query set is designed to be scored on three dimensions. E1.1 ships
-the data and the **expected-fact-recall** scorer; the other two are
-specified here and stubbed in `runner.py` for E1.3.
+The query set is scored on three dimensions, all implemented offline in
+`runner.py`'s `OfflineJudge` (zero network) and aggregated into the
+`neuralmind eval` report by `harness.py`.
 
-1. **Expected-fact recall** *(E1.1, implemented).* Fraction of a query's
+1. **Expected-fact recall** *(implemented).* Fraction of a query's
    `expected_facts` that the answer expresses. The offline judge matches
    a fact when the answer text contains the fact statement or any of its
-   `aliases` (case-insensitive, whitespace-normalised). This is the
-   headline, CI-gating number.
-2. **Citation / grounding rate** *(E1.3, stubbed).* Fraction of the
-   answer's claims that are attributable to one of `expected_modules`
-   (or, more strictly, to retrieved context). Measures whether the
-   answer is grounded in the codebase rather than the model's prior.
-3. **Contradiction check** *(E1.3, stubbed).* Detects statements that
-   conflict with the gold facts (e.g. claiming PostgreSQL when the
-   fixture uses SQLite, or RS256 when it is HS256). A negative signal:
-   an answer can have high recall yet still contradict the code.
+   `aliases` (case-insensitive, whitespace-normalised, token-boundary
+   aware). This is the headline, CI-gating number.
+2. **Citation / grounding rate** *(implemented).* Fraction of a query's
+   `expected_modules` referenced in the answer — a proxy for whether the
+   answer is drawn from the right sources rather than the model's prior.
+3. **Contradiction check** *(implemented).* Flags statements that conflict
+   with the gold facts (e.g. claiming PostgreSQL when the fixture uses
+   SQLite, or RS256 when it is HS256), via a conservative table of
+   mutually-exclusive choices. A negative signal: an answer can have high
+   recall yet still contradict the code.
 
 The faithfulness **delta** the release reports (E1.4) is the difference
 in these scores between an answer generated **with** NeuralMind context

--- a/neuralmind/cli.py
+++ b/neuralmind/cli.py
@@ -317,6 +317,45 @@ def cmd_doctor(args):
         sys.exit(1)
 
 
+def cmd_eval(args):
+    """Run the faithfulness eval: does NeuralMind's selected context contain
+    more gold facts than a matched-budget naive baseline?
+
+    Self-evaluates against the committed reference fixture + gold-fact set,
+    which ship with the *source* repository (the ``evals/`` package), so this
+    is a quality self-test like ``neuralmind benchmark`` — not a per-repo
+    command. The A/B needs the retrieval stack + a built index; ``--selfcheck``
+    validates the gold set and offline scorer with no heavy deps.
+    """
+    try:
+        from evals.faithfulness import harness, runner
+    except ImportError:
+        print(
+            "neuralmind eval runs against the faithfulness gold set that ships "
+            "with the source repository (the `evals/` package), not the installed "
+            "wheel. Clone the repo and run "
+            "`python -m evals.faithfulness.runner --run` from its root.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+    if args.selfcheck:
+        sys.exit(runner.main(["--selfcheck"]))
+
+    try:
+        report = harness.run_and_report(args.project_path)
+    except RuntimeError as exc:
+        print(f"faithfulness A/B unavailable: {exc}", file=sys.stderr)
+        print(
+            "The A/B needs the retrieval stack + a built index. Use `--selfcheck` "
+            "to validate the gold set + offline scorer only.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+    print(harness.render_json(report) if args.json else harness.render_markdown(report))
+
+
 def cmd_next(args):
     """Show what typically follows a node (file path or node id) in the
     learned directional-transition graph."""
@@ -845,6 +884,24 @@ def main():
     stats_p.add_argument("project_path")
     stats_p.add_argument("--json", "-j", action="store_true")
     stats_p.set_defaults(func=cmd_stats)
+
+    eval_p = subparsers.add_parser(
+        "eval",
+        help="Run the faithfulness eval (NeuralMind vs naive baseline) on the reference fixture",
+    )
+    eval_p.add_argument(
+        "project_path",
+        nargs="?",
+        default=None,
+        help="Project to evaluate (default: the committed gold-set fixture)",
+    )
+    eval_p.add_argument("--json", "-j", action="store_true")
+    eval_p.add_argument(
+        "--selfcheck",
+        action="store_true",
+        help="Validate the gold set + offline scorer only (no retrieval deps)",
+    )
+    eval_p.set_defaults(func=cmd_eval)
 
     learn_p = subparsers.add_parser(
         "learn", help="Run continual learning scaffold (safe no-op for MVP)"

--- a/tests/test_eval_faithfulness.py
+++ b/tests/test_eval_faithfulness.py
@@ -1,17 +1,19 @@
-"""Stdlib-only tests for the faithfulness eval foundation (issue #172, E1.1).
+"""Stdlib-only tests for the faithfulness eval (issue #172, E1.1–E1.4).
 
 These deliberately use ``unittest`` (no pytest) and import nothing heavy, so
 they run in a minimal environment that has neither pytest nor chromadb:
 
     python tests/test_eval_faithfulness.py
 
-Covers: queries.json loading/validation and the offline expected-fact-recall
-scorer. Answer generation (E1.2) and the full judge (E1.3) are not tested
-here because they are not implemented yet.
+Covers: queries.json loading/validation, the three offline judge dimensions
+(expected-fact recall, grounding, contradiction), and the A/B harness +
+report (E1.2/E1.4) exercised with injected stub context providers so the real
+retrieval stack is never required.
 """
 
 from __future__ import annotations
 
+import json
 import sys
 import unittest
 from pathlib import Path
@@ -21,11 +23,13 @@ _REPO_ROOT = Path(__file__).resolve().parent.parent
 if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 
+from evals.faithfulness import harness  # noqa: E402
 from evals.faithfulness.runner import (  # noqa: E402
     SCHEMA_VERSION,
     ExpectedFact,
     OfflineJudge,
     Query,
+    QuerySet,
     load_query_set,
 )
 
@@ -158,11 +162,38 @@ class OfflineRecallTests(unittest.TestCase):
         )
         self.assertEqual(self.judge.fact_recall(q, "there is a t value here").matched, 0)
 
-    def test_e1_3_methods_are_stubbed(self) -> None:
-        with self.assertRaises(NotImplementedError):
-            self.judge.grounding_rate(self.query, "x")
-        with self.assertRaises(NotImplementedError):
-            self.judge.contradiction_score(self.query, "x")
+    def test_grounding_rate_counts_cited_modules(self) -> None:
+        q = Query(
+            id="g",
+            question="?",
+            expected_facts=(ExpectedFact("f", "x"),),
+            expected_modules=("auth/handlers.py", "auth/jwt_utils.py"),
+        )
+        # Cites one of the two expected modules → 0.5.
+        self.assertEqual(self.judge.grounding_rate(q, "see auth/handlers.py for login"), 0.5)
+        self.assertEqual(self.judge.grounding_rate(q, "nothing relevant here"), 0.0)
+
+    def test_contradiction_flags_wrong_choice(self) -> None:
+        q = Query(
+            id="db",
+            question="?",
+            expected_facts=(ExpectedFact("f", "the fixture uses SQLite", ("sqlite",)),),
+            expected_modules=("db/connection.py",),
+        )
+        # Gold says SQLite; answer asserts PostgreSQL → contradiction.
+        self.assertGreater(self.judge.contradiction_score(q, "it uses PostgreSQL"), 0.0)
+        # Correct choice → none.
+        self.assertEqual(self.judge.contradiction_score(q, "it uses sqlite"), 0.0)
+
+    def test_contradiction_zero_when_no_group_applies(self) -> None:
+        # No gold fact selects a side of any contradiction group → 0.0.
+        q = Query(
+            id="none",
+            question="?",
+            expected_facts=(ExpectedFact("f", "the password hash is verified"),),
+            expected_modules=("auth/handlers.py",),
+        )
+        self.assertEqual(self.judge.contradiction_score(q, "anything at all"), 0.0)
 
 
 class GoldSetSanityTests(unittest.TestCase):
@@ -177,6 +208,65 @@ class GoldSetSanityTests(unittest.TestCase):
             result = judge.fact_recall(q, perfect)
             with self.subTest(query=q.id):
                 self.assertEqual(result.recall, 1.0)
+
+
+class HarnessTests(unittest.TestCase):
+    """E1.2/E1.4 — the A/B harness + report, run with injected stub providers
+    so no chromadb/tiktoken is required."""
+
+    def setUp(self) -> None:
+        self.qs = QuerySet(
+            schema_version=1,
+            fixture="x",
+            queries=[
+                Query(
+                    id="q1",
+                    question="?",
+                    expected_facts=(ExpectedFact("a", "alpha"), ExpectedFact("b", "beta")),
+                    expected_modules=("m1.py",),
+                ),
+            ],
+        )
+
+    def test_truncate_to_budget_is_bounded(self) -> None:
+        text = " ".join(["word"] * 1000)
+        out = harness._truncate_to_tokens(text, 10)
+        self.assertTrue(out)
+        self.assertLessEqual(harness.count_tokens(out), 10)
+        self.assertEqual(harness._truncate_to_tokens(text, 0), "")
+
+    def test_context_answerer_echoes_context(self) -> None:
+        ans = harness.ContextAnswerer().answer(self.qs.queries[0], "ctx text")
+        self.assertEqual(ans, "ctx text")
+
+    def test_run_ab_neuralmind_beats_naive(self) -> None:
+        results = harness.run_ab(
+            self.qs,
+            context_provider=lambda q: "alpha and beta are both here",
+            naive_provider=lambda budget: "alpha only",
+        )
+        self.assertEqual(len(results), 1)
+        r = results[0]
+        self.assertEqual(r.nm_recall, 1.0)
+        self.assertEqual(r.naive_recall, 0.5)
+        self.assertGreater(r.recall_delta, 0.0)
+
+    def test_build_and_render_report(self) -> None:
+        results = harness.run_ab(
+            self.qs,
+            context_provider=lambda q: "alpha and beta",
+            naive_provider=lambda budget: "",
+        )
+        report = harness.build_report(self.qs, results)
+        self.assertAlmostEqual(report.faithfulness_delta, 1.0)
+
+        payload = json.loads(harness.render_json(report))
+        self.assertEqual(payload["faithfulness_delta"], 1.0)
+        self.assertEqual(payload["n_queries"], 1)
+        self.assertIn("per_query", payload)
+
+        md = harness.render_markdown(report)
+        self.assertIn("faithfulness delta", md.lower())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What this is

The increment that takes the v0.13.0 faithfulness **foundation** to an actual **number**. Refs #172 (Epic E1, tasks E1.2–E1.4).

For every gold query it scores NeuralMind's selected context against a **matched-budget naive baseline** and reports the faithfulness delta.

## The honest metric (the design decision, confirmed up front)

`faithfulness_delta = mean(nm_recall) − mean(naive_recall)` **at an equal per-query token budget.**

- Faithfulness = expected-fact recall of the *answer*. The default answerer is deterministic + offline — the "answer" **is** the context handed to the model (retrieval-as-answer) — so recall measures whether the *selected context* actually contains each gold fact. No LLM, no network → safe as a CI gate.
- The baseline is naive truncation of the repo to the **same token budget** as NeuralMind's context. So a positive delta means smart selection beats dumb truncation **at equal cost** — not the dishonest "small context vs the whole 50k-token repo" (which trivially wins recall at 40–70× the tokens).
- The opt-in LLM-as-judge stays behind `NEURALMIND_EVAL_LLM_JUDGE`, never the default or the gate.

## What landed

- **`evals/faithfulness/harness.py` (E1.2 + E1.4):** the deterministic `ContextAnswerer`, the matched-budget naive baseline, a lazily-imported NeuralMind context provider, `run_ab()`, and the report (`build_report` + Markdown/`--json`). Context providers are injectable so the harness is unit-testable with no chromadb/tiktoken.
- **`runner.py` (E1.3):** filled the judge stubs — `grounding_rate` (expected-module citation) and `contradiction_score` (conservative mutually-exclusive table: SQLite vs PostgreSQL, HS256 vs RS256, …). Added `--run [--project] [--json]`, which degrades with an actionable message when the retrieval stack is absent.
- **`neuralmind eval` CLI:** report / `--json` / `--selfcheck`. A quality self-test against the committed reference fixture, like `neuralmind benchmark`.
- **Tests:** 22 stdlib `unittest`s — the three judge dimensions + the harness/report via injected stub providers (fully offline).
- **Docs:** eval `README.md`/`schema.md` updated (E1.2–E1.4 done; metric + baseline explained); `neuralmind eval` added to the CLI reference.

## Verified ✅ (this environment)
- `python tests/test_eval_faithfulness.py` → **22/22 pass**
- `python -m evals.faithfulness.runner --selfcheck` green (52 facts)
- `--run` without chromadb degrades cleanly (exit 2, actionable message)
- black + ruff clean on all changed files

## Not verified here ⚠️ (honest)
- The **real end-to-end A/B number** needs the retrieval stack (chromadb) + a built index, which aren't in this sandbox. The offline judge, the harness with stub providers, and the graceful degrade are tested here; the live `faithfulness_delta` runs in CI / a dep-complete env.
- The `neuralmind eval` CLI can't load here because the `neuralmind` package imports chromadb at import time (same as every CLI command in this env).

## Release/docs note
This adds the user-facing `neuralmind eval` command, so it's a `feat` → release-please will fold it into **v0.14.0**. The release-level docs/SEO surfaces (README banner, `RELEASE_NOTES_v0.14.0`, landing/about) are best done when v0.14 is actually cut (likely alongside other v0.14 roadmap work), not in this increment — this PR ships the command's reference docs.

Draft for review.

Refs #172

https://claude.ai/code/session_016MZU3vW4yd4SJeA293foF3

---
_Generated by [Claude Code](https://claude.ai/code/session_016MZU3vW4yd4SJeA293foF3)_