### PR TITLE
docs: mark v0.23.0 as the latest release on the landing page

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>NeuralMind — Persistent Memory for AI Coding Agents | 40–70× Token Reduction</title>
-    <meta name="description" content="NeuralMind: Persistent memory for AI coding agents. A brain-like synapse layer learns your codebase from how you actually use it — what files go together, what you usually edit next — and surfaces it automatically on every session. 100% local code indexing with 40–70× per-query token reduction, an Obsidian-style graph view, and PostToolUse hooks that compress tool output and let agents recover dropped middle content without re-running. One-command MCP setup (neuralmind install-mcp auto-detects and registers with Claude Code, Cursor, Cline, Claude Desktop); the bundled tree-sitter backend indexes Python, TypeScript, and Go with no external graphify install, plus incremental updates and an optional SCIP precision pass — all proven by a CI parity gate. neuralmind eval measures answer faithfulness and onboarding lift 100% locally. v0.22 imports without ChromaDB and defaults to an auto backend that prefers the ChromaDB-free turbovec path when available. NIST AI RMF compliant.">
+    <meta name="description" content="NeuralMind: Persistent memory for AI coding agents. A brain-like synapse layer learns your codebase from how you actually use it — what files go together, what you usually edit next — and surfaces it automatically on every session. 100% local code indexing with 40–70× per-query token reduction, an Obsidian-style graph view, and PostToolUse hooks that compress tool output and let agents recover dropped middle content without re-running. One-command MCP setup (neuralmind install-mcp auto-detects and registers with Claude Code, Cursor, Cline, Claude Desktop); the bundled tree-sitter backend indexes Python, TypeScript, and Go with no external graphify install, plus incremental updates and an optional SCIP precision pass — all proven by a CI parity gate. neuralmind eval measures answer faithfulness and onboarding lift 100% locally. v0.22 imports without ChromaDB and defaults to an auto backend that prefers the ChromaDB-free turbovec path when available. v0.23 adds a schema-versioned index contract checked by neuralmind validate, a retrieval-quality CI gate (precision@k / recall@k / MRR), query --trace explainability, and an experimental local daemon. NIST AI RMF compliant.">
     <meta name="keywords" content="semantic code search, AI coding agents, token optimization, code intelligence, local-first, NIST AI RMF, Claude, Cursor, MCP server, graph view, neuralmind serve, Obsidian-style code graph, force-directed graph, synapse layer, Hebbian learning, directional transitions, transition matrix, next-file prediction, code visualization, tool output recovery, bash output cache, agent ergonomics, claude code hooks, install doctor, health check, agent onboarding, faithfulness eval, retrieval quality evaluation, offline llm eval, polyglot code fixtures, typescript code graph, go code graph, neuralmind eval, answer faithfulness, faithfulness delta, tree-sitter, tree-sitter graph backend, built-in code graph, no graphify, standalone code indexing, graphify alternative, pluggable graph backend, backend parity gate, ast code graph, multi-language code intelligence, polyglot codebase indexing, typescript code intelligence, go code intelligence, scip, scip index, scip precision, compiler-accurate call graph, lsp code graph, precise call graph, incremental indexing, incremental code graph, watch mode reindex, live code index, mcp setup, install mcp server, claude code mcp, cursor mcp, cline mcp, claude desktop mcp, mcp auto-detection, onboarding lift, onboarding-lift eval, learned memory eval, synapse recall eval, team memory, agent onboarding eval, turbovec, turboquant, chromadb-free, chromadb alternative, onnx embeddings, vector quantization, compressed vector search, local embeddings, auto-backend-selection, default-backend, zero-dependency-import, chromadb-free by default, index ir, intermediate representation, versioned schema, index contract, neuralmind validate, index validation, dangling edges, orphaned nodes, schema migration, index integrity">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://dfrostar.github.io/neuralmind/">
@@ -26,7 +26,7 @@
       "description": "Persistent memory and semantic code intelligence for AI coding agents. Local-first code indexing with 40–70× per-query token reduction, a brain-like synapse layer that learns associations from how you use the codebase, an Obsidian-style graph view, an MCP server, and a built-in install doctor. Works with Claude Code, Cursor, Cline, Continue, and any MCP-compatible agent.",
       "url": "https://dfrostar.github.io/neuralmind/",
       "downloadUrl": "https://pypi.org/project/neuralmind/",
