### PR TITLE
refactor(backend): import NeuralMind without ChromaDB (v0.22 groundwork)

### DIFF
--- a/neuralmind/__init__.py
+++ b/neuralmind/__init__.py
@@ -18,7 +18,11 @@ warnings.filterwarnings("ignore", module="posthog")
 
 # Suppress posthog/chromadb telemetry noise. Must be CRITICAL because the
 # "Failed to send telemetry event" messages are emitted as logger.error(),
-# and ERROR-level filter lets ERROR messages through.
+# and ERROR-level filter lets ERROR messages through. Setting logger levels +
+# env vars here is import-free (no chromadb dependency); the actual posthog
+# monkey-patch happens lazily inside ``embedder`` when the chroma backend is
+# constructed, so merely importing ``neuralmind`` no longer pulls in ChromaDB.
+# See ``embedder._silence_chroma_telemetry``.
 for _logger_name in (
     "posthog",
     "chromadb.telemetry",
@@ -26,19 +30,6 @@ for _logger_name in (
     "chromadb.telemetry.product.posthog",
 ):
     logging.getLogger(_logger_name).setLevel(logging.CRITICAL)
-
-# Belt-and-suspenders: monkey-patch chromadb's Posthog client capture() to be
-# a silent no-op. This defends against any chromadb version where the logger
-# hierarchy doesn't propagate as expected.
-try:
-    from chromadb.telemetry.product.posthog import Posthog as _ChromaPosthog
-
-    def _noop_capture(self, *args, **kwargs):  # pragma: no cover
-        return None
-
-    _ChromaPosthog.capture = _noop_capture
-except Exception:  # pragma: no cover
-    pass
 
 """
 NeuralMind - Adaptive Neural Knowledge System
@@ -75,7 +66,6 @@ from .compressors import (
 )
 from .context_selector import ContextSelector
 from .core import NeuralMind
-from .embedder import GraphEmbedder
 from .embedding_backend import EmbeddingBackend
 from .hooks import install_hooks
 from .in_memory_backend import InMemoryEmbeddingBackend
@@ -112,3 +102,20 @@ __all__ = [
     "export_synapse_memory",
     "project_memory_file",
 ]
+
+
+def __getattr__(name: str):
+    """Lazily expose ``GraphEmbedder`` without importing ChromaDB at package load.
+
+    ``GraphEmbedder`` lives in :mod:`neuralmind.embedder`, which imports ChromaDB
+    at module level. Importing it eagerly here would make ``import neuralmind``
+    require ChromaDB — the exact coupling v0.22 removes so the package (and the
+    ChromaDB-free ``turbovec`` backend) can run without it. PEP 562 module-level
+    ``__getattr__`` keeps ``from neuralmind import GraphEmbedder`` working for
+    back-compat while deferring the (ChromaDB-pulling) import to first access.
+    """
+    if name == "GraphEmbedder":
+        from .embedder import GraphEmbedder
+
+        return GraphEmbedder
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/neuralmind/embedder.py
+++ b/neuralmind/embedder.py
@@ -24,6 +24,30 @@ from chromadb.config import Settings
 from .embedding_backend import EmbeddingBackend
 
 
+def _silence_chroma_telemetry() -> None:
+    """Monkey-patch ChromaDB's Posthog ``capture()`` to a silent no-op.
+
+    Belt-and-suspenders against any chromadb version whose telemetry logger
+    hierarchy doesn't propagate as expected (env vars + CRITICAL log levels are
+    set in :mod:`neuralmind.__init__`). Lives here — next to the only
+    module-level ``import chromadb`` — so it runs exactly when the chroma
+    backend is loaded, and never when merely importing the ``neuralmind``
+    package (which must stay ChromaDB-free as of v0.22).
+    """
+    try:
+        from chromadb.telemetry.product.posthog import Posthog as _ChromaPosthog
+
+        def _noop_capture(self, *args, **kwargs):  # pragma: no cover
+            return None
+
+        _ChromaPosthog.capture = _noop_capture
+    except Exception:  # pragma: no cover
+        pass
+
+
+_silence_chroma_telemetry()
+
+
 class GraphEmbedder(EmbeddingBackend):
     """
     Embeds graphify graph.json nodes into ChromaDB for semantic search.

