### PR TITLE
docs: add context engineering stack comparative guide (NeuralMind + Ponytail + Headroom)

### DIFF
--- a/docs/about.html
+++ b/docs/about.html
@@ -105,6 +105,50 @@
     </section>
 
     <section>
+        <div class="container" id="context-engineering-stack">
+            <h2>The Context Engineering Stack: NeuralMind, Ponytail, and Headroom</h2>
+            <p>NeuralMind is one piece of a broader context engineering ecosystem. Three tools address token waste at different points in the LLM pipeline — and they compose without conflict:</p>
+            <ul>
+                <li><strong>NeuralMind (Retrieval Stage):</strong> Persistent semantic memory. The agent receives only the few entities that matter (~800 tokens) rather than whole files, and the Hebbian synapse layer learns which files go together from actual usage — carrying that knowledge across sessions.</li>
+                <li><strong><a href="https://github.com/DietrichGebert/ponytail">Ponytail</a> (Generation Stage):</strong> Behavioral prompt steering. Enforces a "lazy senior developer" persona — a sequential optimization ladder (YAGNI → stdlib → native → existing → one-line → minimum code) that blocks custom abstractions until simpler alternatives are exhausted. Any deliberate shortcut is annotated <code>ponytail:</code> and harvested into a technical debt ledger via <code>/ponytail-debt</code>.</li>
+                <li><strong><a href="https://github.com/chopratejas/headroom">Headroom</a> (Transport Stage):</strong> Lossless transport-layer compression. Intercepts traffic between client and LLM, applying a three-stage engine (CacheAligner for KV prefix stability, ContentRouter for JSON/HTML/diff payloads, IntelligentContext for relevance scoring) with 60–95% payload reduction and a reversible CCR loop backed by local SQLite storage.</li>
+            </ul>
+            <h3>Where each tool intervenes</h3>
+            <table style="width:100%;border-collapse:collapse;margin:1rem 0;">
+                <thead>
+                    <tr style="border-bottom:2px solid #667eea;">
+                        <th style="text-align:left;padding:0.5rem 1rem;">Tool</th>
+                        <th style="text-align:left;padding:0.5rem 1rem;">Locus</th>
+                        <th style="text-align:left;padding:0.5rem 1rem;">Primary Mechanism</th>
+                        <th style="text-align:left;padding:0.5rem 1rem;">Verified Savings</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr style="border-bottom:1px solid #eee;">
+                        <td style="padding:0.5rem 1rem;"><strong>NeuralMind</strong></td>
+                        <td style="padding:0.5rem 1rem;">Retrieval</td>
+                        <td style="padding:0.5rem 1rem;">Hebbian synapse networks</td>
+                        <td style="padding:0.5rem 1rem;">40–70× fewer query tokens</td>
+                    </tr>
+                    <tr style="border-bottom:1px solid #eee;">
+                        <td style="padding:0.5rem 1rem;"><a href="https://github.com/DietrichGebert/ponytail">Ponytail</a></td>
+                        <td style="padding:0.5rem 1rem;">Generation</td>
+                        <td style="padding:0.5rem 1rem;">Sequential decision ladder</td>
+                        <td style="padding:0.5rem 1rem;">80–94% output token savings</td>
+                    </tr>
+                    <tr>
+                        <td style="padding:0.5rem 1rem;"><a href="https://github.com/chopratejas/headroom">Headroom</a></td>
+                        <td style="padding:0.5rem 1rem;">Transport</td>
+                        <td style="padding:0.5rem 1rem;">Reversible CCR loops</td>
+                        <td style="padding:0.5rem 1rem;">60–95% payload reduction</td>
+                    </tr>
+                </tbody>
+            </table>
+            <p>For enterprise-scale agentic fleets, the full stack delivers maximum token efficiency, 100% local privacy, and a traceable technical debt ledger. <a href="https://github.com/dfrostar/neuralmind/blob/main/docs/comparisons/context-engineering-stack.md">Read the full comparative guide →</a></p>
+        </div>
+    </section>
+
+    <section>
         <div class="container" id="whats-new-v0260">
             <h2>What's New in v0.26.0 — the selector starts tuning itself</h2>
             <p><strong>NeuralMind's progressive-disclosure selector can now adjust its own L2 recall depth from how an agent actually uses it.</strong> This is phases 1&ndash;2 of the self-improvement engine (issue #156): a logging substrate that records query and wakeup events with a <code>session_id</code>, and an opt-in tuner that reads that signal back to widen or narrow how many community summaries L2 surfaces per query. The whole thing is <strong>off by default</strong> behind <code>NEURALMIND_SELECTOR_AUTOTUNE=1</code>, and with the flag unset behavior is byte-identical to v0.25 — zero extra I/O on the hot path.</p>

