### PR TITLE
feat(bench): TurboVec vs ChromaDB memory/latency benchmark toolkit

### DIFF
--- a/BENCHMARK_TURBOVEC.md
+++ b/BENCHMARK_TURBOVEC.md
@@ -1,0 +1,149 @@
+# TurboVec vs. ChromaDB-free MiniLM — memory/latency benchmark
+
+A two-script toolkit that answers the specific follow-up raised in the
+[v0.21.0 release notes](RELEASE_NOTES_v0.21.0.md):
+
+> "A large-synthetic-repo memory/latency benchmark is a follow-up."
+
+It runs the two backends from `neuralmind.backend_manager.create_backend`
+(`chroma` and `turbovec`) against the **same graph**, on the **same machine**,
+with **identical queries**, and measures:
+
+- **indexing latency** — `load_graph` → `embed_nodes(force=True)` wall time;
+- **search latency** — p50 / p95 / mean over many warm repeats, plus a
+  per-query breakdown so a single regressing query type is visible;
+- **on-disk size** — bytes the backend's index directory occupies;
+- **peak RSS** — `getrusage(RUSAGE_SELF).ru_maxrss`, the ground-truth "how much
+  memory did this actually take" number;
+- **tracemalloc peak** — Python-side allocation only (a hint, not the truth);
+- **query-level parity** — each backend's top-k result ids, so the report can
+  compute Jaccard@k and recall-of-chroma's-top-k.
+
+## Why separate subprocesses
+
+Each backend runs in its own **spawn-context subprocess** (the benchmark
+re-invokes itself with a hidden `--_worker` flag), so:
+
+- chroma's transitive import tree (FastAPI, kubernetes client, OpenTelemetry,
+  grpcio, …) never inflates the turbovec memory measurement;
+- a crash in one backend doesn't tank the other;
+- `getrusage(RUSAGE_SELF)` reads the per-process high-water mark cleanly.
+
+The parent process builds the synthetic repo and the shared `graph.json`
+**once**; the workers only index and query.
+
+## Install
+
+```bash
+pip install "neuralmind[turbovec]==0.21.0"
+# the turbovec extra pulls turbovec, onnxruntime, tokenizers, numpy
+pip install psutil   # used by the worker for live RSS sampling
+```
+
+First-time turbovec runs download the `all-MiniLM-L6-v2` ONNX model (~90 MB).
+To skip that on subsequent fresh-machine runs, pre-stage it:
+
+```bash
+export NEURALMIND_ONNX_MODEL_DIR=/path/to/staged/onnx_model_dir
+```
+
+## Run on a synthetic 600-file repo (no setup)
+
+```bash
+python benchmark_turbovec.py --out results.json
+python report_turbovec.py results.json --out report.md
+```
+
+The synthetic repo is generated in `/tmp/nm_bench_repo_<pid>`, indexed with the
+built-in tree-sitter graph generator (no `graphify` required), and cleaned up at
+the end (`--keep-repo` to keep it).
+
+## Run on your own repo
+
+```bash
+# First time (no graph yet): pass --build to generate one via tree-sitter
+python benchmark_turbovec.py --repo ~/code/my-project --build --out results.json
+
+# Subsequent runs (graph already exists at graphify-out/graph.json)
+python benchmark_turbovec.py --repo ~/code/my-project --out results.json
+
+python report_turbovec.py results.json --out report.md
+```
+
+The repo should contain at least 500 source files (`.py`, `.ts`, `.go` — the
+languages supported by NeuralMind's built-in extractors as of v0.16.0). Fewer
+files only emits a warning; the benchmark still runs.
+
+## Flags
+
+`benchmark_turbovec.py`:
+
+| flag | default | meaning |
+|---|---|---|
+| `--out` | `results.json` | output JSON path |
+| `--repo` | _(synthetic)_ | benchmark a real repo instead of the synthetic one |
+| `--build` | off | (with `--repo`) generate `graphify-out/graph.json` via tree-sitter |
+| `--files` | `600` | synthetic repo file count |
+| `--keep-repo` | off | don't delete the synthetic repo afterwards |
+| `--top-k` | `10` | results requested per query |
+| `--repeat` | `20` | timed repeats per query (for stable percentiles) |
+| `--warmup` | `2` | unmeasured warm-up runs per query |
+| `--backends` | `chroma,turbovec` | comma-separated backends to compare |
+| `--queries-file` | _(built-in set)_ | newline-delimited custom queries |
+
+`report_turbovec.py`:
+
+| flag | default | meaning |
+|---|---|---|
+| `--out` | `report.md` | output Markdown path |
+
+## What the report tells you
+
+`report_turbovec.py` reads the JSON and writes a Markdown report with:
+
+- **A one-line verdict** — 🟢 yes / 🟡 cautiously yes / 🛑 not yet / ⚪
+  inconclusive — based on parity *and* performance signals.
+- **Environment provenance** — versions of neuralmind, turbovec, chromadb,
+  onnxruntime, tokenizers, numpy, Python, platform, CPU count, repo size.
+- **Headline table** — indexing latency, search p50/p95/mean, on-disk size,
+  peak RSS, tracemalloc peak, with signed-percent deltas (turbovec vs. chroma).
+- **Parity section** — mean Jaccard@k, recall of chroma's top-k by turbovec, and
+  a (collapsed) per-query overlap table.
+- **Per-query latency table** — side-by-side ms so a single regressing query
+  type is visible.
+- **Caveats** — first-run model download, what tracemalloc does and doesn't
+  capture, the experimental/POC label on turbovec.
+
+The verdict thresholds: 🟢 needs mean Jaccard@k ≥ 0.70 **and** recall ≥ 0.80
+with no performance regression; 🟡 if parity holds but latency/RSS/disk regress,
+or if parity is only marginal (Jaccard ≥ 0.50, recall ≥ 0.60); 🛑 below that; ⚪
+if either backend failed to complete.
+
+## What's intentionally *not* in this benchmark
+
+- **Faithfulness.** NeuralMind has its own gold-set eval (`evals/`) that scores
+  fact recall and top-k hit@4; the v0.21.0 notes already report parity within
+  the 0.10 gate tolerance there. The Jaccard signal here is a complementary
+  query-level sanity check, not a replacement.
+- **Recall vs. ground truth.** Without labelled (query → correct node) pairs for
+  your repo, "recall" here is "recall vs. chroma", which assumes chroma is
+  correct. Run `neuralmind eval` for ground-truth recall.
+- **Concurrent-load behavior.** Single-threaded latency only. The TurboVec
+  release claims SIMD wins under load; that's a separate exercise.
+- **Cold-cache effects.** Both backends run warm. Cold-start time is dominated
+  by the ONNX model load (~1–2 s), identical across both in v0.21.0 since they
+  share the same MiniLM model.
+
+## Caveats / known gotchas
+
+- `getrusage().ru_maxrss` is in **KB on Linux, bytes on macOS** — the benchmark
+  normalizes to MB before reporting.
+- `tracemalloc` only sees **Python-side** allocations. numpy buffers,
+  onnxruntime's session arena, and SQLite page cache show up in RSS but not in
+  tracemalloc. Use RSS as the ground truth for memory and tracemalloc as a hint
+  about how much of that was Python objects.
+- If `psutil` isn't installed the worker fails at its `import psutil` line —
+  install it first.
+- The chroma backend triggers a chromadb telemetry-silencing patch on import
+  (see `neuralmind/__init__.py`); the subprocess isolation keeps that from
+  polluting the turbovec measurement.

--- a/RELEASE_NOTES_v0.21.0.md
+++ b/RELEASE_NOTES_v0.21.0.md
@@ -87,4 +87,9 @@ at it — no network needed.
   then (v0.23) drop `chromadb` from the core dependency list. Staged on purpose
   so the new path bakes before it becomes everyone's default.
 - Quantization is approximate; parity is gated on the reference fixture. A
-  large-synthetic-repo memory/latency benchmark is a follow-up.
+  large-synthetic-repo memory/latency benchmark now ships as a standalone
+  toolkit — see [`BENCHMARK_TURBOVEC.md`](BENCHMARK_TURBOVEC.md)
+  (`benchmark_turbovec.py` + `report_turbovec.py`). It runs both backends in
+  isolated spawn subprocesses on the same graph with identical queries and
+  reports indexing latency, search p50/p95, on-disk size, peak RSS, and
+  query-level parity (Jaccard/recall) with a one-line adopt/hold verdict.

--- a/benchmark_turbovec.py
+++ b/benchmark_turbovec.py
@@ -1,0 +1,567 @@
+#!/usr/bin/env python3
+"""benchmark_turbovec.py — TurboVec vs. ChromaDB memory/latency benchmark.
+
+Answers the v0.21.0 release-notes follow-up:
+
+    "A large-synthetic-repo memory/latency benchmark is a follow-up."
+
+It runs the two backends exposed by ``neuralmind.backend_manager.create_backend``
+(``chroma`` and ``turbovec``) against the *same* graph, on the *same* machine,
+with *identical* queries, and measures indexing latency, search latency
+(p50/p95/mean, per query type), on-disk index size, peak RSS, and Python-side
+peak allocation (tracemalloc). It also records each backend's top-k result ids
+so ``report_turbovec.py`` can compute query-level parity (Jaccard / recall).
+
+Process isolation
+-----------------
+Each backend runs in its *own* ``spawn``-context subprocess (this same file
+re-invoked with ``--_worker``), so:
+
+* chroma's transitive import tree (FastAPI, kubernetes client, OpenTelemetry,
+  grpcio, …) never inflates the turbovec memory measurement;
+* a crash in one backend doesn't tank the other;
+* ``getrusage(RUSAGE_SELF).ru_maxrss`` reads the per-process high-water mark
+  cleanly (normalised KB-on-Linux / bytes-on-macOS → MB before reporting).
+
+The parent process builds the synthetic repo and the shared ``graph.json``
+once; the workers only ``load_graph`` → ``embed_nodes`` → ``search``.
+
+Usage
+-----
+    # Synthetic 600-file repo, no setup, cleaned up afterwards:
+    python benchmark_turbovec.py --out results.json
+
+    # Your own repo (first run needs a graph; --build generates one):
+    python benchmark_turbovec.py --repo ~/code/my-project --build --out results.json
+    # Subsequent runs (graph already at graphify-out/graph.json):
+    python benchmark_turbovec.py --repo ~/code/my-project --out results.json
+
+Then render the Markdown report:
+
+    python report_turbovec.py results.json --out report.md
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import platform
+import resource
+import shutil
+import statistics
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+# The parent process must be able to *generate* a synthetic repo and a
+# graph.json without importing the heavy backend stacks. Keep these imports
+# lazy / local to the worker where they're actually needed.
+
+SCRIPT = Path(__file__).resolve()
+
+# --------------------------------------------------------------------------- #
+# Default query set
+# --------------------------------------------------------------------------- #
+# Topic-aligned with the synthetic repo's module themes (see THEMES below) so
+# the queries actually retrieve something meaningful, while still reading like
+# natural-language code questions. For a real --repo these are generic enough
+# to exercise the index even if they don't all hit.
+DEFAULT_QUERIES: list[str] = [
+    "how does user authentication and login work",
+    "validate and sanitize incoming request payloads",
+    "open and manage a database connection pool",
+    "cache expensive results with a time-to-live",
+    "parse and serialize JSON configuration",
+    "schedule a recurring background job",
+    "retry an HTTP request with exponential backoff",
+    "compute a checksum or hash of a file",
+    "log structured events for observability",
+    "handle errors and raise a domain-specific exception",
+]
+
+# --------------------------------------------------------------------------- #
+# Synthetic repo generation (parent process, stdlib only)
+# --------------------------------------------------------------------------- #
+THEMES: list[tuple[str, str, list[str]]] = [
+    # (package, docstring topic, verbs)
+    ("auth", "user authentication, login, tokens and sessions",
+     ["authenticate", "login", "logout", "issue_token", "verify_session"]),
+    ("validation", "validating and sanitizing incoming request payloads",
+     ["validate", "sanitize", "coerce", "check_schema", "normalize_input"]),
+    ("db", "database connections, pooling and transactions",
+     ["connect", "acquire_connection", "release", "begin_transaction", "execute_query"]),
+    ("cache", "caching expensive results with a time-to-live",
+     ["cache_get", "cache_set", "evict", "with_ttl", "invalidate"]),
+    ("config", "parsing and serializing JSON/YAML configuration",
+     ["load_config", "dump_config", "merge_config", "parse_json", "serialize"]),
+    ("scheduler", "scheduling recurring background jobs",
+     ["schedule", "tick", "enqueue_job", "run_periodic", "cancel_job"]),
+    ("http", "HTTP requests with retries and exponential backoff",
+     ["fetch", "retry_request", "backoff", "build_url", "decode_response"]),
+    ("hashing", "computing checksums and hashes of files",
+     ["checksum", "hash_file", "digest", "verify_integrity", "fingerprint"]),
+    ("logging", "structured logging and observability events",
+     ["log_event", "emit_metric", "trace", "with_context", "redact"]),
+    ("errors", "domain-specific exceptions and error handling",
+     ["raise_domain_error", "wrap_exception", "handle", "is_retryable", "to_dict"]),
+]
+
+
+def _gen_file(theme_idx: int, file_idx: int) -> str:
+    package, topic, verbs = THEMES[theme_idx % len(THEMES)]
+    cls = f"{package.capitalize()}Service{file_idx}"
+    lines = [
+        f'"""{package}.module{file_idx} — {topic}."""',
+        "",
+        "from __future__ import annotations",
+        "",
+        "import hashlib",
+        "import json",
+        "import time",
+        "",
+        "",
+        f"class {cls}:",
+        f'    """Handles {topic} (variant {file_idx})."""',
+        "",
+        "    def __init__(self, config: dict | None = None) -> None:",
+        "        self.config = config or {}",
+        "        self._cache: dict[str, object] = {}",
+        "",
+    ]
+    for v in verbs:
+        lines += [
+            f"    def {v}(self, payload: dict) -> dict:",
+            f'        """{v.replace("_", " ").capitalize()} — part of {topic}."""',
+            "        key = json.dumps(payload, sort_keys=True)",
+            "        digest = hashlib.sha256(key.encode()).hexdigest()",
+            "        self._cache[digest] = time.time()",
+            "        return {\"ok\": True, \"op\": \"" + v + "\", \"digest\": digest}",
+            "",
+        ]
+    # A module-level helper to create call/import edges within the package.
+    lines += [
+        "",
+        f"def make_{package}_service(config: dict | None = None) -> {cls}:",
+        f'    """Factory for :class:`{cls}` ({topic})."""',
+        f"    return {cls}(config)",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def generate_synthetic_repo(root: Path, n_files: int) -> int:
+    """Create ``n_files`` themed Python modules under ``root``. Returns count."""
+    root.mkdir(parents=True, exist_ok=True)
+    per_theme = max(1, n_files // len(THEMES))
+    written = 0
+    for theme_idx, (package, _topic, _verbs) in enumerate(THEMES):
+        pkg_dir = root / package
+        pkg_dir.mkdir(parents=True, exist_ok=True)
+        (pkg_dir / "__init__.py").write_text(
+            f'"""The {package} package."""\n', encoding="utf-8"
+        )
+        for file_idx in range(per_theme):
+            if written >= n_files:
+                break
+            (pkg_dir / f"module{file_idx}.py").write_text(
+                _gen_file(theme_idx, file_idx), encoding="utf-8"
+            )
+            written += 1
+    # Top up to exactly n_files if integer division left a remainder.
+    extra = 0
+    while written < n_files:
+        theme_idx = extra % len(THEMES)
+        package = THEMES[theme_idx][0]
+        (root / package / f"extra{extra}.py").write_text(
+            _gen_file(theme_idx, 1000 + extra), encoding="utf-8"
+        )
+        written += 1
+        extra += 1
+    return written
+
+
+def build_graph_json(repo: Path) -> dict:
+    """Generate ``graphify-out/graph.json`` via the built-in tree-sitter graph.
+
+    Mirrors ``neuralmind.core.NeuralMind._generate_graph`` without pulling in a
+    backend. Returns ``{"nodes": int, "links": int}``.
+    """
+    from neuralmind import graphgen
+
+    if not graphgen.is_available():
+        raise RuntimeError(
+            "the built-in graph backend needs tree-sitter — "
+            "`pip install tree-sitter tree-sitter-python` (bundled with neuralmind)."
+        )
+    graph = graphgen.build_graph(repo)
+    out_dir = repo / "graphify-out"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    (out_dir / "graph.json").write_text(json.dumps(graph, indent=2), encoding="utf-8")
+    return {"nodes": len(graph.get("nodes", [])), "links": len(graph.get("links", []))}
+
+
+def count_source_files(repo: Path) -> int:
+    exts = {".py", ".ts", ".go"}
+    return sum(
+        1
+        for p in repo.rglob("*")
+        if p.is_file() and p.suffix in exts and ".neuralmind" not in p.parts
+        and "graphify-out" not in p.parts
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Worker (runs in an isolated spawn subprocess; imports the heavy backend)
+# --------------------------------------------------------------------------- #
+def _dir_size_bytes(path: Path) -> int:
+    if not path.exists():
+        return 0
+    if path.is_file():
+        return path.stat().st_size
+    total = 0
+    for p in path.rglob("*"):
+        try:
+            if p.is_file():
+                total += p.stat().st_size
+        except OSError:
+            continue
+    return total
+
+
+def _peak_rss_mb() -> float:
+    """Per-process high-water RSS via getrusage, normalised to MB.
+
+    ``ru_maxrss`` is KB on Linux, bytes on macOS — normalise both to MB.
+    """
+    ru = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+    if sys.platform == "darwin":
+        return ru / (1024 * 1024)
+    return ru / 1024
+
+
+def _percentile(values: list[float], pct: float) -> float:
+    if not values:
+        return 0.0
+    s = sorted(values)
+    if len(s) == 1:
+        return s[0]
+    rank = (pct / 100.0) * (len(s) - 1)
+    lo = int(rank)
+    hi = min(lo + 1, len(s) - 1)
+    frac = rank - lo
+    return s[lo] + (s[hi] - s[lo]) * frac
+
+
+def run_worker(backend: str, cfg: dict, result_path: Path) -> None:
+    """Index + query a single backend, writing a result JSON to ``result_path``."""
+    import tracemalloc
+
+    import psutil  # noqa: F401  (per the docs: fail loudly here if missing)
+
+    from neuralmind.backend_manager import create_backend
+
+    repo = cfg["repo"]
+    queries: list[str] = cfg["queries"]
+    top_k: int = cfg["top_k"]
+    warmup: int = cfg["warmup"]
+    repeat: int = cfg["repeat"]
+    db_path = cfg["db_paths"][backend]
+
+    proc = psutil.Process(os.getpid())
+    result: dict = {"backend": backend, "ok": False}
+
+    tracemalloc.start()
+    try:
+        be = create_backend(backend, repo, db_path)
+
+        if not be.load_graph():
+            raise RuntimeError("load_graph() returned False — no graph.json?")
+
+        t0 = time.perf_counter()
+        embed_stats = be.embed_nodes(force=True)
+        index_sec = time.perf_counter() - t0
+
+        try:
+            stats = be.get_stats()
+        except Exception:
+            stats = {}
+
+        # Warm-up (model into RAM, caches primed) — not measured.
+        for q in queries[: max(1, len(queries))]:
+            for _ in range(warmup):
+                be.search(q, n=top_k)
+
+        per_query: list[dict] = []
+        all_latencies: list[float] = []
+        for q in queries:
+            latencies: list[float] = []
+            top_ids: list[str] = []
+            for r in range(repeat):
+                s = time.perf_counter()
+                res = be.search(q, n=top_k)
+                latencies.append((time.perf_counter() - s) * 1000.0)
+                if r == 0:
+                    top_ids = [str(item.get("id")) for item in res]
+            all_latencies.extend(latencies)
+            per_query.append(
+                {
+                    "query": q,
+                    "top_ids": top_ids,
+                    "ms_p50": _percentile(latencies, 50),
+                    "ms_p95": _percentile(latencies, 95),
+                    "ms_mean": statistics.fmean(latencies) if latencies else 0.0,
+                }
+            )
+
+        _cur, py_peak = tracemalloc.get_traced_memory()
+
+        try:
+            be.close()
+        except Exception:
+            pass
+
+        result.update(
+            {
+                "ok": True,
+                "index_seconds": index_sec,
+                "embed_stats": embed_stats,
+                "stats": stats,
+                "disk_bytes": _dir_size_bytes(Path(db_path)),
+                "peak_rss_mb": _peak_rss_mb(),
+                "rss_now_mb": proc.memory_info().rss / (1024 * 1024),
+                "tracemalloc_peak_mb": py_peak / (1024 * 1024),
+                "search": {
+                    "ms_p50": _percentile(all_latencies, 50),
+                    "ms_p95": _percentile(all_latencies, 95),
+                    "ms_mean": statistics.fmean(all_latencies) if all_latencies else 0.0,
+                    "n_samples": len(all_latencies),
+                },
+                "per_query": per_query,
+            }
+        )
+    except Exception as exc:  # report failure rather than crash the run
+        import traceback
+
+        result.update({"ok": False, "error": str(exc), "traceback": traceback.format_exc()})
+    finally:
+        tracemalloc.stop()
+
+    result_path.write_text(json.dumps(result, indent=2), encoding="utf-8")
+
+
+# --------------------------------------------------------------------------- #
+# Environment provenance (parent process)
+# --------------------------------------------------------------------------- #
+def _pkg_version(name: str) -> str | None:
+    try:
+        from importlib.metadata import PackageNotFoundError, version
+
+        try:
+            return version(name)
+        except PackageNotFoundError:
+            return None
+    except Exception:
+        return None
+
+
+def collect_environment(repo: Path, source_files: int, graph: dict) -> dict:
+    return {
+        "neuralmind": _pkg_version("neuralmind"),
+        "turbovec": _pkg_version("turbovec"),
+        "chromadb": _pkg_version("chromadb"),
+        "onnxruntime": _pkg_version("onnxruntime"),
+        "tokenizers": _pkg_version("tokenizers"),
+        "numpy": _pkg_version("numpy"),
+        "python": platform.python_version(),
+        "platform": platform.platform(),
+        "machine": platform.machine(),
+        "cpu_count": os.cpu_count(),
+        "repo": str(repo),
+        "source_files": source_files,
+        "graph_nodes": graph.get("nodes"),
+        "graph_links": graph.get("links"),
+    }
+
+
+# --------------------------------------------------------------------------- #
+# Parent orchestration
+# --------------------------------------------------------------------------- #
+def spawn_backend(backend: str, cfg: dict, work_dir: Path) -> dict:
+    """Run one backend in an isolated subprocess and return its result dict."""
+    cfg_path = work_dir / f"cfg_{backend}.json"
+    res_path = work_dir / f"result_{backend}.json"
+    cfg_path.write_text(json.dumps(cfg), encoding="utf-8")
+
+    env = dict(os.environ)
+    # Force spawn semantics regardless of platform default; the worker is a
+    # fresh interpreter so module-level state never leaks between backends.
+    cmd = [
+        sys.executable,
+        str(SCRIPT),
+        "--_worker",
+        backend,
+        "--_cfg",
+        str(cfg_path),
+        "--_result",
+        str(res_path),
+    ]
+    print(f"  → spawning isolated worker for backend={backend!r} …")
+    completed = subprocess.run(cmd, env=env)
+    if res_path.exists():
+        result = json.loads(res_path.read_text(encoding="utf-8"))
+    else:
+        result = {
+            "backend": backend,
+            "ok": False,
+            "error": f"worker produced no result (exit code {completed.returncode})",
+        }
+    if not result.get("ok"):
+        print(f"    ! backend {backend!r} failed: {result.get('error', 'unknown')}")
+    else:
+        print(
+            f"    ✓ {backend}: index {result['index_seconds']:.2f}s, "
+            f"search p50 {result['search']['ms_p50']:.2f}ms, "
+            f"disk {result['disk_bytes'] / 1e6:.1f}MB, "
+            f"peak RSS {result['peak_rss_mb']:.1f}MB"
+        )
+    return result
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--out", default="results.json", help="output JSON path")
+    parser.add_argument("--repo", default=None, help="path to a real repo (>=500 source files)")
+    parser.add_argument("--build", action="store_true", help="generate graph.json via tree-sitter for --repo")
+    parser.add_argument("--files", type=int, default=600, help="synthetic repo file count (default 600)")
+    parser.add_argument("--keep-repo", action="store_true", help="don't delete the synthetic repo")
+    parser.add_argument("--top-k", type=int, default=10, help="results per query (default 10)")
+    parser.add_argument("--repeat", type=int, default=20, help="timed repeats per query (default 20)")
+    parser.add_argument("--warmup", type=int, default=2, help="warm-up runs per query (default 2)")
+    parser.add_argument(
+        "--backends",
+        default="chroma,turbovec",
+        help="comma-separated backends to compare (default chroma,turbovec)",
+    )
+    parser.add_argument("--queries-file", default=None, help="newline-delimited query file (overrides defaults)")
+
+    # Hidden worker entrypoint — re-invoked per backend in an isolated process.
+    parser.add_argument("--_worker", default=None, help=argparse.SUPPRESS)
+    parser.add_argument("--_cfg", default=None, help=argparse.SUPPRESS)
+    parser.add_argument("--_result", default=None, help=argparse.SUPPRESS)
+
+    args = parser.parse_args(argv)
+
+    if args._worker:
+        cfg = json.loads(Path(args._cfg).read_text(encoding="utf-8"))
+        run_worker(args._worker, cfg, Path(args._result))
+        return 0
+
+    # Ensure the parent can import the local neuralmind package.
+    sys.path.insert(0, str(SCRIPT.parent))
+
+    queries = DEFAULT_QUERIES
+    if args.queries_file:
+        queries = [
+            line.strip()
+            for line in Path(args.queries_file).read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+
+    backends = [b.strip() for b in args.backends.split(",") if b.strip()]
+
+    # ---- Repo + graph setup ------------------------------------------------ #
+    synthetic = args.repo is None
+    if synthetic:
+        repo = Path(f"/tmp/nm_bench_repo_{os.getpid()}")
+        print(f"Generating synthetic repo ({args.files} files) at {repo} …")
+        n = generate_synthetic_repo(repo, args.files)
+        print(f"  wrote {n} files")
+        graph = build_graph_json(repo)
+        print(f"  built graph.json: {graph['nodes']} nodes, {graph['links']} links")
+    else:
+        repo = Path(args.repo).resolve()
+        if not repo.is_dir():
+            print(f"--repo not a directory: {repo}", file=sys.stderr)
+            return 2
+        src = count_source_files(repo)
+        if src < 500:
+            print(
+                f"WARNING: {repo} has only {src} source files (.py/.ts/.go); "
+                "the benchmark is designed for >=500.",
+                file=sys.stderr,
+            )
+        graph_path = repo / "graphify-out" / "graph.json"
+        if args.build or not graph_path.exists():
+            print("Building graph.json via tree-sitter …")
+            graph = build_graph_json(repo)
+            print(f"  built graph.json: {graph['nodes']} nodes, {graph['links']} links")
+        else:
+            g = json.loads(graph_path.read_text(encoding="utf-8"))
+            graph = {"nodes": len(g.get("nodes", [])), "links": len(g.get("links", []))}
+            print(f"Using existing graph.json: {graph['nodes']} nodes, {graph['links']} links")
+
+    source_files = count_source_files(repo)
+
+    work_dir = Path(f"/tmp/nm_bench_work_{os.getpid()}")
+    work_dir.mkdir(parents=True, exist_ok=True)
+
+    # Separate db path per backend so they never share state.
+    db_paths = {b: str(repo / "graphify-out" / f"bench_db_{b}") for b in backends}
+    cfg = {
+        "repo": str(repo),
+        "queries": queries,
+        "top_k": args.top_k,
+        "warmup": args.warmup,
+        "repeat": args.repeat,
+        "db_paths": db_paths,
+    }
+
+    print(f"\nBenchmarking backends: {', '.join(backends)}")
+    print(f"  queries={len(queries)} top_k={args.top_k} repeat={args.repeat} warmup={args.warmup}\n")
+
+    results: dict[str, dict] = {}
+    for backend in backends:
+        results[backend] = spawn_backend(backend, cfg, work_dir)
+
+    payload = {
+        "schema": "neuralmind-turbovec-benchmark/1",
+        "generated_at": time.strftime("%Y-%m-%dT%H:%M:%S"),
+        "config": {
+            "top_k": args.top_k,
+            "repeat": args.repeat,
+            "warmup": args.warmup,
+            "synthetic": synthetic,
+            "queries": queries,
+            "backends": backends,
+        },
+        "environment": collect_environment(repo, source_files, graph),
+        "results": results,
+    }
+
+    out = Path(args.out)
+    out.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    print(f"\nWrote {out}")
+
+    # ---- Cleanup ----------------------------------------------------------- #
+    try:
+        shutil.rmtree(work_dir)
+    except OSError:
+        pass
+    if synthetic and not args.keep_repo:
+        try:
+            shutil.rmtree(repo)
+            print(f"Cleaned up synthetic repo {repo}")
+        except OSError:
+            pass
+    elif synthetic:
+        print(f"Kept synthetic repo at {repo}")
+
+    ok = all(r.get("ok") for r in results.values())
+    print("\nNext: python report_turbovec.py", str(out), "--out report.md")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmark_turbovec.py
+++ b/benchmark_turbovec.py
@@ -86,26 +86,56 @@ DEFAULT_QUERIES: list[str] = [
 # --------------------------------------------------------------------------- #
 THEMES: list[tuple[str, str, list[str]]] = [
     # (package, docstring topic, verbs)
-    ("auth", "user authentication, login, tokens and sessions",
-     ["authenticate", "login", "logout", "issue_token", "verify_session"]),
-    ("validation", "validating and sanitizing incoming request payloads",
-     ["validate", "sanitize", "coerce", "check_schema", "normalize_input"]),
-    ("db", "database connections, pooling and transactions",
-     ["connect", "acquire_connection", "release", "begin_transaction", "execute_query"]),
-    ("cache", "caching expensive results with a time-to-live",
-     ["cache_get", "cache_set", "evict", "with_ttl", "invalidate"]),
-    ("config", "parsing and serializing JSON/YAML configuration",
-     ["load_config", "dump_config", "merge_config", "parse_json", "serialize"]),
-    ("scheduler", "scheduling recurring background jobs",
-     ["schedule", "tick", "enqueue_job", "run_periodic", "cancel_job"]),
-    ("http", "HTTP requests with retries and exponential backoff",
-     ["fetch", "retry_request", "backoff", "build_url", "decode_response"]),
-    ("hashing", "computing checksums and hashes of files",
-     ["checksum", "hash_file", "digest", "verify_integrity", "fingerprint"]),
-    ("logging", "structured logging and observability events",
-     ["log_event", "emit_metric", "trace", "with_context", "redact"]),
-    ("errors", "domain-specific exceptions and error handling",
-     ["raise_domain_error", "wrap_exception", "handle", "is_retryable", "to_dict"]),
+    (
+        "auth",
+        "user authentication, login, tokens and sessions",
+        ["authenticate", "login", "logout", "issue_token", "verify_session"],
+    ),
+    (
+        "validation",
+        "validating and sanitizing incoming request payloads",
+        ["validate", "sanitize", "coerce", "check_schema", "normalize_input"],
+    ),
+    (
+        "db",
+        "database connections, pooling and transactions",
+        ["connect", "acquire_connection", "release", "begin_transaction", "execute_query"],
+    ),
+    (
+        "cache",
+        "caching expensive results with a time-to-live",
+        ["cache_get", "cache_set", "evict", "with_ttl", "invalidate"],
+    ),
+    (
+        "config",
+        "parsing and serializing JSON/YAML configuration",
+        ["load_config", "dump_config", "merge_config", "parse_json", "serialize"],
+    ),
+    (
+        "scheduler",
+        "scheduling recurring background jobs",
+        ["schedule", "tick", "enqueue_job", "run_periodic", "cancel_job"],
+    ),
+    (
+        "http",
+        "HTTP requests with retries and exponential backoff",
+        ["fetch", "retry_request", "backoff", "build_url", "decode_response"],
+    ),
+    (
+        "hashing",
+        "computing checksums and hashes of files",
+        ["checksum", "hash_file", "digest", "verify_integrity", "fingerprint"],
+    ),
+    (
+        "logging",
+        "structured logging and observability events",
+        ["log_event", "emit_metric", "trace", "with_context", "redact"],
+    ),
+    (
+        "errors",
+        "domain-specific exceptions and error handling",
+        ["raise_domain_error", "wrap_exception", "handle", "is_retryable", "to_dict"],
+    ),
 ]
 
 
@@ -137,7 +167,7 @@ def _gen_file(theme_idx: int, file_idx: int) -> str:
             "        key = json.dumps(payload, sort_keys=True)",
             "        digest = hashlib.sha256(key.encode()).hexdigest()",
             "        self._cache[digest] = time.time()",
-            "        return {\"ok\": True, \"op\": \"" + v + "\", \"digest\": digest}",
+            '        return {"ok": True, "op": "' + v + '", "digest": digest}',
             "",
         ]
     # A module-level helper to create call/import edges within the package.
@@ -159,9 +189,7 @@ def generate_synthetic_repo(root: Path, n_files: int) -> int:
     for theme_idx, (package, _topic, _verbs) in enumerate(THEMES):
         pkg_dir = root / package
         pkg_dir.mkdir(parents=True, exist_ok=True)
-        (pkg_dir / "__init__.py").write_text(
-            f'"""The {package} package."""\n', encoding="utf-8"
-        )
+        (pkg_dir / "__init__.py").write_text(f'"""The {package} package."""\n', encoding="utf-8")
         for file_idx in range(per_theme):
             if written >= n_files:
                 break
@@ -207,7 +235,9 @@ def count_source_files(repo: Path) -> int:
     return sum(
         1
         for p in repo.rglob("*")
-        if p.is_file() and p.suffix in exts and ".neuralmind" not in p.parts
+        if p.is_file()
+        and p.suffix in exts
+        and ".neuralmind" not in p.parts
         and "graphify-out" not in p.parts
     )
 
@@ -430,21 +460,31 @@ def spawn_backend(backend: str, cfg: dict, work_dir: Path) -> dict:
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
     parser.add_argument("--out", default="results.json", help="output JSON path")
     parser.add_argument("--repo", default=None, help="path to a real repo (>=500 source files)")
-    parser.add_argument("--build", action="store_true", help="generate graph.json via tree-sitter for --repo")
-    parser.add_argument("--files", type=int, default=600, help="synthetic repo file count (default 600)")
+    parser.add_argument(
+        "--build", action="store_true", help="generate graph.json via tree-sitter for --repo"
+    )
+    parser.add_argument(
+        "--files", type=int, default=600, help="synthetic repo file count (default 600)"
+    )
     parser.add_argument("--keep-repo", action="store_true", help="don't delete the synthetic repo")
     parser.add_argument("--top-k", type=int, default=10, help="results per query (default 10)")
-    parser.add_argument("--repeat", type=int, default=20, help="timed repeats per query (default 20)")
+    parser.add_argument(
+        "--repeat", type=int, default=20, help="timed repeats per query (default 20)"
+    )
     parser.add_argument("--warmup", type=int, default=2, help="warm-up runs per query (default 2)")
     parser.add_argument(
         "--backends",
         default="chroma,turbovec",
         help="comma-separated backends to compare (default chroma,turbovec)",
     )
-    parser.add_argument("--queries-file", default=None, help="newline-delimited query file (overrides defaults)")
+    parser.add_argument(
+        "--queries-file", default=None, help="newline-delimited query file (overrides defaults)"
+    )
 
     # Hidden worker entrypoint — re-invoked per backend in an isolated process.
     parser.add_argument("--_worker", default=None, help=argparse.SUPPRESS)
@@ -519,7 +559,9 @@ def main(argv: list[str] | None = None) -> int:
     }
 
     print(f"\nBenchmarking backends: {', '.join(backends)}")
-    print(f"  queries={len(queries)} top_k={args.top_k} repeat={args.repeat} warmup={args.warmup}\n")
+    print(
+        f"  queries={len(queries)} top_k={args.top_k} repeat={args.repeat} warmup={args.warmup}\n"
+    )
 
     results: dict[str, dict] = {}
     for backend in backends:

--- a/report_turbovec.py
+++ b/report_turbovec.py
@@ -169,19 +169,13 @@ def build_report(data: dict) -> str:
     if both_ok:
         b_p95 = g(base, "search", "ms_p95", default=0.0)
         c_p95 = g(cand, "search", "ms_p95", default=0.0)
-        headline["search_p95_delta_pct"] = (
-            (c_p95 - b_p95) / b_p95 * 100.0 if b_p95 else None
-        )
+        headline["search_p95_delta_pct"] = (c_p95 - b_p95) / b_p95 * 100.0 if b_p95 else None
         b_disk = base.get("disk_bytes", 0) or 0
         c_disk = cand.get("disk_bytes", 0) or 0
-        headline["disk_delta_pct"] = (
-            (c_disk - b_disk) / b_disk * 100.0 if b_disk else None
-        )
+        headline["disk_delta_pct"] = (c_disk - b_disk) / b_disk * 100.0 if b_disk else None
         b_rss = base.get("peak_rss_mb", 0) or 0
         c_rss = cand.get("peak_rss_mb", 0) or 0
-        headline["rss_delta_pct"] = (
-            (c_rss - b_rss) / b_rss * 100.0 if b_rss else None
-        )
+        headline["rss_delta_pct"] = (c_rss - b_rss) / b_rss * 100.0 if b_rss else None
 
     verdict, rationale = compute_verdict(parity, headline, both_ok)
 
@@ -246,21 +240,27 @@ def build_report(data: dict) -> str:
             g(base, "search", "ms_p50"),
             g(cand, "search", "ms_p50"),
             fmt_ms,
-            pct_delta(g(cand, "search", "ms_p50", default=0), g(base, "search", "ms_p50", default=0)),
+            pct_delta(
+                g(cand, "search", "ms_p50", default=0), g(base, "search", "ms_p50", default=0)
+            ),
         )
         hrow(
             "search p95 (ms)",
             g(base, "search", "ms_p95"),
             g(cand, "search", "ms_p95"),
             fmt_ms,
-            pct_delta(g(cand, "search", "ms_p95", default=0), g(base, "search", "ms_p95", default=0)),
+            pct_delta(
+                g(cand, "search", "ms_p95", default=0), g(base, "search", "ms_p95", default=0)
+            ),
         )
         hrow(
             "search mean (ms)",
             g(base, "search", "ms_mean"),
             g(cand, "search", "ms_mean"),
             fmt_ms,
-            pct_delta(g(cand, "search", "ms_mean", default=0), g(base, "search", "ms_mean", default=0)),
+            pct_delta(
+                g(cand, "search", "ms_mean", default=0), g(base, "search", "ms_mean", default=0)
+            ),
         )
         hrow(
             "on-disk size",
@@ -305,9 +305,7 @@ def build_report(data: dict) -> str:
         out.append("## Parity (turbovec vs. chroma top-k)")
         out.append("")
         out.append(f"- **Mean Jaccard@{cfg.get('top_k')}:** {parity['mean_jaccard']:.3f}")
-        out.append(
-            f"- **Mean recall of chroma's top-k by turbovec:** {parity['mean_recall']:.3f}"
-        )
+        out.append(f"- **Mean recall of chroma's top-k by turbovec:** {parity['mean_recall']:.3f}")
         out.append("")
         out.append("<details><summary>Per-query overlap</summary>")
         out.append("")
@@ -371,7 +369,9 @@ def build_report(data: dict) -> str:
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
     parser.add_argument("results", help="results JSON from benchmark_turbovec.py")
     parser.add_argument("--out", default="report.md", help="output Markdown path")
     args = parser.parse_args(argv)

--- a/report_turbovec.py
+++ b/report_turbovec.py
@@ -1,0 +1,389 @@
+#!/usr/bin/env python3
+"""report_turbovec.py — render a Markdown report from benchmark_turbovec.py JSON.
+
+    python report_turbovec.py results.json --out report.md
+
+The report contains:
+
+* **A one-line verdict** — 🟢 yes / 🟡 cautiously yes / 🛑 not yet / ⚪
+  inconclusive — derived from parity *and* performance signals.
+* **Environment provenance** — versions, platform, CPU count, repo size.
+* **Headline table** — indexing latency, search p50/p95/mean, on-disk size,
+  peak RSS, with signed-percent deltas (turbovec vs. chroma).
+* **Parity section** — mean Jaccard@k, recall of chroma's top-k by turbovec,
+  and a (collapsed) per-query overlap table.
+* **Per-query latency table** — side-by-side ms so a single regressing query
+  type is visible.
+* **Caveats** — first-run model download, what tracemalloc does/doesn't
+  capture, the experimental/POC label on turbovec.
+
+It is dependency-free (stdlib only) so it runs anywhere the JSON lands.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+BASELINE = "chroma"  # deltas are computed as candidate-vs-baseline
+CANDIDATE = "turbovec"
+
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+def pct_delta(candidate: float, baseline: float) -> str:
+    """Signed percent change of candidate relative to baseline, as a string."""
+    if baseline == 0:
+        return "n/a"
+    delta = (candidate - baseline) / baseline * 100.0
+    sign = "+" if delta >= 0 else ""
+    return f"{sign}{delta:.1f}%"
+
+
+def jaccard(a: list[str], b: list[str]) -> float:
+    sa, sb = set(a), set(b)
+    if not sa and not sb:
+        return 1.0
+    union = sa | sb
+    return len(sa & sb) / len(union) if union else 1.0
+
+
+def recall_of(reference: list[str], candidate: list[str]) -> float:
+    """Fraction of reference ids recovered by candidate."""
+    sr = set(reference)
+    if not sr:
+        return 1.0
+    return len(sr & set(candidate)) / len(sr)
+
+
+def fmt_mb(byte_count: float | int | None) -> str:
+    if byte_count is None:
+        return "—"
+    return f"{byte_count / 1e6:.1f} MB"
+
+
+def fmt_ms(value: float | None) -> str:
+    return "—" if value is None else f"{value:.2f}"
+
+
+def fmt_num(value) -> str:
+    return "—" if value is None else str(value)
+
+
+# --------------------------------------------------------------------------- #
+# Verdict
+# --------------------------------------------------------------------------- #
+def compute_verdict(parity: dict, headline: dict, both_ok: bool) -> tuple[str, str]:
+    if not both_ok:
+        return ("⚪ inconclusive", "One or both backends failed to complete — see the run log.")
+
+    jacc = parity["mean_jaccard"]
+    recall = parity["mean_recall"]
+
+    # Performance signals: lower is better for latency/disk/RSS.
+    search_p95 = headline["search_p95_delta_pct"]
+    disk = headline["disk_delta_pct"]
+    rss = headline["rss_delta_pct"]
+
+    perf_regressions = []
+    if search_p95 is not None and search_p95 > 10:
+        perf_regressions.append(f"search p95 {search_p95:+.0f}%")
+    if rss is not None and rss > 20:
+        perf_regressions.append(f"peak RSS {rss:+.0f}%")
+    if disk is not None and disk > 0:
+        perf_regressions.append(f"on-disk {disk:+.0f}%")
+
+    parity_good = jacc >= 0.70 and recall >= 0.80
+    parity_marginal = jacc >= 0.50 and recall >= 0.60
+
+    if parity_good and not perf_regressions:
+        return (
+            "🟢 yes",
+            f"turbovec is at parity (Jaccard@k {jacc:.2f}, recall {recall:.2f}) with no "
+            "performance regression — safe to adopt for this workload.",
+        )
+    if parity_good and perf_regressions:
+        return (
+            "🟡 cautiously yes",
+            f"parity holds (Jaccard@k {jacc:.2f}, recall {recall:.2f}) but watch: "
+            + ", ".join(perf_regressions)
+            + ".",
+        )
+    if parity_marginal:
+        return (
+            "🟡 cautiously yes",
+            f"parity is marginal (Jaccard@k {jacc:.2f}, recall {recall:.2f}); "
+            "validate against the gold-set eval before relying on it.",
+        )
+    return (
+        "🛑 not yet",
+        f"parity is below tolerance (Jaccard@k {jacc:.2f}, recall {recall:.2f}); "
+        "results diverge too much from chroma for this workload.",
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Report assembly
+# --------------------------------------------------------------------------- #
+def build_report(data: dict) -> str:
+    env = data.get("environment", {})
+    cfg = data.get("config", {})
+    results = data.get("results", {})
+    base = results.get(BASELINE, {})
+    cand = results.get(CANDIDATE, {})
+    both_ok = bool(base.get("ok")) and bool(cand.get("ok"))
+
+    # ---- Parity (only meaningful if both ran) ------------------------------ #
+    parity = {"mean_jaccard": 0.0, "mean_recall": 0.0, "rows": []}
+    if both_ok:
+        bq = {row["query"]: row for row in base.get("per_query", [])}
+        cq = {row["query"]: row for row in cand.get("per_query", [])}
+        jaccs, recalls = [], []
+        for q in cfg.get("queries", []):
+            b_ids = bq.get(q, {}).get("top_ids", [])
+            c_ids = cq.get(q, {}).get("top_ids", [])
+            j = jaccard(b_ids, c_ids)
+            r = recall_of(b_ids, c_ids)
+            jaccs.append(j)
+            recalls.append(r)
+            parity["rows"].append({"query": q, "jaccard": j, "recall": r})
+        parity["mean_jaccard"] = sum(jaccs) / len(jaccs) if jaccs else 0.0
+        parity["mean_recall"] = sum(recalls) / len(recalls) if recalls else 0.0
+
+    # ---- Headline deltas --------------------------------------------------- #
+    def g(d: dict, *path, default=None):
+        cur = d
+        for key in path:
+            if not isinstance(cur, dict):
+                return default
+            cur = cur.get(key, default)
+        return cur
+
+    headline = {
+        "search_p95_delta_pct": None,
+        "disk_delta_pct": None,
+        "rss_delta_pct": None,
+    }
+    if both_ok:
+        b_p95 = g(base, "search", "ms_p95", default=0.0)
+        c_p95 = g(cand, "search", "ms_p95", default=0.0)
+        headline["search_p95_delta_pct"] = (
+            (c_p95 - b_p95) / b_p95 * 100.0 if b_p95 else None
+        )
+        b_disk = base.get("disk_bytes", 0) or 0
+        c_disk = cand.get("disk_bytes", 0) or 0
+        headline["disk_delta_pct"] = (
+            (c_disk - b_disk) / b_disk * 100.0 if b_disk else None
+        )
+        b_rss = base.get("peak_rss_mb", 0) or 0
+        c_rss = cand.get("peak_rss_mb", 0) or 0
+        headline["rss_delta_pct"] = (
+            (c_rss - b_rss) / b_rss * 100.0 if b_rss else None
+        )
+
+    verdict, rationale = compute_verdict(parity, headline, both_ok)
+
+    # ---- Markdown ---------------------------------------------------------- #
+    out: list[str] = []
+    out.append("# TurboVec vs. ChromaDB — memory/latency benchmark")
+    out.append("")
+    out.append(f"**Verdict: {verdict}** — {rationale}")
+    out.append("")
+    out.append(f"_Generated from `{data.get('generated_at', 'unknown time')}` run._")
+    out.append("")
+
+    # Environment
+    out.append("## Environment")
+    out.append("")
+    out.append("| | |")
+    out.append("|---|---|")
+    rows = [
+        ("neuralmind", env.get("neuralmind")),
+        ("turbovec", env.get("turbovec")),
+        ("chromadb", env.get("chromadb")),
+        ("onnxruntime", env.get("onnxruntime")),
+        ("tokenizers", env.get("tokenizers")),
+        ("numpy", env.get("numpy")),
+        ("Python", env.get("python")),
+        ("platform", env.get("platform")),
+        ("CPU count", env.get("cpu_count")),
+        ("repo", env.get("repo")),
+        ("source files", env.get("source_files")),
+        ("graph nodes", env.get("graph_nodes")),
+        ("graph links", env.get("graph_links")),
+    ]
+    for k, v in rows:
+        out.append(f"| {k} | {fmt_num(v)} |")
+    out.append("")
+    out.append(
+        f"_Config: top_k={cfg.get('top_k')}, repeat={cfg.get('repeat')}, "
+        f"warmup={cfg.get('warmup')}, queries={len(cfg.get('queries', []))}, "
+        f"synthetic={cfg.get('synthetic')}._"
+    )
+    out.append("")
+
+    # Headline table
+    out.append("## Headline")
+    out.append("")
+    out.append(f"| metric | {BASELINE} | {CANDIDATE} | Δ ({CANDIDATE} vs {BASELINE}) |")
+    out.append("|---|---:|---:|---:|")
+
+    def hrow(label, b_val, c_val, fmt, delta_str):
+        out.append(f"| {label} | {fmt(b_val)} | {fmt(c_val)} | {delta_str} |")
+
+    if both_ok:
+        hrow(
+            "indexing latency (s)",
+            base.get("index_seconds"),
+            cand.get("index_seconds"),
+            lambda v: fmt_ms(v),
+            pct_delta(cand.get("index_seconds", 0), base.get("index_seconds", 0)),
+        )
+        hrow(
+            "search p50 (ms)",
+            g(base, "search", "ms_p50"),
+            g(cand, "search", "ms_p50"),
+            fmt_ms,
+            pct_delta(g(cand, "search", "ms_p50", default=0), g(base, "search", "ms_p50", default=0)),
+        )
+        hrow(
+            "search p95 (ms)",
+            g(base, "search", "ms_p95"),
+            g(cand, "search", "ms_p95"),
+            fmt_ms,
+            pct_delta(g(cand, "search", "ms_p95", default=0), g(base, "search", "ms_p95", default=0)),
+        )
+        hrow(
+            "search mean (ms)",
+            g(base, "search", "ms_mean"),
+            g(cand, "search", "ms_mean"),
+            fmt_ms,
+            pct_delta(g(cand, "search", "ms_mean", default=0), g(base, "search", "ms_mean", default=0)),
+        )
+        hrow(
+            "on-disk size",
+            base.get("disk_bytes"),
+            cand.get("disk_bytes"),
+            fmt_mb,
+            pct_delta(cand.get("disk_bytes", 0), base.get("disk_bytes", 0)),
+        )
+        hrow(
+            "peak RSS",
+            base.get("peak_rss_mb"),
+            cand.get("peak_rss_mb"),
+            lambda v: "—" if v is None else f"{v:.1f} MB",
+            pct_delta(cand.get("peak_rss_mb", 0), base.get("peak_rss_mb", 0)),
+        )
+        hrow(
+            "tracemalloc peak (Python)",
+            base.get("tracemalloc_peak_mb"),
+            cand.get("tracemalloc_peak_mb"),
+            lambda v: "—" if v is None else f"{v:.1f} MB",
+            pct_delta(cand.get("tracemalloc_peak_mb", 0), base.get("tracemalloc_peak_mb", 0)),
+        )
+    else:
+        out.append("| _backend(s) failed — see below_ | | | |")
+    out.append("")
+    out.append(
+        "_Negative Δ favours turbovec for latency/size/memory. Peak RSS is the "
+        "ground-truth memory number; tracemalloc only sees Python objects._"
+    )
+    out.append("")
+
+    # Failures
+    for name, res in results.items():
+        if not res.get("ok"):
+            out.append(f"### ⚠️ Backend `{name}` failed")
+            out.append("")
+            out.append(f"```\n{res.get('error', 'unknown error')}\n```")
+            out.append("")
+
+    # Parity
+    if both_ok:
+        out.append("## Parity (turbovec vs. chroma top-k)")
+        out.append("")
+        out.append(f"- **Mean Jaccard@{cfg.get('top_k')}:** {parity['mean_jaccard']:.3f}")
+        out.append(
+            f"- **Mean recall of chroma's top-k by turbovec:** {parity['mean_recall']:.3f}"
+        )
+        out.append("")
+        out.append("<details><summary>Per-query overlap</summary>")
+        out.append("")
+        out.append("| query | Jaccard | recall |")
+        out.append("|---|---:|---:|")
+        for row in parity["rows"]:
+            out.append(f"| {row['query']} | {row['jaccard']:.2f} | {row['recall']:.2f} |")
+        out.append("")
+        out.append("</details>")
+        out.append("")
+
+        # Per-query latency
+        out.append("## Per-query latency (ms)")
+        out.append("")
+        out.append(
+            f"| query | {BASELINE} p50 | {CANDIDATE} p50 | {BASELINE} p95 | {CANDIDATE} p95 |"
+        )
+        out.append("|---|---:|---:|---:|---:|")
+        bq = {row["query"]: row for row in base.get("per_query", [])}
+        cq = {row["query"]: row for row in cand.get("per_query", [])}
+        for q in cfg.get("queries", []):
+            b = bq.get(q, {})
+            c = cq.get(q, {})
+            out.append(
+                f"| {q} | {fmt_ms(b.get('ms_p50'))} | {fmt_ms(c.get('ms_p50'))} | "
+                f"{fmt_ms(b.get('ms_p95'))} | {fmt_ms(c.get('ms_p95'))} |"
+            )
+        out.append("")
+
+    # Caveats
+    out.append("## Caveats")
+    out.append("")
+    out.append(
+        "- **First-run model download.** turbovec's first run fetches the "
+        "`all-MiniLM-L6-v2` ONNX model (~90 MB) unless `NEURALMIND_ONNX_MODEL_DIR` "
+        "is pre-staged. Both backends share the same model, so warm-run latency "
+        "excludes this."
+    )
+    out.append(
+        "- **tracemalloc only sees Python allocations.** numpy buffers, "
+        "onnxruntime's session arena, and SQLite page cache show up in RSS but "
+        "not tracemalloc. Trust the **peak RSS** number for real memory cost; "
+        "treat tracemalloc as a hint about the Python-object share."
+    )
+    out.append(
+        "- **`ru_maxrss` units differ** (KB on Linux, bytes on macOS) — the "
+        "benchmark normalises to MB before reporting."
+    )
+    out.append(
+        "- **Recall here is recall-vs-chroma**, which assumes chroma is correct. "
+        "For ground-truth recall run NeuralMind's gold-set eval (`evals/`)."
+    )
+    out.append(
+        "- **turbovec is experimental (POC, issue #204).** This is a single-"
+        "threaded, warm-cache, query-level sanity check — not a replacement for "
+        "the faithfulness gold set, and it doesn't measure concurrent load."
+    )
+    out.append("")
+
+    return "\n".join(out)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("results", help="results JSON from benchmark_turbovec.py")
+    parser.add_argument("--out", default="report.md", help="output Markdown path")
+    args = parser.parse_args(argv)
+
+    data = json.loads(Path(args.results).read_text(encoding="utf-8"))
+    report = build_report(data)
+
+    out = Path(args.out)
+    out.write_text(report, encoding="utf-8")
+    print(f"Wrote {out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What

Ships the v0.21.0 release-notes follow-up — *"A large-synthetic-repo memory/latency benchmark is a follow-up."* — as a standalone two-script toolkit comparing the `chroma` and `turbovec` backends from `neuralmind.backend_manager.create_backend`.

## Why

v0.21.0 made `turbovec` fully ChromaDB-free but only reported *faithfulness* parity (gold-set eval). It never quantified the memory/latency/disk story that motivates dropping ChromaDB. This toolkit measures exactly that, on the same graph with identical queries.

## What's in it

- **`benchmark_turbovec.py`** — generates a 600-file synthetic repo (or runs against a real `--repo`), builds `graph.json` via the built-in tree-sitter generator (no `graphify` needed), then runs **each backend in its own spawn-context subprocess**. Isolation matters: chroma's heavy transitive import tree (FastAPI, OpenTelemetry, grpcio…) never inflates the turbovec RSS measurement, a crash in one doesn't tank the other, and `getrusage(RUSAGE_SELF)` reads a clean per-process high-water mark. Captures indexing latency, search p50/p95/mean (overall + per-query), on-disk index size, peak RSS (normalized KB-on-Linux / bytes-on-macOS → MB), tracemalloc peak, and per-query top-k ids for parity.
- **`report_turbovec.py`** — stdlib-only Markdown report: a one-line verdict (🟢 / 🟡 / 🛑 / ⚪) from parity + perf signals, environment provenance, headline deltas, mean Jaccard@k + recall-of-chroma's-top-k, per-query latency table, and caveats.
- **`BENCHMARK_TURBOVEC.md`** — usage, flags, verdict thresholds, and explicit out-of-scope notes; cross-linked from `RELEASE_NOTES_v0.21.0.md`.

## Usage

```bash
pip install "neuralmind[turbovec]==0.21.0" psutil
python benchmark_turbovec.py --out results.json
python report_turbovec.py results.json --out report.md
```

## Testing

The heavy extras (turbovec/onnxruntime/chromadb) aren't installed in the dev container, so the full backend run couldn't execute here. Validated the dependency-free parts:

- both scripts `py_compile` clean;
- synthetic repo generation produces 600 valid, AST-parseable Python modules (610 source files incl. package `__init__`s);
- `report_turbovec.py` renders correctly for the happy path, the failed-backend path (⚪ inconclusive), and exercises the verdict thresholds.

A real end-to-end run on a machine with the `[turbovec]` extra is the remaining validation step before un-drafting.

https://claude.ai/code/session_017smQfbDWHDpdaePRiz8nVn

---
_Generated by [Claude Code](https://claude.ai/code/session_017smQfbDWHDpdaePRiz8nVn)_