### PR TITLE
perf(turbovec): skip numpy→list→numpy round-trip when indexing

### DIFF
--- a/neuralmind/turbovec_backend.py
+++ b/neuralmind/turbovec_backend.py
@@ -137,6 +137,22 @@ class TurboVecEmbedder(EmbeddingBackend):
             self._embed_fn = _default_embed_fn()
         return self._embed_fn
 
+    def _embed_matrix(self, texts: list[str]) -> np.ndarray:
+        """Embed ``texts`` into an ``(n, dim)`` array, numpy-native where possible.
+
+        The default ``OnnxMiniLMEmbedder`` exposes ``embed()`` returning an
+        ``ndarray`` directly. Its ``__call__`` (the ChromaDB-compatible interface)
+        instead returns ``list[list[float]]`` via ``.tolist()`` — and the caller
+        immediately rebuilds an array from it. For a large graph that round-trip
+        materialises one Python ``float`` per element (n × 384), ~150 MB of
+        transient heap that inflates peak RSS during indexing. Prefer ``embed()``
+        when the embedder offers it; injected callables still work via the
+        ``__call__`` fallback.
+        """
+        fn = self.embed_fn
+        embed = getattr(fn, "embed", None)
+        return embed(texts) if callable(embed) else fn(texts)
+
     @property
     def project_path(self) -> Path:
         return self._project_path
@@ -268,7 +284,7 @@ class TurboVecEmbedder(EmbeddingBackend):
             self._conn.commit()
             return stats
 
-        vectors = _l2_normalize(self.embed_fn([p[2] for p in pending]))
+        vectors = _l2_normalize(self._embed_matrix([p[2] for p in pending]))
         dim = vectors.shape[1]
         idx = self._ensure_index(dim)
 
@@ -361,7 +377,7 @@ class TurboVecEmbedder(EmbeddingBackend):
 
         total = self._conn.execute("SELECT COUNT(*) AS c FROM nodes").fetchone()["c"]
         k = max(1, min(n, allowlist.size if allowlist is not None else total))
-        q = _l2_normalize(self.embed_fn([query]))
+        q = _l2_normalize(self._embed_matrix([query]))
 
         try:
             scores, ids = idx.search(q, k, allowlist=allowlist)

--- a/tests/test_turbovec_backend.py
+++ b/tests/test_turbovec_backend.py
@@ -179,6 +179,34 @@ class TurboVecBackendTests(unittest.TestCase):
         self.assertGreaterEqual(stats["communities"], 1)
         be.close()
 
+    def test_prefers_numpy_native_embed_over_tolist(self) -> None:
+        """An embedder exposing ``embed()`` is used numpy-native, skipping the
+        ``__call__`` → ``list[list[float]]`` round-trip that inflated peak RSS.
+        """
+
+        class NdEmbedder:
+            def __init__(self) -> None:
+                self.embed_calls = 0
+                self.call_calls = 0
+
+            def embed(self, texts: list[str]) -> np.ndarray:
+                self.embed_calls += 1
+                return np.asarray(_fake_embed(texts), dtype=np.float32)
+
+            def __call__(self, texts: list[str]) -> list[list[float]]:
+                self.call_calls += 1
+                return _fake_embed(texts)
+
+        emb = NdEmbedder()
+        be = TurboVecEmbedder(str(self.root), db_path=self.db, embed_fn=emb)
+        be.embed_nodes()
+        results = be.search("authenticate_user", n=1)
+        self.assertEqual(results[0]["id"], "n_auth")
+        # embed() carried the work for both indexing and the query; __call__ unused.
+        self.assertGreaterEqual(emb.embed_calls, 2)
+        self.assertEqual(emb.call_calls, 0)
+        be.close()
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## What

Follow-up to the benchmark toolkit merged in #211. That benchmark surfaced exactly one regression for the `turbovec` backend — and it turned out to be a fixable artifact, not an inherent cost. This fixes it.

## The finding

On a 600-file / 10,220-node synthetic repo, turbovec's **peak RSS during indexing was ~50% higher than chroma** (1393 MB vs 927 MB), with tracemalloc peak +260%. Everything else favored turbovec (search ~5× faster, disk ~7× smaller), so this was the one thing standing between it and the v0.22 default-flip decision.

## Root cause

The default embedder is `OnnxMiniLMEmbedder`, whose `__call__` (the ChromaDB-compatible interface) returns `list[list[float]]` via `.tolist()`. `embed_nodes` then immediately rebuilds an ndarray from it (`_l2_normalize` → `np.asarray`). For a large graph that round-trip materialises **one Python `float` per element** (n × 384 ≈ 3.9M objects) — ~150 MB of transient heap that drives up the high-water mark. `OnnxMiniLMEmbedder.embed()` already returns a normalised ndarray directly, so the list hop is pure waste.

## Fix

Add `_embed_matrix()`, which prefers the embedder's numpy-native `embed()` when present and falls back to `__call__` for injected callables (tests, custom embedders). Route both the indexing and query embed paths through it. **Output is unchanged** — embeddings stay byte-identical (`embed()` applies the same L2 normalisation), so retrieval parity is fully preserved.

## Re-measured (same synthetic repo, after the fix)

| metric | before | after | Δ |
|---|---:|---:|---:|
| peak RSS | 1393 MB | **850 MB** | **−39%** (now below chroma's 927 MB) |
| tracemalloc peak | 160 MB | **64 MB** | **−60%** |
| on-disk size | 6.3 MB | 6.3 MB | unchanged |
| search latency | ~5× faster than chroma | unchanged | — |
| retrieval results | — | byte-identical | parity preserved |

The +50% RSS regression is gone — flipped to a ~8% win — so turbovec is now faster on search, smaller on disk, **and** lower peak RSS than chroma.

## Tests

- Added `test_prefers_numpy_native_embed_over_tolist` — asserts an embedder exposing `embed()` is used numpy-native (and `__call__` is never hit), with search results unchanged.
- Existing 7 turbovec tests still pass (the bag-of-words fake is a plain callable, exercising the `__call__` fallback).
- Black + Ruff clean.

🤖 Validated by actually running both backends locally (`chromadb 1.5.9`, `turbovec 0.7.0`, `onnxruntime 1.26.0`).

https://claude.ai/code/session_017smQfbDWHDpdaePRiz8nVn

---
_Generated by [Claude Code](https://claude.ai/code/session_017smQfbDWHDpdaePRiz8nVn)_