### PR TITLE
docs: add Google Search Console site-verification file

### DIFF
--- a/docs/google4af0b44a17447d3e.html
+++ b/docs/google4af0b44a17447d3e.html
@@ -1,0 +1,1 @@
+google-site-verification: google4af0b44a17447d3e.html


### PR DESCRIPTION
Adds the Google Search Console verification file at the Pages root so the URL-prefix property for `https://dfrostar.github.io/neuralmind/` can be verified. Required before submitting the rebuilt 46-URL sitemap (#236) for indexing.

Per Google's instructions the file must stay in place after verification succeeds.

https://claude.ai/code/session_01FkHXHcjpWZL2EWn4HGi547

---
_Generated by [Claude Code](https://claude.ai/code/session_01FkHXHcjpWZL2EWn4HGi547)_