--- a/docs/comparisons/context-engineering-stack.md
+++ b/docs/comparisons/context-engineering-stack.md
@@ -1,0 +1,166 @@
+---
+title: "The Context Engineering Stack: A Comparative Guide to NeuralMind, Ponytail, and Headroom"
+description: "How NeuralMind, Ponytail, and Headroom address token waste at every stage of the LLM pipeline: retrieval, transport, and generation."
+---
+
+# The Context Engineering Stack: A Comparative Guide to NeuralMind, Ponytail, and Headroom
+
+## 1. The Strategic Shift: From Raw Ingestion to Context Engineering
+
+The industry has reached a critical resource bottleneck at the LLM-local runtime interface. In early agentic implementations, "naive" workflows relied on raw file ingestion — indiscriminately dumping source code into a prompt and delegating the retrieval burden to the model. This approach is no longer tenable. We are observing a strategic transition toward *engineered* context, where token optimization is treated as a core architectural requirement rather than a cost-saving afterthought.
+
+Unguided agents operating without context engineering frequently produce fragile speculative abstractions and redundant boilerplate, clogging the development cycle. The systemic failures of naive ingestion are well-documented:
+
+- **Context Bloat:** Persistent ingestion of multi-hundred-line source files exponentially inflates token overhead and degrades reasoning performance.
+- **API Latency:** Massive payloads induce high operational wait times, fracturing developer flow and increasing the risk of timeout-related failures.
+- **Model Hallucinations:** Unconstrained context creates a high noise-to-signal ratio, causing models to prioritize irrelevant code segments over critical logic.
+
+To mitigate these risks, modern infrastructure must adopt sophisticated paradigms for context management: **NeuralMind** for semantic memory, **[Ponytail](https://github.com/DietrichGebert/ponytail)** for behavioral steering, and **[Headroom](https://github.com/chopratejas/headroom)** for algorithmic transport compression.
+
+---
+
+## 2. NeuralMind: Persistent Semantic Retrieval and Codebase Memory
+
+NeuralMind functions as a local-first semantic memory engine designed to model a codebase with the intuition of a senior engineer. By moving beyond flat text ingestion, it allows agents to navigate a structural graph of code relationships, ensuring that only the most relevant linkages enter the reasoning window.
+
+### Core Mechanism: AST Parsing and the Hebbian Synapse Layer
+
+NeuralMind employs Abstract Syntax Tree (AST) parsing natively for **Python, TypeScript, and Go** via its built-in tree-sitter backend. Additional language support is available through the optional [graphify](https://github.com/safishamsi/graphify) backend — any language graphify supports feeds the same retrieval pipeline. Relationships are stored in an offline ChromaDB instance (or the dependency-free turbovec backend), providing a secure, local-first boundary that ensures proprietary logic never leaves the developer's environment.
+
+The system's primary learning signal is the **Hebbian Synapse Layer**. This layer continuously records user queries and file edits, allowing active associations to strengthen while unused connections naturally decay. In the v0.25.0 release, the previous co-occurrence reranker was deprecated and removed; internal benchmarks confirmed it was "runtime-inert on the warm path," adding 0.0 points to accuracy while increasing complexity.
+
+### Retrieval Accuracy: v0.25.0 Evaluation
+
+The removal of the reranker highlights the efficacy of the synapse layer as a standalone signal.
+
+| Memory Engine Configuration | Top-k Hit Rate (Cold Path) | Top-k Hit Rate (Warm Path) | Accuracy Gain |
+|---|---|---|---|
+| Synapses Off | 71.7% | 71.7% | 0.0 |
+| Synapses On | 83.3% | 83.3% | +11.6 pts |
+
+Reproduce locally: `python -m tests.benchmark.run`
+
+### Self-Tuning and Namespace Isolation
+
+NeuralMind manages retrieval volume through an opt-in **self-improvement tuner** (enabled via `NEURALMIND_SELECTOR_AUTOTUNE=1`) that targets the L2 recall depth. This closed-loop tuner monitors session-based re-query rates; if the agent requires successive queries with overlapping contexts, the recall depth is incremented to widen the window. Conversely, successful resolutions trigger a parameter decay to prioritize token conservation.
+
+To prevent feature-branch experimentalism from polluting the long-term memory of the main production branch, NeuralMind uses **Memory Namespace isolation**. Final ranking scores use a localized scaling formula:
+
+```
+Synapse Weight_final = 1.0 · W_active_branch + 0.8 · W_personal + 0.5 · W_shared_baseline
+```
+
+For regulated industries, NeuralMind provides architectural explainability by tagging every retrieved edge as `EXTRACTED` (verbatim from source) or `INFERRED` (heuristically inferred from static code analysis, e.g., inferred call edges), ensuring every context decision is auditable.
+
+---
+
+## 3. Ponytail: Programmatic Laziness and the YAGNI Generation Constraint
+
+While NeuralMind optimizes the *input*, [Ponytail](https://github.com/DietrichGebert/ponytail) focuses on the *generation* boundary. It enforces a "lazy senior developer" persona, compelling the model to exhaustively evaluate native, minimal-effort solutions before generating any custom logic.
+
+### The Ponytail Optimization Ladder
+
+The engine forces agents to stop at the highest possible rung of its sequential decision ladder:
+
+1. **YAGNI:** Does this feature even need to exist? (You Ain't Gonna Need It)
+2. **Stdlib:** Can the standard library handle this natively?
+3. **Native:** Is there a native platform feature (e.g., HTML5 `<input type="date">`) available?
+4. **Existing:** Can an already-installed dependency solve it?
+5. **One-line:** Can the logic be distilled into a single line?
+6. **Minimum Code:** Write the absolute minimum code required to pass logic checks.
+
+### Intensity Profiles and Technical Debt
+
+Ponytail provides three intensity profiles to manage these constraints:
+
+| Profile | Behavior | Example: "Custom Caching" Request |
+|---|---|---|
+| Lite | Builds the feature but identifies native alternatives. | Builds class; notes `functools.lru_cache` exists. |
+| Full (Default) | Enforces the ladder; uses native features first. | Uses `@lru_cache`; skips custom class. |
+| Ultra | Actively challenges the necessity of the request. | Rejects cache until a profiler proves latency. |
+
+To ensure codebase stability, any deliberate shortcut must be annotated with a `ponytail:` inline comment. These annotations are harvested by the `/ponytail-debt` command into a structured ledger, allowing teams to track and resolve technical debt systematically.
+
+### Verification and Safety
+
+Ponytail excludes critical trust-boundary operations from its simplification rules: input validation, security controls, data-loss prevention, and accessibility are never compromised. This behavioral steering yields output token savings of 80–94% while preserving core system integrity.
+
+---
+
+## 4. Headroom: Lossless Algorithmic Transport-Layer Compression
+
+[Headroom](https://github.com/chopratejas/headroom) acts as network transport middleware, intercepting traffic between the client and LLM. It focuses on payload reduction and KV cache optimization without altering the functional output of the model.
+
+### The Three-Stage Compression Engine
+
+1. **CacheAligner:** Stabilizes provider-side KV caches via prefix alignment. By relocating dynamic metadata to the tail of the payload, it ensures the static prefix remains stable across turns.
+2. **ContentRouter:** Routes data to specialized compressors, including Trafilatura-based text-to-content isolators for HTML and SmartCrusher for JSON.
+3. **IntelligentContext:** Scores blocks for relevance, utilizing LLMLingua for prose and CodeCompressor for AST-based code stripping.
+
+| Content Type | Typical Token Savings | Compression Strategy |
+|---|---|---|
+| JSON Arrays | 70–90% | Schema extraction and field-level variance analysis |
+| HTML Payloads | ~95% | Article extraction via Trafilatura isolators |
+| Unified Diffs | 60–80% | Line-level delta simplification |
+| Source Code | 40–70% | AST signature preservation; inner body stripping |
+| Build Logs | 85–95% | Sequential pattern clustering of stack traces |
+
+### CCR (Compress-Cache-Retrieve) Reversibility
+
+Headroom ensures 100% reversibility through the CCR Loop. Original payloads are stored in a local SQLite database. If the LLM identifies a "compressed context" marker and requires the full data, it invokes the `headroom_retrieve` tool, which performs a localized BM25 search over the SQLite records to return the missing segments.
+
+To prevent unnecessary latency, Headroom enforces strict operational limits: payloads under 200 tokens or JSON arrays with fewer than five items bypass the engine entirely. Enterprise deployments are supported via Docker variants and TLS inspection workarounds for corporate network environments.
+
+---
+
+## 5. Deep Comparative Evaluation: Structural and Economic Differences
+
+Strategic efficacy is determined by the locus of intervention. While some tools prune the input, others constrain the output.
+
+### Architectural Synthesis
+
+| Evaluative Dimension | NeuralMind | Ponytail | Headroom |
+|---|---|---|---|
+| Operational Paradigm | Persistent Semantic Memory | Behavioral Prompt Steering | Lossless Algorithmic Proxy |
+| Locus of Intervention | Retrieval Stage | Generation Stage | Network Transport Stage |
+| Target Audience | Regulated Enterprises | Teams Fighting Code Bloat | SRE / High-Volume Pipelines |
+| Primary Mechanism | Hebbian Synapse Networks | Sequential Decision Ladder | Reversible CCR Loops |
+| Verified Token Savings | 40–70× cheaper queries | 80–94% per-task output tokens | 60–95% payload reduction |
+
+### The Deliberation Cost Paradox
+
+On advanced reasoning models, strict prompt-steering (Ponytail) can trigger a financial liability. Because these models utilize internal "thinking" cycles to evaluate rules, the overhead of deliberating on the optimization ladder can exceed the tokens saved in the final output. The net cost is modeled as:
+
+```
+Net Cost = (T_baseline_out − T_lazy_out) · P_out − (T_rules_in · P_in + T_reasoning · P_think)
+```
+
+This dynamic is driving the industry toward **Edge-Based Code Preprocessing**, where NeuralMind and Headroom handle high-volume data reduction locally before any tokens are transmitted to the cloud.
+
+---
+
+## 6. The Synergistic Stack: Deploying the End-to-End Optimization Pipeline
+
+These three technologies are not competing products; they form a unified optimization stack that addresses token waste at every lifecycle stage.
+
+### The Unified Execution Flow
+
+1. **Retrieval Phase (NeuralMind):** Serves precise, synapse-weighted relationships, ensuring the model only receives structural signal.
+2. **Transport Phase (Headroom):** Compresses tool results and logs while stabilizing KV caches via prefix alignment for faster sequential turns.
+3. **Generation Phase (Ponytail):** Enforces a "lazy" output persona to ensure the model writes only maintainable, native code.
+
+### Implementation Recommendations
+
+- **For high-volume research and SRE incident debugging:** Deploy Headroom + NeuralMind to maximize the retrieval of vast logs while stabilizing transport costs.
+- **For rapid feature building and MVP development:** Deploy Ponytail + NeuralMind to maintain codebase purity and iterate with minimal boilerplate.
+- **For enterprise-scale agentic fleets:** Deploy the full stack to achieve maximum token efficiency, 100% local privacy, and a traceable technical debt ledger.
+
+---
+
+## See also
+
+- [NeuralMind vs. Headroom](./vs-headroom.md) — detailed head-to-head comparison
+- [Ponytail on GitHub](https://github.com/DietrichGebert/ponytail)
+- [Headroom on GitHub](https://github.com/chopratejas/headroom)
+- [All comparisons](./README.md)
+- [NeuralMind benchmarks](../wiki/Benchmarks.md)

--- a/docs/index.html
+++ b/docs/index.html
@@ -511,7 +511,7 @@
                 </tbody>
             </table>
         </div>
-        <p class="center-cta"><a href="wiki/Comparisons">View detailed comparisons →</a></p>
+        <p class="center-cta"><a href="wiki/Comparisons">View detailed comparisons →</a> &nbsp;·&nbsp; <a href="comparisons/context-engineering-stack">The full context engineering stack: NeuralMind + Ponytail + Headroom →</a></p>
     </div>
 </section>
 

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -61,6 +61,11 @@
     <priority>0.7</priority>
   </url>
   <url>
+    <loc>https://dfrostar.github.io/neuralmind/comparisons/context-engineering-stack.html</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.75</priority>
+  </url>
+  <url>
     <loc>https://dfrostar.github.io/neuralmind/comparisons/vs-langchain-llamaindex.html</loc>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>

--- a/docs/wiki/Comparisons.md
+++ b/docs/wiki/Comparisons.md
@@ -21,6 +21,7 @@ Full source of these pages lives at [docs/comparisons/](https://github.com/dfros
 | [Generic RAG over a codebase](https://github.com/dfrostar/neuralmind/blob/main/docs/comparisons/vs-rag.md) | "Isn't this just RAG with extra steps?" |
 | [Tree-sitter / ctags / grep](https://github.com/dfrostar/neuralmind/blob/main/docs/comparisons/vs-treesitter-ctags.md) | "Why do I need embeddings at all?" |
 | [Headroom](https://github.com/dfrostar/neuralmind/blob/main/docs/comparisons/vs-headroom.md) | "Isn't a compression layer between my agent and the LLM enough?" |
+| [The Context Engineering Stack (NeuralMind + Ponytail + Headroom)](https://github.com/dfrostar/neuralmind/blob/main/docs/comparisons/context-engineering-stack.md) | "How do NeuralMind, Ponytail, and Headroom work together as a unified token optimization stack?" |
 
 ## One-line verdicts
 
@@ -38,6 +39,8 @@ Full source of these pages lives at [docs/comparisons/](https://github.com/dfros
 | Long context (1M/2M) | Possible ≠ cheap — NeuralMind gives ~60× cost reduction on the same model |
 | Generic RAG | Text chunking loses structure; NeuralMind keeps the call graph |
 | Tree-sitter / ctags / grep | Deterministic but syntactic; use alongside NeuralMind, not instead of |
+| Headroom | Use both — Headroom compresses what flows to the model; NeuralMind stops most of it from flowing in the first place |
+| Context Engineering Stack (NeuralMind + Ponytail + Headroom) | These compose: NeuralMind (retrieval) + Headroom (transport) + Ponytail (generation) address token waste at every pipeline stage |
 
 ## TL;DR
 


### PR DESCRIPTION
## Summary

- **New page** `docs/comparisons/context-engineering-stack.md` — full comparative guide positioning NeuralMind alongside [Ponytail](https://github.com/DietrichGebert/ponytail) and [Headroom](https://github.com/chopratejas/headroom) as a three-stage unified token optimization stack (retrieval / generation / transport)
- **`docs/about.html`** — new "Context Engineering Stack" section with summary table, placed before the v0.26.0 release notes
- **`docs/index.html`** — CTA link to the stack guide added alongside the existing comparisons link
- **`docs/wiki/Comparisons.md`** — new rows in both the "when to read" and "one-line verdicts" tables
- **`docs/sitemap.xml`** — new URL added at priority 0.75

## Validation corrections applied

The source article had three factual issues, all fixed before publishing:

| Issue | Original claim | Corrected to |
|---|---|---|
| Language support | "13 programming languages" | "Python, TypeScript, and Go natively; additional languages via the optional graphify backend" |
| Tuner name | "Self-Tuning Autoselector Engine" | "self-improvement tuner" (the documented name, matches CLI output and all existing docs) |
| INFERRED tag | "model-reasoned" | "heuristically inferred from static code analysis, e.g., inferred call edges" |

All NeuralMind-specific benchmark numbers (71.7%/83.3%/+11.6 pts, 40–70×, namespace weights 1.0/0.8/0.5) verified against `RELEASE_NOTES_v0.25.0.md`, `docs/wiki/Benchmarks.md`, and `neuralmind/synapses.py`.

## Test plan

- [ ] Preview `docs/comparisons/context-engineering-stack.md` renders correctly (tables, code blocks, links)
- [ ] `docs/about.html` new section appears between "Where NeuralMind is going next" and "What's New in v0.26.0"
- [ ] `docs/index.html` compare section CTA links resolve correctly
- [ ] `docs/wiki/Comparisons.md` new rows display in both tables
- [ ] `docs/sitemap.xml` valid XML, new URL present

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01389YFP5onpBmvsPNwwPu5Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01389YFP5onpBmvsPNwwPu5Q)_