-      "softwareVersion": "0.22.0",
+      "softwareVersion": "0.23.0",
       "license": "https://opensource.org/licenses/MIT",
       "programmingLanguage": "Python",
       "operatingSystemRequirements": "Python 3.10+",
@@ -355,7 +355,7 @@
     </div>
     <div class="container hero-grid">
         <div>
-            <p class="badge"><span class="dot"></span> v0.22.0 — latest release&nbsp;·&nbsp;<a href="https://github.com/dfrostar/neuralmind/blob/main/RELEASE_NOTES_v0.22.0.md">release notes</a></p>
+            <p class="badge"><span class="dot"></span> v0.23.0 — latest release&nbsp;·&nbsp;<a href="https://github.com/dfrostar/neuralmind/blob/main/RELEASE_NOTES_v0.23.0.md">release notes</a></p>
             <h1>Persistent memory for <span class="grad">AI coding agents</span></h1>
             <p class="hero-sub">Your agent learns your codebase the way a senior engineer would — <strong>what files go together, what you usually edit next, what patterns matter</strong>. The memory persists across sessions and surfaces automatically.</p>
             <p class="hero-local"><strong>100% local.</strong> Your code never leaves your machine. Side effect: <strong>40–70× cheaper code questions</strong>, measured in CI on every commit.</p>
@@ -583,12 +583,12 @@ bash scripts/demo.sh">Copy</button>
         <h2>What's new</h2>
         <p class="lede">Shipped in small, verifiable increments — every release gated by the CI benchmark.</p>
         <div class="timeline">
-            <div class="tl-item dev">
-                <div class="tl-head"><b>v0.23.0</b><span class="pill pill-dev">In development</span></div>
-                <p>Four future-proofing foundations: a <b>schema-versioned index contract (IR)</b> checked by the new <code>neuralmind validate</code>, a <b>retrieval-quality harness</b> (<code>benchmark --quality</code>: precision@k / recall@k / MRR over 30 golden queries, failing CI on regression), <b>debug traces</b> (<code>query --trace</code> shows why a result came back), and an experimental <b>local daemon</b> that keeps project state warm. <a href="https://github.com/dfrostar/neuralmind/blob/main/RELEASE_NOTES_v0.23.0.md">Draft notes →</a></p>
+            <div class="tl-item">
+                <div class="tl-head"><b>v0.23.0</b><span class="pill pill-latest">Latest release</span></div>
+                <p>Four future-proofing foundations: a <b>schema-versioned index contract (IR)</b> checked by the new <code>neuralmind validate</code>, a <b>retrieval-quality harness</b> (<code>benchmark --quality</code>: precision@k / recall@k / MRR over 30 golden queries, failing CI on regression), <b>debug traces</b> (<code>query --trace</code> shows why a result came back), and an experimental <b>local daemon</b> that keeps project state warm. <a href="https://github.com/dfrostar/neuralmind/blob/main/RELEASE_NOTES_v0.23.0.md">Release notes →</a></p>
             </div>
             <div class="tl-item">
-                <div class="tl-head"><b>v0.22.0</b><span class="pill pill-latest">Latest release</span></div>
+                <div class="tl-head"><b>v0.22.0</b></div>
                 <p><b>ChromaDB-free by default.</b> <code>import neuralmind</code> no longer requires ChromaDB; the default <code>auto</code> backend prefers turbovec when its deps are installed, with a one-time auto-reindex and chroma fallback — nothing deleted. <a href="https://github.com/dfrostar/neuralmind/blob/main/RELEASE_NOTES_v0.22.0.md">Release notes →</a></p>
             </div>
             <div class="tl-item">


### PR DESCRIPTION
Follow-up to merging release PR #219: v0.23.0 is now tagged and published, so the landing page's version story needs to advance. Flips the hero badge, JSON-LD `softwareVersion`, the meta description, and the release-timeline pills from "v0.22.0 latest / v0.23.0 in development" to "v0.23.0 latest".

Docs-only, one file.

https://claude.ai/code/session_01FkHXHcjpWZL2EWn4HGi547

---
_Generated by [Claude Code](https://claude.ai/code/session_01FkHXHcjpWZL2EWn4HGi547)_