### PR TITLE
ci: cross-platform test gate (Linux + macOS) + gate the faithfulness eval

### DIFF
--- a/.github/workflows/ci-benchmark.yml
+++ b/.github/workflows/ci-benchmark.yml
@@ -61,6 +61,35 @@ jobs:
           graphify update tests/fixtures/sample_project
           neuralmind build tests/fixtures/sample_project --force
 
+      - name: Faithfulness eval (A/B) gate
+        # Reuses the index built above to run the real with-NeuralMind vs
+        # matched-budget naive A/B and gate on the measured fact-recall delta.
+        # The benchmark answers "how many tokens?"; this answers "are the right
+        # facts still in the context?" — the honesty half of the story.
+        run: |
+          python -m evals.faithfulness.runner --run --json | tee eval_faithfulness.json
+          python - <<'PY'
+          import json
+          d = json.load(open("eval_faithfulness.json"))
+          nm, naive = d["nm_mean_recall"], d["naive_mean_recall"]
+          delta = d["faithfulness_delta"]
+          print(
+              f"[eval] fact-recall  NeuralMind {nm:.3f}  vs  "
+              f"naive(matched-budget) {naive:.3f}  ->  delta {delta:+.3f}  "
+              f"over {d['n_queries']} queries"
+          )
+          # Gate: NeuralMind's *selected* context must not carry fewer gold
+          # facts than dumb truncation of the whole repo to the same token
+          # budget. A negative delta means retrieval regressed below a naive
+          # baseline — that's the failure we want CI to catch. Floor at 0 is
+          # deliberately conservative on this tiny fixture; tighten once we
+          # have a stable measured distribution.
+          assert delta >= 0.0, (
+              f"faithfulness regression: NeuralMind recall {nm:.3f} < "
+              f"naive {naive:.3f} (delta {delta:+.3f})"
+          )
+          PY
+
       - name: Run benchmark (Phase 1 + Phase 2)
         id: bench
         run: |

--- a/.github/workflows/ci-benchmark.yml
+++ b/.github/workflows/ci-benchmark.yml
@@ -66,17 +66,26 @@ jobs:
         # matched-budget naive A/B and gate on the measured fact-recall delta.
         # The benchmark answers "how many tokens?"; this answers "are the right
         # facts still in the context?" — the honesty half of the story.
+        # Single in-process call — no pipe/tee/subprocess round-trip — so the
+        # measured report can't be lost to shell plumbing between producing it
+        # and gating on it. Writes the JSON out for the artifact upload too.
         run: |
-          python -m evals.faithfulness.runner --run --json | tee eval_faithfulness.json
           python - <<'PY'
           import json
-          d = json.load(open("eval_faithfulness.json"))
+          from evals.faithfulness import harness
+
+          report = harness.run_and_report(None)
+          d = report.to_dict()
+          with open("eval_faithfulness.json", "w", encoding="utf-8") as fh:
+              json.dump(d, fh, indent=2)
+
           nm, naive = d["nm_mean_recall"], d["naive_mean_recall"]
           delta = d["faithfulness_delta"]
           print(
               f"[eval] fact-recall  NeuralMind {nm:.3f}  vs  "
               f"naive(matched-budget) {naive:.3f}  ->  delta {delta:+.3f}  "
-              f"over {d['n_queries']} queries"
+              f"over {d['n_queries']} queries  "
+              f"(grounding {d['nm_mean_grounding']:.3f} vs {d['naive_mean_grounding']:.3f})"
           )
           # Gate: NeuralMind's *selected* context must not carry fewer gold
           # facts than dumb truncation of the whole repo to the same token

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,8 +42,12 @@ jobs:
           # actually exercised without a full 3x3 runner-minute blow-up.
           - os: macos-latest
             python-version: '3.12'
-          - os: windows-latest
-            python-version: '3.12'
+          # windows-latest is intentionally omitted from the gating matrix:
+          # the suite has real Windows issues (chromadb holds open file
+          # handles so tempdir teardown hits WinError 32, event-log rotation
+          # relies on POSIX rename-over-open, and a concurrent-append test
+          # loses writes). Tracked separately before Windows can be claimed
+          # as supported — see the Windows-support tracking issue.
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,12 +30,20 @@ jobs:
         run: ruff check .
 
   test:
