### PR TITLE
docs(security): document chromadb CVE-2026-45829 has no fixed release

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -138,16 +138,25 @@ NeuralMind processes code from your projects. Here's what you should know:
 
 1. **ChromaDB.** We rely on ChromaDB for vector storage. Monitor their security advisories.
 
-   - **CVE-2026-45829 (chromadb ≥ 1.0.0) — not exploitable in NeuralMind.**
+   - **CVE-2026-45829 / GHSA-f4j7-r4q5-qw2c (chromadb ≥ 1.0.0, CRITICAL) —
+     not exploitable in NeuralMind.**
      This is a pre-authentication remote code-execution flaw in ChromaDB's
      *client/server* HTTP API (`/api/v2/.../collections`), triggered by a
      malicious model repository when `trust_remote_code=true`. NeuralMind
      embeds ChromaDB via `chromadb.PersistentClient` (local, on-disk) — it
      never starts the ChromaDB server, never exposes that endpoint, and never
      sets `trust_remote_code`. The vulnerable code path is therefore
-     unreachable in NeuralMind's usage, so the corresponding Dependabot alert
-     is dismissed as "vulnerable code is not used." The pin will be bumped
-     once ChromaDB publishes a patched release (none exists as of this note).
+     unreachable in NeuralMind's usage, so the recommended disposition for the
+     corresponding Dependabot alert is to **dismiss it as "vulnerable code is
+     not used."**
+     - **No patched release exists yet.** Per the advisory, *every* published
+       version is affected (`introduced: 1.0.0`, `last_affected: 1.5.9` — the
+       current latest), so a version bump cannot resolve it. The pin will be
+       bumped the moment ChromaDB ships a fixed release.
+     - Severity: CRITICAL, `CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:H/SI:H/SA:H` (CWE-94).
+     - References: [NVD](https://nvd.nist.gov/vuln/detail/CVE-2026-45829) ·
+       [GHSA-f4j7-r4q5-qw2c](https://github.com/advisories/GHSA-f4j7-r4q5-qw2c) ·
+       [upstream issue](https://github.com/chroma-core/chroma/issues/6717).
 
 2. **MCP Server.** If using the MCP server (`neuralmind.mcp_server`), be aware:
    - It runs locally over stdio by default — no network port is opened.

--- a/requirements-pinned.txt
+++ b/requirements-pinned.txt
@@ -4,11 +4,14 @@
 # Install with: pip install -r requirements-pinned.txt
 
 # Core dependencies
-# chromadb pinned at 1.5.8. CVE-2026-45829 (pre-auth RCE) affects the ChromaDB
-# *server* HTTP API with trust_remote_code=true; NeuralMind uses the embedded
-# PersistentClient only (no server, no trust_remote_code), so the vulnerable
-# path is unreachable. See SECURITY.md "Known Security Considerations". Bump
-# once a patched chromadb release ships.
+# chromadb pinned at 1.5.8. CVE-2026-45829 / GHSA-f4j7-r4q5-qw2c (CRITICAL,
+# pre-auth RCE) affects the ChromaDB *server* HTTP API with
+# trust_remote_code=true; NeuralMind uses the embedded PersistentClient only
+# (no server, no trust_remote_code), so the vulnerable path is unreachable.
+# Note: every published version is affected (introduced 1.0.0, last_affected
+# 1.5.9 — the current latest), so there is no fixed version to bump to yet;
+# bumping to 1.5.9 would NOT clear the alert. See SECURITY.md "Known Security
+# Considerations". Bump the moment a patched chromadb release ships.
 chromadb==1.5.8
 pyyaml==6.0.3
 toml==0.10.2


### PR DESCRIPTION
## Summary

Addresses the **critical Dependabot alert #7** — `GHSA-f4j7-r4q5-qw2c` / `CVE-2026-45829` on the pinned `chromadb==1.5.8`.

**There is no code or dependency fix available**, and the vulnerability is **not exploitable** in NeuralMind. This PR makes the security record precise so the alert can be dismissed with full evidence.

## Findings

- **No fixed release exists.** Per [OSV/GHSA](https://github.com/advisories/GHSA-f4j7-r4q5-qw2c), the advisory affects `introduced: 1.0.0` → `last_affected: 1.5.9` (the current latest on PyPI). Bumping to 1.5.9 would **not** clear the alert.
- **Not exploitable here.** The flaw is a pre-auth RCE in ChromaDB's *server* HTTP API (`/api/v2/.../collections`), reachable only with `trust_remote_code=true`. NeuralMind's only ChromaDB usage is embedded `chromadb.PersistentClient` (`neuralmind/embedder.py:61`) — no server, no `HttpClient`, no `trust_remote_code` anywhere in the codebase. The vulnerable endpoint is never exposed.

## Changes

- `SECURITY.md` — add the GHSA id, CVSS 4.0 vector, CWE-94, references, and the explicit "no patched release (last_affected 1.5.9)" fact; frame the Dependabot disposition as **dismiss "vulnerable code is not used."**
- `requirements-pinned.txt` — pin comment notes that every version is affected and bumping to 1.5.9 won't help.

## Action still required (maintainer)

The alert itself must be **dismissed in the GitHub Security UI** ([alert #7](https://github.com/dfrostar/neuralmind/security/dependabot/7)) with reason **"Risk is tolerable / vulnerable code is not used."** I don't have a Dependabot-alerts API tool to do this programmatically. The pin should be bumped the moment ChromaDB publishes a fixed release.

https://claude.ai/code/session_016MZU3vW4yd4SJeA293foF3

---
_Generated by [Claude Code](https://claude.ai/code/session_016MZU3vW4yd4SJeA293foF3)_