### PR TITLE
ci: watch for a chromadb release that resolves CVE-2026-45829

### DIFF
--- a/.github/workflows/chromadb-cve-watch.yml
+++ b/.github/workflows/chromadb-cve-watch.yml
@@ -1,0 +1,112 @@
+name: chromadb CVE watch
+
+# Watches for a chromadb release that resolves GHSA-f4j7-r4q5-qw2c /
+# CVE-2026-45829 (pre-auth RCE; CRITICAL). Every published version through the
+# current latest is affected (introduced 1.0.0, last_affected 1.5.9), so the
+# pin in requirements-pinned.txt is held at 1.5.8 and the Dependabot alert is
+# dismissed as "vulnerable code is not used" (NeuralMind only embeds
+# chromadb.PersistentClient — no server, no trust_remote_code). See SECURITY.md.
+#
+# A plain Dependabot version-update is the wrong tool here: it would nag to bump
+# 1.5.8 -> 1.5.9, which does NOT clear the advisory. This job instead asks OSV
+# whether the *latest* published chromadb is still flagged by the advisory, and
+# opens a tracking issue only once a genuinely unaffected release ships — the
+# signal to bump the pin.
+
+on:
+  schedule:
+    # Mondays 09:00 UTC.
+    - cron: "0 9 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: chromadb-cve-watch
+  cancel-in-progress: false
+
+jobs:
+  watch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check whether the latest chromadb still carries the advisory
+        id: check
+        run: |
+          python - <<'PY'
+          import json, os, urllib.request
+
+          ADVISORY = {"GHSA-f4j7-r4q5-qw2c", "CVE-2026-45829"}
+
+          def fetch(url, payload=None):
+              data = json.dumps(payload).encode() if payload is not None else None
+              req = urllib.request.Request(
+                  url, data=data,
+                  headers={"User-Agent": "neuralmind-cve-watch", "Content-Type": "application/json"},
+              )
+              with urllib.request.urlopen(req, timeout=30) as r:
+                  return json.load(r)
+
+          out = open(os.environ["GITHUB_OUTPUT"], "a")
+          try:
+              latest = fetch("https://pypi.org/pypi/chromadb/json")["info"]["version"]
+              osv = fetch(
+                  "https://api.osv.dev/v1/query",
+                  {"package": {"name": "chromadb", "ecosystem": "PyPI"}, "version": latest},
+              )
+              ids = set()
+              for v in osv.get("vulns") or []:
+                  ids.add(v.get("id"))
+                  ids.update(v.get("aliases") or [])
+              still_affected = bool(ADVISORY & ids)
+              print(f"latest chromadb = {latest}")
+              print(f"affected by {sorted(ADVISORY)} = {still_affected}")
+              print(f"all advisory ids for {latest}: {sorted(i for i in ids if i)}")
+              out.write(f"latest={latest}\n")
+              out.write(f"fixed={'false' if still_affected else 'true'}\n")
+          except Exception as e:  # network/transient — warn, never fail the schedule
+              print(f"::warning::chromadb CVE watch could not complete: {e}")
+              out.write("fixed=unknown\n")
+          finally:
+              out.close()
+          PY
+
+      - name: Open a tracking issue when an unaffected release exists
+        if: steps.check.outputs.fixed == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const latest = "${{ steps.check.outputs.latest }}";
+            const label = "chromadb-cve-watch";
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: "open",
+              labels: label,
+            });
+            if (existing.data.length > 0) {
+              core.info(`Tracking issue already open (#${existing.data[0].number}); nothing to do.`);
+              return;
+            }
+            const body = [
+              `chromadb \`${latest}\` is **no longer flagged** by GHSA-f4j7-r4q5-qw2c / CVE-2026-45829`,
+              `(verified against the [OSV API](https://api.osv.dev/) by \`.github/workflows/chromadb-cve-watch.yml\`).`,
+              ``,
+              `A patched/unaffected release is available — time to clear the held pin:`,
+              ``,
+              `- [ ] Bump \`chromadb\` in \`requirements-pinned.txt\` from \`1.5.8\` to \`${latest}\` (and verify the floor in \`pyproject.toml\`).`,
+              `- [ ] Run the test + benchmark + parity suites against the new version.`,
+              `- [ ] Update the CVE-2026-45829 note in \`SECURITY.md\` (resolved as of \`${latest}\`).`,
+              `- [ ] Dismiss/confirm closure of the Dependabot alert.`,
+              ``,
+              `_Auto-filed by the chromadb CVE watch. Closing this issue stops the reminder until a newer flagged version appears._`,
+            ].join("\n");
+            const issue = await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `Bump chromadb pin — ${latest} resolves CVE-2026-45829`,
+              labels: [label, "security", "dependencies"],
+              body,
+            });
+            core.info(`Opened tracking issue #${issue.data.number}.`);


### PR DESCRIPTION
## Summary

Adds a targeted watcher so the chromadb pin (held at `1.5.8` for `CVE-2026-45829` / `GHSA-f4j7-r4q5-qw2c`) gets bumped **the moment an actually-patched release ships** — without nagging in the meantime.

## Why not just Dependabot version-updates?

A plain Dependabot pip update would immediately open a PR to bump `1.5.8 → 1.5.9`, which does **not** clear the advisory (`last_affected: 1.5.9`). That's counterproductive noise. This watcher instead asks the **OSV API** whether the *latest published* chromadb is still flagged by the advisory, and only acts when one isn't.

## How it works

- `.github/workflows/chromadb-cve-watch.yml` — weekly (`cron`) + `workflow_dispatch`.
- Queries PyPI for the latest chromadb, then OSV for that version.
- If the advisory no longer applies → opens a single tracking issue (idempotent via a `chromadb-cve-watch` label) with a bump checklist. If it still applies → no-op.
- Network/transient errors degrade to a `::warning::`, never a failed scheduled run.

## Verified

- YAML parses; the detection logic dry-run against live OSV today returns `latest=1.5.9 → still affected → fixed=false` (correctly stays silent).

Pairs with the `main` health check requested: CI on `main` is green (latest run = the #201 merge), and release-please PR #202 (`0.20.1`) is queued with the security doc fix.

https://claude.ai/code/session_016MZU3vW4yd4SJeA293foF3

---
_Generated by [Claude Code](https://claude.ai/code/session_016MZU3vW4yd4SJeA293foF3)_