-    name: Test (Python ${{ matrix.python-version }})
-    runs-on: ubuntu-latest
+    name: Test (${{ matrix.os }}, Python ${{ matrix.python-version }})
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
+        os: [ubuntu-latest]
         python-version: ['3.10', '3.11', '3.12']
+        include:
+          # Cross-OS coverage on a representative Python so every platform is
+          # actually exercised without a full 3x3 runner-minute blow-up.
+          - os: macos-latest
+            python-version: '3.12'
+          - os: windows-latest
+            python-version: '3.12'
 
     steps:
       - uses: actions/checkout@v6
@@ -82,14 +90,21 @@ jobs:
         continue-on-error: true
 
   fresh-install:
-    name: Fresh Install (Python ${{ matrix.python-version }})
-    runs-on: ubuntu-latest
+    name: Fresh Install (${{ matrix.os }}, Python ${{ matrix.python-version }})
+    runs-on: ${{ matrix.os }}
     permissions:
       contents: read
     strategy:
       fail-fast: false
       matrix:
+        os: [ubuntu-latest]
         python-version: ['3.10', '3.11', '3.12']
+        include:
+          # macOS shares the bash + venv bin/ layout the smoke steps assume, so
+          # they run as-is. Windows fresh-install needs Scripts/ venv path
+          # handling — tracked as a follow-up.
+          - os: macos-latest
+            python-version: '3.12'
     steps:
       - uses: actions/checkout@v6
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -138,6 +138,17 @@ NeuralMind processes code from your projects. Here's what you should know:
 
 1. **ChromaDB.** We rely on ChromaDB for vector storage. Monitor their security advisories.
 
+   - **CVE-2026-45829 (chromadb ≥ 1.0.0) — not exploitable in NeuralMind.**
+     This is a pre-authentication remote code-execution flaw in ChromaDB's
+     *client/server* HTTP API (`/api/v2/.../collections`), triggered by a
+     malicious model repository when `trust_remote_code=true`. NeuralMind
+     embeds ChromaDB via `chromadb.PersistentClient` (local, on-disk) — it
+     never starts the ChromaDB server, never exposes that endpoint, and never
+     sets `trust_remote_code`. The vulnerable code path is therefore
+     unreachable in NeuralMind's usage, so the corresponding Dependabot alert
+     is dismissed as "vulnerable code is not used." The pin will be bumped
+     once ChromaDB publishes a patched release (none exists as of this note).
+
 2. **MCP Server.** If using the MCP server (`neuralmind.mcp_server`), be aware:
    - It runs locally over stdio by default — no network port is opened.
    - RBAC is enabled by default with three roles: `admin` (all tools), `builder` (retrieval tools — `wakeup`, `query`, `search`, `build`, `stats`, `benchmark`, `skeleton`), `reader` (read-only retrieval). The synapse-family tools (`synaptic_neighbors`, `synapse_stats`, `synapse_decay`, `next_likely`, `export_synapse_memory`) are **admin-only by default**.

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -21,9 +21,9 @@
 
 | OS | Status | Tested Versions | Notes |
 |----|--------|-----------------|-------|
-| Linux | ✅ Full | Ubuntu 20.04+ | All features supported |
-| macOS | ✅ Full | 11.0+ | x86 and Apple Silicon |
-| Windows | ✅ Full | 10, 11 | Task Scheduler integration tested |
+| Linux | ✅ Full | Ubuntu 20.04+ | CI-verified on every PR (Python 3.10–3.12) |
+| macOS | ✅ Full | 11.0+ | CI-verified on every PR; x86 and Apple Silicon |
+| Windows | ⚠️ Experimental | 10, 11 | Installs and runs; **not yet CI-green** — the test suite has known Windows issues (ChromaDB holds open file handles so temp-dir teardown hits `WinError 32`, event-log rotation relies on POSIX rename-over-open, and a concurrent-append path loses writes). Task Scheduler walkthrough works; full support is tracked before Windows is gated in CI. |
 | Docker | ✅ Full | Docker 20.10+ | Included in releases |
 
 ---

--- a/docs/index.html
+++ b/docs/index.html
@@ -14,7 +14,7 @@
       "@type": "SoftwareApplication",
       "name": "NeuralMind",
       "applicationCategory": "DeveloperApplication",
