### PR TITLE
feat: add context-engineering-stack PyPI keywords to trigger v0.29.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,7 +158,10 @@ keywords = [
     "fable-5",
     "self-improvement-engine",
     "selector-autotuning",
-    "adaptive-recall-depth"
+    "adaptive-recall-depth",
+    "context-engineering-stack",
+    "unified-token-optimization",
+    "ponytail-headroom-integration"
 ]
 classifiers = [
     "Development Status :: 4 - Beta",


### PR DESCRIPTION
## Summary

- Adds three PyPI keywords to `pyproject.toml`: `context-engineering-stack`, `unified-token-optimization`, `ponytail-headroom-integration`
- These surface the new context engineering stack guide on PyPI search for teams evaluating NeuralMind alongside Ponytail and Headroom
- The `feat:` prefix triggers release-please to open a v0.29.0 release PR

This completes the CLAUDE.md shipping checklist for the context engineering stack feature (PRs #243 and #244).

## Test plan

- [ ] `pyproject.toml` keywords list contains all three new terms
- [ ] release-please opens a v0.29.0 release PR after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01389YFP5onpBmvsPNwwPu5Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01389YFP5onpBmvsPNwwPu5Q)_