### PR TITLE
fix: stop suggesting graphify update as the fix for a missing graph

### DIFF
--- a/docs/wiki/CLI-Reference.md
+++ b/docs/wiki/CLI-Reference.md
@@ -661,7 +661,7 @@ JSON output (`--json`) is stable for scripting and agent consumption:
   "checks": [
     {"name": "Code graph", "status": "fail",
      "detail": "not found at /repo/graphify-out/graph.json",
-     "fix": "Generate it: graphify update /repo"}
+     "fix": "Generate it: neuralmind build /repo"}
   ]
 }
 ```

--- a/neuralmind/_demo_report.py
+++ b/neuralmind/_demo_report.py
@@ -154,9 +154,9 @@ def run_demo_report(
     print(" Real repos consistently hit 40–70× on the same pipeline.")
     print()
     print(" Try it on YOUR code:")
-    print("   pip install neuralmind graphifyy")
+    print("   pip install neuralmind")
     print("   cd /path/to/your-repo")
-    print("   graphify update . && neuralmind build .")
+    print("   neuralmind build .")
     print("   neuralmind benchmark . --contribute")
     print()
     return 0

--- a/neuralmind/core.py
+++ b/neuralmind/core.py
@@ -71,7 +71,8 @@ def validate_project(project_path: str | Path, *, write: bool = False) -> dict:
                 "ok": False,
                 "error": (
                     f"No index found for {project_path}. Run `neuralmind build` "
-                    f"first (or `graphify update {project_path}`)."
+                    f"first (or `graphify update {project_path}` if you use "
+                    f"the optional graphify backend)."
                 ),
             }
     except ir_mod.IRError as exc:

--- a/neuralmind/doctor.py
+++ b/neuralmind/doctor.py
@@ -52,7 +52,7 @@ def _check_graph(project: Path) -> Check:
             "Code graph",
             FAIL,
             f"not found at {graph}",
-            fix=f"Generate it: graphify update {project}",
+            fix=f"Generate it: neuralmind build {project}",
         )
     try:
         nodes = len(json.loads(graph.read_text(encoding="utf-8")).get("nodes", []))
@@ -61,7 +61,7 @@ def _check_graph(project: Path) -> Check:
             "Code graph",
             FAIL,
             f"unreadable ({e})",
-            fix=f"Regenerate it: graphify update {project}",
+            fix=f"Regenerate it: neuralmind build {project}",
         )
     return Check("Code graph", OK, f"{nodes} nodes at {graph}")
 

--- a/neuralmind/server.py
+++ b/neuralmind/server.py
@@ -490,9 +490,11 @@ def _ensure_graph_or_explain(project_path: Path) -> None:
     msg = (
         f"no graph found at {graph_path}\n"
         f"\n"
-        f"NeuralMind needs a graphify build first. To generate one:\n"
-        f"  pip install graphifyy        # if not already installed\n"
-        f"  graphify update {project_path}\n"
+        f"NeuralMind needs a code graph first. To generate one:\n"
+        f"  neuralmind build {project_path}\n"
+        f"\n"
+        f"(On the optional graphify backend? Run:\n"
+        f"  pip install graphifyy && graphify update {project_path})\n"
         f"\n"
         f"Then re-run: neuralmind serve {project_path}"
     )

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -47,7 +47,7 @@ def test_graph_check_ok_when_present(temp_project):
 def test_graph_check_fail_when_missing(empty_project):
     check = doctor._check_graph(empty_project)
     assert check.status == doctor.FAIL
-    assert "graphify update" in check.fix
+    assert "neuralmind build" in check.fix
 
 
 def test_graph_check_fail_when_corrupt(empty_project):
@@ -56,7 +56,7 @@ def test_graph_check_fail_when_corrupt(empty_project):
     (out / "graph.json").write_text("{ not valid json", encoding="utf-8")
     check = doctor._check_graph(empty_project)
     assert check.status == doctor.FAIL
-    assert "graphify update" in check.fix
+    assert "neuralmind build" in check.fix
 
 
 def test_index_check_fail_when_not_built(temp_project):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -54,9 +54,12 @@ def test_ensure_graph_or_explain_missing(tmp_path):
         _ensure_graph_or_explain(tmp_path)
     msg = str(exc.value)
     assert "no graph found" in msg
-    # The supported graphify entrypoint is `graphify update`; the package
-    # on PyPI is `graphifyy` (yes, two y's). Lock in both so we don't
-    # quietly regress to the deprecated `graphify build` guidance.
+    # The primary fix is the built-in backend; graphify stays as the
+    # qualified optional alternative. The PyPI package is `graphifyy`
+    # (yes, two y's) and the supported entrypoint is `graphify update` —
+    # lock all three in so we don't regress to graphify-as-required or
+    # to the deprecated `graphify build` guidance.
+    assert "neuralmind build" in msg
     assert "graphifyy" in msg
     assert "graphify update" in msg
 


### PR DESCRIPTION
Final code follow-up from the adoption audit: since v0.15.0 the built-in tree-sitter backend generates the code graph, but four user-facing messages still told users the fix for a missing graph was the optional `graphify` tool.

## Changes

- **`doctor`** — the "Code graph" check's fix command is now `neuralmind build <project>` for both the missing and the corrupt `graph.json` cases (was `graphify update <project>`).
- **`serve`** — the no-graph startup error now leads with `neuralmind build` and demotes graphify (`pip install graphifyy && graphify update …`) to a clearly-qualified optional alternative.
- **`validate`** — the no-index error's graphify parenthetical is now qualified as the optional backend.
- **demo report** — the "Try it on YOUR code" epilogue drops `graphifyy` from the install line and `graphify update` from the build line, matching the README quickstart.

The query-path `GraphNotBuiltError` already had the correct framing (build first, graphify as an explicit alternative) and is unchanged.

## Tests & docs

- `tests/test_doctor.py`: the two graph-check assertions now lock in `neuralmind build`.
- `tests/test_server.py`: now asserts the primary fix **and** keeps the existing `graphifyy` / `graphify update` spelling locks so the optional path can't regress to `graphify build`.
- `docs/wiki/CLI-Reference.md`: the doctor JSON example updated to match the real output (it was deliberately left matching the old code in #222).

All 36 tests in `test_doctor.py` + `test_server.py` pass locally.

Also closes out the audit's security item context: chromadb still has **no patched release** for CVE-2026-45829 (verified today: 1.5.9 is both latest and last_affected), so the pinned-requirements comment remains accurate and the Dependabot alert needs a manual dismissal rather than a version bump.

https://claude.ai/code/session_01FkHXHcjpWZL2EWn4HGi547

---
_Generated by [Claude Code](https://claude.ai/code/session_01FkHXHcjpWZL2EWn4HGi547)_