-      "operatingSystem": "Linux, macOS, Windows",
+      "operatingSystem": "Linux, macOS",
       "description": "Persistent memory and semantic code intelligence for AI coding agents. Local-first code indexing with 40–70× per-query token reduction, a brain-like synapse layer that learns associations from how you use the codebase, an Obsidian-style graph view, an MCP server, and a built-in install doctor. Works with Claude Code, Cursor, Cline, Continue, and any MCP-compatible agent.",
       "url": "https://dfrostar.github.io/neuralmind/",
       "downloadUrl": "https://pypi.org/project/neuralmind/",

--- a/evals/faithfulness/runner.py
+++ b/evals/faithfulness/runner.py
@@ -127,8 +127,14 @@ def load_query_set(path: str | os.PathLike[str] | None = None) -> QuerySet:
         modules = entry.get("expected_modules")
         if not isinstance(modules, list) or not modules:
             raise ValueError(f"query {qid!r} needs a non-empty 'expected_modules' list")
+        for m in modules:
+            if not isinstance(m, str) or not m.strip():
+                raise ValueError(
+                    f"query {qid!r} has a non-string/empty entry in 'expected_modules'"
+                )
 
         facts: list[ExpectedFact] = []
+        seen_fact_ids: set[str] = set()
         for f in entry.get("expected_facts", []):
             if not isinstance(f, dict):
                 raise ValueError(f"query {qid!r} has a non-object entry in 'expected_facts'")
@@ -136,9 +142,24 @@ def load_query_set(path: str | os.PathLike[str] | None = None) -> QuerySet:
             ftext = f.get("fact")
             if not isinstance(fid, str) or not fid.strip():
                 raise ValueError(f"query {qid!r} has an expected_fact missing a non-empty 'id'")
+            if fid in seen_fact_ids:
+                raise ValueError(f"duplicate expected_fact id {fid!r} in query {qid!r}")
+            seen_fact_ids.add(fid)
             if not isinstance(ftext, str) or not ftext.strip():
                 raise ValueError(f"fact {fid!r} in query {qid!r} is missing non-empty 'fact' text")
-            facts.append(ExpectedFact(id=fid, fact=ftext, aliases=tuple(f.get("aliases", []))))
+            # 'aliases' must be a list of non-empty strings. A bare string here
+            # would otherwise be silently exploded into per-character aliases
+            # (tuple("postgres") -> 'p','o','s',...), corrupting recall scoring.
+            aliases = f.get("aliases", [])
+            if not isinstance(aliases, list):
+                raise ValueError(
+                    f"fact {fid!r} in query {qid!r}: 'aliases' must be a list of strings, "
+                    f"got {type(aliases).__name__}"
+                )
+            for a in aliases:
+                if not isinstance(a, str) or not a.strip():
+                    raise ValueError(f"fact {fid!r} in query {qid!r} has a non-string/empty alias")
+            facts.append(ExpectedFact(id=fid, fact=ftext, aliases=tuple(aliases)))
         if not facts:
             raise ValueError(f"query {qid!r} has no expected_facts")
 
@@ -200,16 +221,27 @@ def _module_cited(module: str, answer: str) -> bool:
     return len(base) > 3 and base in a
 
 