--- a/tests/test_turbovec_backend.py
+++ b/tests/test_turbovec_backend.py
@@ -11,6 +11,7 @@ deletion), not embedding quality.
 
 from __future__ import annotations
 
+import hashlib
 import importlib.util
 import json
 import sys
@@ -40,13 +41,20 @@ _DIM = 32
 _VOCAB_TOKENS = ("auth", "login", "billing", "invoice", "user", "db", "token", "refund")
 
 
+def _stable_bucket(tok: str) -> int:
+    """Process-stable token→bucket (unlike ``hash()``, which PYTHONHASHSEED
+    randomises per run — the source of prior flakiness in these tests)."""
+    digest = hashlib.md5(tok.encode("utf-8")).digest()
+    return int.from_bytes(digest[:4], "little") % _DIM
+
+
 def _fake_embed(texts: list[str]) -> list[list[float]]:
     """Deterministic bag-of-words hashing embedder (no model needed)."""
     out = []
     for t in texts:
         vec = np.zeros(_DIM, dtype=np.float32)
         for tok in t.lower().replace("\n", " ").split():
-            vec[hash(tok) % _DIM] += 1.0
+            vec[_stable_bucket(tok)] += 1.0
         out.append(vec.tolist())
     return out
 


### PR DESCRIPTION
## What

First staged step of the v0.22 plan (from `RELEASE_NOTES_v0.21.0.md`): **`import neuralmind` no longer pulls in ChromaDB.** Prerequisite for v0.23 dropping `chromadb` from the core dependency list.

## The two couplings removed

1. **Eager `GraphEmbedder` import.** `__init__.py` did `from .embedder import GraphEmbedder`, and `embedder.py` imports `chromadb` at module level → bare `import neuralmind` required chromadb. Now exposed via PEP 562 module-level `__getattr__`, so `from neuralmind import GraphEmbedder` still works but defers the chromadb-pulling import to first access.
2. **Eager telemetry monkey-patch.** `__init__.py` imported chromadb's Posthog client to silence its telemetry `capture()`. Moved into `embedder._silence_chroma_telemetry()`, invoked at embedder module load — exactly when the chroma backend is used, never on a bare import. The import-free env-var + CRITICAL log-level suppression stays in `__init__` (so it's set before any later chromadb import).

## Not a behavior change for current users

ChromaDB is **still a core dependency** — still installed, still the default backend. This only removes the *import-time* requirement. The payoff lands in v0.23 when chromadb leaves the core deps; this is the decoupling that makes that safe.

## Verified

- `import neuralmind` succeeds with **chromadb entirely absent** (simulated by blocking the import) — version resolves, `create_backend` importable.
- `import neuralmind` no longer adds `chromadb` to `sys.modules`; `neuralmind.GraphEmbedder` lazy-loads it on first access; unknown attrs still raise `AttributeError`.
- Backend-manager, turbovec, and doctor suites pass; lint clean; no new mypy errors.

## Also: fixed a latent flaky test (separate commit)

`tests/test_turbovec_backend.py`'s `_fake_embed` bucketed tokens with builtin `hash()`, which Python randomises per process. With no `PYTHONHASHSEED` pinned in CI, the suite passed only on seeds where token→dim collisions happened to preserve the expected ranking (seed 0 fails `test_persistence_reload`, seed 2 fails `test_search_ranks_relevant_node_first`). Replaced with a stable md5 bucket — green across seeds 0,1,2,3,4,5,7,13,42. (Surfaced while validating this PR locally; pre-existing on main.)

## Next (the consequential part — asking before I build it)

This PR is the safe groundwork. The v0.22 headline — **flipping the default to turbovec with a chroma fallback + reindex migration** — changes every user's default backend, so I'm confirming the design with the maintainer before implementing it rather than guessing.

https://claude.ai/code/session_017smQfbDWHDpdaePRiz8nVn

---
_Generated by [Claude Code](https://claude.ai/code/session_017smQfbDWHDpdaePRiz8nVn)_