### PR TITLE
fix: force UTF-8 stdout in CLI (Windows cp1252 crash)

### DIFF
--- a/neuralmind/cli.py
+++ b/neuralmind/cli.py
@@ -15,6 +15,21 @@ from neuralmind import memory
 from neuralmind.core import GraphNotBuiltError, NeuralMind, create_mind
 
 
+def _force_utf8_io() -> None:
+    """Force UTF-8 on stdout/stderr so non-ASCII output (arrows, em-dashes,
+    box-drawing glyphs in the context/report) doesn't crash on Windows consoles,
+    which default to the cp1252 codec and raise UnicodeEncodeError.
+
+    No-op where it isn't needed or possible: streams already UTF-8 (Linux/macOS)
+    or that lack ``reconfigure`` (e.g. pytest capture objects).
+    """
+    for stream in (sys.stdout, sys.stderr):
+        try:
+            stream.reconfigure(encoding="utf-8")
+        except (AttributeError, ValueError):
+            pass
+
+
 def cmd_build(args):
     project_path = args.project_path or "."
     force = args.force
@@ -1302,6 +1317,11 @@ fi
 
 
 def main():
+    # Windows consoles default to cp1252 and crash (UnicodeEncodeError) on the
+    # Unicode glyphs we print — and on the em-dash argparse prints in --help.
+    # Force UTF-8 before any output. No-op on Linux/macOS and under pytest capture.
+    _force_utf8_io()
+
     parser = argparse.ArgumentParser(
         description=(
             "NeuralMind — reduce Claude/GPT/Gemini token costs 40-70x on code questions. "

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,6 +7,41 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 
+class TestCLIEncoding:
+    """Regression tests for the Windows cp1252 stdout crash — UnicodeEncodeError
+    when printing arrows / em-dashes / box-drawing glyphs (e.g. `neuralmind query`
+    output, and the em-dash in argparse --help) to a cp1252 console."""
+
+    def test_force_utf8_io_lets_cp1252_stream_print_non_ascii(self, monkeypatch):
+        import io
+
+        from neuralmind.cli import _force_utf8_io
+
+        buf = io.BytesIO()
+        # A cp1252 text stream raises UnicodeEncodeError on these glyphs...
+        cp1252_stream = io.TextIOWrapper(buf, encoding="cp1252", newline="")
+        monkeypatch.setattr(sys, "stdout", cp1252_stream)
+
+        _force_utf8_io()
+
+        # ...but after the reconfigure the same print must succeed as UTF-8.
+        # → = →, — = em-dash, ─ = box-drawing, é = é
+        glyphs = "→ — ─ café"
+        print(glyphs)
+        sys.stdout.flush()
+        assert glyphs.encode("utf-8") in buf.getvalue()
+
+    def test_force_utf8_io_is_noop_when_reconfigure_missing(self, monkeypatch):
+        from neuralmind.cli import _force_utf8_io
+
+        class _NoReconfigure:
+            pass
+
+        monkeypatch.setattr(sys, "stdout", _NoReconfigure())
+        monkeypatch.setattr(sys, "stderr", _NoReconfigure())
+        _force_utf8_io()  # must not raise (e.g. under pytest capture objects)
+
+
 class TestCLIBuild:
     """Tests for CLI build command."""
 


### PR DESCRIPTION
## Problem
`neuralmind query` / `search` — and any subcommand that prints context/graph text, plus `argparse --help` (its description contains an em-dash) — crash on Windows consoles with `UnicodeEncodeError`. The Windows default cp1252 codec can't encode the Unicode glyphs (arrows `→`, em-dashes `—`, box-drawing `─`) in the output.

Repro (Windows PowerShell):
```
neuralmind query . "how does X work"
#   ...
#   File "neuralmind/cli.py", line 135, in cmd_query
#     print(result.context)
# UnicodeEncodeError: 'charmap' codec can't encode characters ...
```
It's purely a stdout-encoding issue — `PYTHONUTF8=1 neuralmind query ...` already succeeds.

## Fix
Add `_force_utf8_io()` and call it at the very top of `main()`, reconfiguring stdout/stderr to UTF-8 before any output. One call at the entry point covers every subcommand and argparse's own help. Guarded: a no-op on Linux/macOS (already UTF-8) and on streams without `reconfigure` (pytest capture).

The `neuralmind-mcp` server (`mcp_server:main`) is a **separate** entry point that returns results as JSON over the stdio transport and only prints to stderr — unaffected and unchanged.

## Tests
- New `TestCLIEncoding` in `tests/test_cli.py`: a cp1252 stream can print the offending glyphs after the reconfigure, and the helper is a safe no-op when `reconfigure` is missing.
- `tests/test_cli.py` passes locally (38 passed, 1 pre-existing Windows skip); `ruff` clean.

## Context
Surfaced while registering neuralmind as an MCP server (`neuralmind-mcp`, user scope) for another project on Windows and hitting the CLI crash during a smoke test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