-# Mutually-exclusive technical choices in the fixture domain. If a query's gold
-# facts pick exactly one option from a group and the answer asserts a *different*
-# one, that's a contradiction. Conservative on purpose — only well-known,
-# unambiguous pairs, so the CI gate isn't tripped by false positives.
-_CONTRADICTION_GROUPS: tuple[tuple[str, ...], ...] = (
-    ("sqlite", "postgresql", "postgres", "mysql", "mongodb", "redis"),
-    ("hs256", "rs256", "es256"),
-    ("symmetric", "asymmetric"),
-    ("bcrypt", "scrypt", "argon2", "pbkdf2"),
+# Mutually-exclusive technical choices in the fixture domain. Each group is a
+# set of competing *choices*; each choice is one or more synonymous surface
+# tokens (matched as whole words). If a query's gold facts pick exactly one
+# choice and the answer asserts a *different* choice, that's a contradiction.
+# Conservative on purpose — only well-known, unambiguous pairs, so the CI gate
+# isn't tripped by false positives. Synonyms within a choice (postgres ==
+# postgresql) never conflict with each other.
+_CONTRADICTION_GROUPS: tuple[tuple[tuple[str, ...], ...], ...] = (
+    # Primary persistence engine. Redis is deliberately excluded: it's
+    # typically a cache *alongside* the primary store, not a competing choice,
+    # so "sqlite + a redis cache" must not read as a contradiction.
+    (("sqlite",), ("postgresql", "postgres"), ("mysql",), ("mongodb",)),
+    (("hs256",), ("rs256",), ("es256",)),
+    (("symmetric",), ("asymmetric",)),
+    (("bcrypt",), ("scrypt",), ("argon2",), ("pbkdf2",)),
 )
+
+
+def _choice_present(text_norm: str, choice: tuple[str, ...]) -> bool:
+    """Is any synonym of ``choice`` present in the normalized text (whole-word)?"""
+    return any(_phrase_in(text_norm, _normalize(tok)) for tok in choice)
 
 
 @dataclass
@@ -308,13 +340,12 @@ class OfflineJudge:
         applicable = 0
         contradicted = 0
         for group in _CONTRADICTION_GROUPS:
-            gold_side = {opt for opt in group if _phrase_in(gold_norm, _normalize(opt))}
-            if len(gold_side) != 1:
+            gold_choices = [c for c in group if _choice_present(gold_norm, c)]
+            if len(gold_choices) != 1:
                 continue  # group not unambiguously relevant to this query
             applicable += 1
-            if any(
-                _phrase_in(answer_norm, _normalize(opt)) for opt in group if opt not in gold_side
-            ):
+            gold_choice = gold_choices[0]
+            if any(_choice_present(answer_norm, c) for c in group if c is not gold_choice):
                 contradicted += 1
         return contradicted / applicable if applicable else 0.0
 

--- a/requirements-pinned.txt
+++ b/requirements-pinned.txt
@@ -4,6 +4,11 @@
 # Install with: pip install -r requirements-pinned.txt
 
 # Core dependencies
+# chromadb pinned at 1.5.8. CVE-2026-45829 (pre-auth RCE) affects the ChromaDB
+# *server* HTTP API with trust_remote_code=true; NeuralMind uses the embedded
+# PersistentClient only (no server, no trust_remote_code), so the vulnerable
+# path is unreachable. See SECURITY.md "Known Security Considerations". Bump
+# once a patched chromadb release ships.
 chromadb==1.5.8
 pyyaml==6.0.3
 toml==0.10.2

--- a/tests/test_eval_faithfulness.py
+++ b/tests/test_eval_faithfulness.py
@@ -87,6 +87,68 @@ class LoadQuerySetTests(unittest.TestCase):
         finally:
             os.unlink(path)
 
+    def _load_query(self, query: dict) -> None:
+        """Write a one-query set with the given query dict and load it."""
+        import os
+        import tempfile
+
+        payload = {"schema_version": self.qs.schema_version, "fixture": "x", "queries": [query]}
+        with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False, encoding="utf-8") as fh:
+            json.dump(payload, fh)
+            path = fh.name
+        try:
+            load_query_set(path)
+        finally:
+            os.unlink(path)
+
+    def test_bare_string_aliases_rejected(self) -> None:
+        # A string (not a list) would explode into per-character aliases.
+        with self.assertRaises(ValueError):
+            self._load_query(
+                {
+                    "id": "q",
+                    "question": "?",
+                    "expected_modules": ["m"],
+                    "expected_facts": [{"id": "f", "fact": "x", "aliases": "postgres"}],
+                }
+            )
+
+    def test_non_string_module_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            self._load_query(
+                {
+                    "id": "q",
+                    "question": "?",
+                    "expected_modules": ["ok", 123],
+                    "expected_facts": [{"id": "f", "fact": "x"}],
+                }
+            )
+
+    def test_duplicate_fact_id_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            self._load_query(
+                {
+                    "id": "q",
+                    "question": "?",
+                    "expected_modules": ["m"],
+                    "expected_facts": [
+                        {"id": "dup", "fact": "a"},
+                        {"id": "dup", "fact": "b"},
+                    ],
+                }
+            )
+
+    def test_valid_aliases_list_accepted(self) -> None:
+        # A proper list of strings still loads cleanly.
+        self._load_query(
+            {
+                "id": "q",
+                "question": "?",
+                "expected_modules": ["m"],
+                "expected_facts": [{"id": "f", "fact": "x", "aliases": ["pg", "postgres"]}],
+            }
+        )
+
 
 class OfflineRecallTests(unittest.TestCase):
     def setUp(self) -> None:
@@ -194,6 +256,32 @@ class OfflineRecallTests(unittest.TestCase):
             expected_modules=("auth/handlers.py",),
         )
         self.assertEqual(self.judge.contradiction_score(q, "anything at all"), 0.0)
+
+    def test_contradiction_treats_postgres_synonyms_as_one_choice(self) -> None:
+        # "postgres" and "postgresql" are the same choice — not a contradiction.
+        q = Query(
+            id="pg",
+            question="?",
+            expected_facts=(ExpectedFact("f", "the store is PostgreSQL", ("postgresql",)),),
+            expected_modules=("db/connection.py",),
+        )
+        self.assertEqual(self.judge.contradiction_score(q, "it uses postgres"), 0.0)
+        # A genuinely different engine is still flagged.
+        self.assertGreater(self.judge.contradiction_score(q, "it uses mysql"), 0.0)
+
+    def test_contradiction_ignores_redis_cache_alongside_primary_store(self) -> None:
+        # Redis as a cache *alongside* the gold SQLite store is not a
+        # contradiction — redis is excluded from the persistence-engine group.
+        q = Query(
+            id="db",
+            question="?",
+            expected_facts=(ExpectedFact("f", "the fixture uses SQLite", ("sqlite",)),),
+            expected_modules=("db/connection.py",),
+        )
+        self.assertEqual(
+            self.judge.contradiction_score(q, "sqlite primary store with a redis cache layer"),
+            0.0,
+        )
 
 
 class GoldSetSanityTests(unittest.TestCase):


### PR DESCRIPTION
## What this does

Two testing-coverage gaps, closed together.

### 1. Cross-platform CI — honestly
Added macOS + Windows to the test matrix and ran the suite on each for the first time. The result was informative:

| Platform | Result |
|----------|--------|
| Linux 3.10 / 3.11 / 3.12 | ✅ green |
| **macOS 3.12** | ✅ **green** — real new coverage, kept in the gate |
| Windows 3.12 | ❌ 509 passed, **5 failed, 134 errors** |

Windows failures are genuine, not flukes: ~134 ChromaDB temp-dir teardown errors (`WinError 32` — open file handles), event-log rotation relying on POSIX rename-over-open, and a concurrent-append path that loses writes. Rather than ship a Windows support claim we can't back, this PR:

- keeps **macOS** in the gating matrix (it passes),
- **drops `windows-latest`** from the gate and tracks the real work in **#186**,
- tells the truth in the docs: `COMPATIBILITY.md` Windows → ⚠️ Experimental (with the concrete failure modes), and `schema.org` `operatingSystem` → "Linux, macOS" so the machine-readable claim matches what CI verifies.

### 2. Gate the faithfulness eval in CI
The self-benchmark answers *"how many tokens?"*. It never checked *"are the right facts still in the context?"*. This wires the faithfulness A/B (merged in #182) into `ci-benchmark.yml`: after the fixture index is built, run `evals.faithfulness.runner --run --json` and **gate that NeuralMind's selected context carries at least as many gold facts as a matched-budget naive truncation** (`delta >= 0`). The floor is conservative on this tiny fixture; it'll be tightened once we have a stable measured distribution.

### 3. Harden the offline judge (from an adversarial review pass)
- Treat `postgres`/`postgresql` as **one** choice and drop `redis` from the persistence-engine contradiction group — a redis cache alongside SQLite is not a contradiction (was a latent false-positive).
- `load_query_set` now rejects bare-string `aliases` (which silently exploded into per-character aliases), non-string `expected_modules` entries, and duplicate fact ids — instead of corrupting scoring silently.
- 6 new stdlib tests lock both fixes in (28 total).

## Follow-up
- **#186** — Windows support: make the suite CI-green, then re-add the gate and restore the support claim.

https://claude.ai/code/session_016MZU3vW4yd4SJeA293foF3