### PR TITLE
docs: disclosed-maker launch kit under docs/launch/

### DIFF
--- a/docs/launch/NEXT-SESSION.md
+++ b/docs/launch/NEXT-SESSION.md
@@ -1,0 +1,111 @@
+# Session handoff — launch readiness
+
+**Last updated:** 2026-06-20 · **Branch of record for this work:** `claude/launch-kit` (PR #263, draft)
+**Copy-paste this whole file into the next session's first message to resume with full context.**
+
+---
+
+## TL;DR for the next session
+
+NeuralMind is **launch-ready**. Four roadmap items shipped (v0.30→v0.33), the
+public-facing positioning is the **four data-backed benefits**, and the launch
+copy lives in `docs/launch/`. The remaining work is **execution** (the maker
+posts to HN / r/LocalLLaMA / awesome-mcp) plus an optional next roadmap item.
+Nothing is blocked on code.
+
+The one hard standing rule, carried across sessions: **disclosed-maker only**
+for all outreach. No unaffiliated-end-user posts, no sockpuppet/persona
+creation, no platform-rule evasion. This was asked for repeatedly and declined
+every time — keep declining it; the benchmark credibility is the whole asset.
+
+---
+
+## What shipped this arc (done — on `main`, released)
+
+| Version | Feature | PR | Evidence |
+|---|---|---|---|
+| v0.30.0 | **Team memory** — commit learned synapse signal; teammates' agents inherit it (`.neuralmind-team-memory.json`, `shared` namespace, content-hash idempotent, fail-open) | shipped within #257 | `tests/test_team_memory.py` |
+| v0.31.0 | **Honest public benchmark** — `neuralmind benchmark --public`, gold-file recall (objective def-site oracle, no LLM judge), cost+correctness jointly | #257 | `evals/public/`, `docs/benchmarks/public.md` |
+| v0.32.0 | **C / C++ extractors** — tree-sitter backend now 7 languages, proven at parity (100% coverage, 0 dangling) | #259-ish | `tests/test_graphgen.py` (C/CExtractorEdgeCase) |
+| v0.33.0 | **Live competitor head-to-head** vs `codebase-memory-mcp` 0.8.1 — same repos/questions/scorer, raw traces committed | #259/#260 | `evals/public/competitor.py`, `bench/public/competitor/` |
+| (docs) | **Four-benefit positioning** across README + docs + wiki | #261 | README "Why NeuralMind" |
+| (docs) | **Launch kit** — this folder | #263 (draft) | `docs/launch/` |
+
+## Current state of the repo
+
+- `main` is at the v0.33.0 release (`d56d0bc` was the positioning PR merge).
+- **No open release PR** — release-please is idle; next `feat:` opens one.
+- PR #263 (`claude/launch-kit`) is **draft, docs-only**, both substantive CI
+  gates green (parity gate PASS; self-benchmark PASS, which re-confirmed the
+  +11.7-pt synapse number and faithfulness +0.143 live).
+
+## The four data-backed benefits (single source of truth: README "Why NeuralMind")
+
+| Benefit | Result | Where measured |
+|---|---|---|
+| Cheaper context | 100% gold-file recall at **38–85× fewer tokens** vs pasting files; beats `ripgrep` on both axes | public benchmark (`requests`, `click`) |
+| Finds the *right* code | 100% recall, **MRR 0.96**; beats `codebase-memory-mcp` ranking (0.96 vs 0.23) | same benchmark |
+| Learns how you work | Hebbian synapses **+11.7 pts** hit-rate (71.7%→83.3%), budget-neutral | synapse A/B |
+| Better-grounded answers | matched budget: **faithfulness +0.143, grounding 1.00** | parity/faithfulness gate |
+
+Honest-scope caveat (carry it everywhere): cost+accuracy are real pinned-OSS-repo
+reproducible; learning+grounding are reference-fixture A/Bs (real, smaller-scope);
+a well-tuned vector RAG ties on findability and is cheaper on raw tokens — shown
+in the table, not hidden.
+
+---
+
+## Recommended next steps (in priority order)
+
+1. **Merge #263** once you're happy with the post copy (held for your okay;
+   docs-only, won't trigger a release).
+2. **Execute the launch** — you, as the disclosed maker:
+   - Submit the Show HN (`docs/launch/show-hn.md`), post the first comment
+     immediately, be around to answer for the first few hours.
+   - Post the r/LocalLLaMA self-post (`docs/launch/r-localllama.md`).
+   - Open the awesome-mcp-servers PR (`docs/launch/awesome-mcp-servers.md`).
+   - Use the warm-up comments (`docs/launch/hn-warmup-comments.md`) only on
+     genuinely relevant threads, disclosed.
+3. **Pick the next roadmap item** (see candidates below). The value-ordered
+   four are done; the next tier is about deepening the proof and breadth.
+
+### Candidate next roadmap items (not yet started)
+
+- **Opt-in LLM-judged answerability arm** for the public benchmark
+  (`--judge`, publish model+prompt+transcripts as a clearly-labeled *secondary*
+  signal). Already scoped as "planned" in `docs/benchmarks/public.md`. Directly
+  answers the "recall ≠ answering" critique a serious reviewer will raise.
+- **schema.org JSON-LD** (`SoftwareApplication` / `Article`) on docs pages —
+  an explicit SEO gap noted in CLAUDE.md as of v0.10.0; richer Google results.
+- **More languages** behind the same `_SUFFIX_LANG` → `_EXTRACTORS` seam
+  (C# / Ruby / PHP are the obvious breadth adds; each is additive + parity-gated).
+- **Expand the public benchmark corpus** beyond `requests`/`click` (one
+  `manifest.json` entry per repo with def-site gold) to harden "you picked easy
+  repos."
+
+---
+
+## How we work here (cadence + constraints — keep these)
+
+- **Per feature:** PRD (`docs/prd/`) → build on a fresh branch (code + tests +
+  docs/SEO per the CLAUDE.md checklist) → CI green → **hold for explicit merge
+  okay** → merge → release-please cuts the release. Docs+SEO ship in the *same*
+  PR as the feature.
+- **Fresh branch per feature** (avoids the CI-trigger dead-end).
+- **Never** bump `pyproject.toml` / manifest / `CHANGELOG.md` by hand —
+  release-please owns versioning off `feat:`/`fix:` commits.
+- **Benchmarks deterministic:** `NEURALMIND_SYNAPSE_INJECT=0` for fixed numbers.
+- **Bar for any public/benchmark work:** must pass engineering + Reddit scrutiny
+  by serious technicians. Report losses, pin versions, commit raw traces.
+- **Disclosed-maker only** for all outreach (the standing ethical line above).
+
+---
+
+## Pointers
+
+- Launch copy: `docs/launch/` (README is the index).
+- Benchmark methodology + raw data: `docs/benchmarks/public.md`,
+  `bench/public/`.
+- Reproduce headline: `python -m evals.public.run`; competitor:
+  `python -m evals.public.competitor`.
+- Architecture + shipping checklist: `CLAUDE.md`.

--- a/docs/launch/README.md
+++ b/docs/launch/README.md
@@ -19,6 +19,7 @@ post there — we don't post under a disguise.
 | [`r-localllama.md`](r-localllama.md) | r/LocalLLaMA | Self-post, maker-disclosed, four-benefit block with live links. |
 | [`awesome-mcp-servers.md`](awesome-mcp-servers.md) | `awesome-mcp-servers` PR | One-line directory entry + PR description. |
 | [`hn-warmup-comments.md`](hn-warmup-comments.md) | Hacker News (other threads) | Genuine, on-topic, disclosed comments on adjacent posts. Not drive-by promo. |
+| [`NEXT-SESSION.md`](NEXT-SESSION.md) | (internal) | Session handoff + "what we did" record + recommended next steps. Copy-paste to resume. |
 
 ## Live anchors (keep these accurate)
 

--- a/docs/launch/README.md
+++ b/docs/launch/README.md
@@ -1,0 +1,58 @@
+# Launch kit
+
+Copy-paste-ready launch materials for NeuralMind, kept in the repo so they
+survive across sessions and stay in sync with the shipped numbers.
+
+**One hard rule for everything in this folder: disclosed-maker only.** Every
+post here is written in the first person *as the author of the project*. We do
+**not** write "unaffiliated end-user" posts, age or rent personas, or evade a
+platform's self-promotion rules. The credibility of the benchmark work is the
+whole point of the launch; sockpuppeting throws it away and breaks the rules of
+every venue below. If a venue won't allow a disclosed maker to post, we don't
+post there — we don't post under a disguise.
+
+## Contents
+
+| File | Venue | Notes |
+|---|---|---|
+| [`show-hn.md`](show-hn.md) | Hacker News (Show HN) | Title + body + first-comment context. Maker submits, discloses in the comment. |
+| [`r-localllama.md`](r-localllama.md) | r/LocalLLaMA | Self-post, maker-disclosed, four-benefit block with live links. |
+| [`awesome-mcp-servers.md`](awesome-mcp-servers.md) | `awesome-mcp-servers` PR | One-line directory entry + PR description. |
+| [`hn-warmup-comments.md`](hn-warmup-comments.md) | Hacker News (other threads) | Genuine, on-topic, disclosed comments on adjacent posts. Not drive-by promo. |
+
+## Live anchors (keep these accurate)
+
+All posts cite these — update them here and in the posts together if the
+numbers move.
+
+- Repo: <https://github.com/dfrostar/neuralmind>
+- Benchmark methodology + raw data: [`docs/benchmarks/public.md`](../benchmarks/public.md)
+- Reproduce the headline number: `python -m evals.public.run`
+- Reproduce the competitor row: `python -m evals.public.competitor`
+
+### The four data-backed benefits (single source of truth: README "Why NeuralMind")
+
+| Benefit | Measured result | Where |
+|---|---|---|
+| **Cheaper context** | 100% gold-file recall at **38–85× fewer tokens** than pasting files; beats `ripgrep` on both recall and cost | Public benchmark (`requests`, `click`) |
+| **Finds the *right* code** | 100% gold-file recall, **MRR 0.96**; beats incumbent `codebase-memory-mcp` on ranking (0.96 vs 0.23) | Same benchmark |
+| **Learns how you work** | Hebbian synapse layer: **+11.7 pts** top-k hit-rate (71.7%→83.3%), budget-neutral | Synapse A/B eval |
+| **Better-grounded answers** | At matched budget, **faithfulness +0.143, grounding 1.00** | Faithfulness/parity gate |
+
+*Honest-scope caveat carried in every post:* cost + accuracy run on real pinned
+OSS repos (fully reproducible); learning + grounding are committed A/Bs on the
+bundled reference fixture (real but smaller-scope). A well-tuned vector RAG ties
+NeuralMind on pure findability and is cheaper on raw tokens — that's in the
+table, not hidden.
+
+## HN posting guidance (operational)
+
+- Submit the **Show HN** yourself, as the maker. Title starts with `Show HN:`.
+- Post the disclosure/context as the **first comment** immediately after
+  submitting (HN convention) — see `show-hn.md`.
+- Don't ask for upvotes anywhere. Don't post the link in unrelated threads.
+- The warm-up comments in `hn-warmup-comments.md` are for *genuinely relevant*
+  existing threads — they lead with something useful and disclose the
+  affiliation when NeuralMind is mentioned. They are not a vote-ring.
+- Best time: a weekday morning US Eastern. Be around to answer for the first
+  few hours — engaged maker answers are what move a Show HN.

--- a/docs/launch/awesome-mcp-servers.md
+++ b/docs/launch/awesome-mcp-servers.md
@@ -1,0 +1,49 @@
+# awesome-mcp-servers entry
+
+A directory PR to the `awesome-mcp-servers` list (and any equivalent curated MCP
+directories). Maker-submitted; these lists welcome maker submissions as long as
+the entry is accurate and in the right category.
+
+## The entry line
+
+Place under the code/developer-tools (or "Knowledge & Memory") category,
+alphabetically if the list is sorted:
+
+```markdown
+- [NeuralMind](https://github.com/dfrostar/neuralmind) 🐍 🏠 - Local semantic code-memory for AI agents: progressive context disclosure (40–70× fewer tokens on code questions) plus a Hebbian "synapse" layer that learns code associations from your usage. 100% on-device, no API key. Ships a reproducible public benchmark.
+```
+
+Legend reminder (use whatever symbols the target list defines):
+- 🐍 Python
+- 🏠 local / self-hosted
+- (add the list's "open-source" / language marks as appropriate)
+
+## PR title
+
+```
+Add NeuralMind — local semantic code-memory MCP server
+```
+
+## PR description
+
+```
+Adds NeuralMind, an open-source, 100%-local MCP server that gives AI coding
+agents semantic memory of a codebase.
+
+What it does:
+- Progressive context disclosure (L0–L3) — assembles a compact structured
+  context (project map → relevant symbols → call edges) instead of pasting files
+  or dumping raw RAG chunks. ~40–70× fewer tokens on code questions.
+- A Hebbian "synapse" layer that learns which code goes with what from how you
+  actually use the codebase, and decays unused links.
+- Runs on-device; the index needs no API key.
+
+Why it belongs on the list: it's a working MCP server (tools for any MCP client —
+Claude Code, Cursor, Cline, Continue), open-source, and ships a reproducible
+public benchmark (cost + correctness reported together, gold-file recall with an
+objective def-site oracle, no LLM judge):
+https://github.com/dfrostar/neuralmind/blob/main/docs/benchmarks/public.md
+
+Disclosure: I'm the author. Entry follows the list's format/category
+conventions; happy to adjust placement or wording.
+```

--- a/docs/launch/hn-warmup-comments.md
+++ b/docs/launch/hn-warmup-comments.md
@@ -1,0 +1,83 @@
+# HN warm-up comments
+
+Genuine, on-topic comments for *existing* HN threads that are actually about
+agent context / memory / coding-agent loops. These are **not** a vote-ring and
+**not** drive-by promo: each leads with something substantive, and discloses the
+NeuralMind affiliation the moment the project is named. If a comment wouldn't be
+worth posting without the NeuralMind mention, don't post it.
+
+**Rule:** mention NeuralMind only where it genuinely answers the thread's
+question, and always with "(disclosure: I built it)" or equivalent. One link
+max. No "check out my project" with no substance.
+
+---
+
+## Comment A — for a thread about coding-agent context/memory (e.g. the "Gora" thread)
+
+```
+The thing that bit us repeatedly is that the agent re-loads context it already
+"understood" earlier in the session — every turn it re-reads the same files
+because nothing persists between turns except the raw transcript. So the window
+fills with re-derivation, not new reasoning.
+
+Two angles that helped, independent of any specific tool:
+1. Disclose context progressively. Don't paste files; give the agent a map
+   first (symbols + call edges) and let it pull the bodies it actually needs.
+   The recall hit from this is smaller than people expect if your retrieval is
+   decent.
+2. Persist associations, not just embeddings. Which files get edited together,
+   which symbols get queried together — that signal is cheap to record and
+   strong for "what should I look at next," and a static vector index throws it
+   away every session.
+
+(Disclosure: I went down this rabbit hole far enough that I built an open MCP
+server around it — github.com/dfrostar/neuralmind — so take the framing with
+that grain of salt. The reproducible benchmark is the part I'd actually defend.)
+```
+
+## Comment B — for a thread about RAG-for-code / retrieval quality (e.g. the "Zeroshot" thread)
+
+```
+One thing worth measuring that a lot of code-retrieval write-ups skip: report
+cost and correctness *together*. A token-reduction number with no "did the right
+file actually make it into the window" number attached is unfalsifiable.
+
+A cheap objective oracle that avoids an LLM judge: pick the gold file as the
+definition site of a named symbol, and say a method "answered" iff that file
+lands in its assembled context. Verifiable with one rg command, deterministic,
+nothing to rig. When I scored that way, plain ripgrep missed the right file ~29%
+of the time (keyword search has no notion of meaning), while a same-encoder
+vector RAG was genuinely strong on findability — which is the honest result, not
+the marketing one.
+
+(Disclosure: this is from building github.com/dfrostar/neuralmind; the harness
+is in the repo if you want to tear the methodology apart, which is the point.)
+```
+
+## Comment C — for a thread about Claude Code / agent loops specifically
+
+```
+On the Claude Code loop specifically: the lifecycle hooks (SessionStart,
+UserPromptSubmit, PreCompact, PostToolUse) are the underused seam. PreCompact in
+particular is where you can persist a distilled memory before the window gets
+summarized away, so the next compaction cycle doesn't start from zero. Most
+"memory for agents" setups only write to a file the agent has to remember to
+read; wiring it into the compaction lifecycle instead means the recall happens
+whether or not the model thinks to ask for it.
+
+(Disclosure: I build on these hooks in an open MCP server,
+github.com/dfrostar/neuralmind — but the hook seam itself is just Claude Code's
+public lifecycle API and worth using regardless of any tool.)
+```
+
+---
+
+### Notes for posting
+
+- Only post a comment if the thread is genuinely about this topic and the
+  comment adds something a reader would value even without the disclosure line.
+- Match the thread's specifics — edit the opening sentence to reference what the
+  OP actually said. A generic paste reads as spam; a specific reply reads as a
+  practitioner.
+- Never post all three in a short window across threads. Space them; engage with
+  replies.

--- a/docs/launch/r-localllama.md
+++ b/docs/launch/r-localllama.md
@@ -1,0 +1,86 @@
+# r/LocalLLaMA — self-post
+
+**Disclosed-maker post.** First person, as the author. r/LocalLLaMA tolerates
+maker self-posts when they're technical, honest, and local-first — which this is
+(100% local, no API key for the index). Disclose in the first line. Don't ask
+for upvotes.
+
+---
+
+## Title
+
+```
+I built a local semantic-memory layer for coding agents — and an honest benchmark to back it (100% local, no API key)
+```
+
+## Body (copy-paste)
+
+```
+I'm the author of NeuralMind, an open-source local memory layer for AI coding
+agents (Claude Code, Cursor, Cline, any MCP client). Posting it here because it's
+exactly the kind of thing this sub cares about: it runs 100% on-device, the index
+needs no API key, and your code never leaves the machine. The more capable your
+local model, the more each saved token is worth — context compression pays off
+more, not less, as models get better.
+
+The pitch in one line: instead of pasting files or dumping a vector-RAG result
+into the window, NeuralMind assembles a compact, structured context on demand
+(project map → relevant symbols → call edges), and a brain-like "synapse" layer
+learns which code goes with what from how you actually work.
+
+I'm allergic to token-reduction claims with no correctness number attached, so
+every benefit below ships with an eval you can run yourself. Four data-backed
+benefits, not just "fewer tokens":
+
+  💸 Cheaper context — 100% gold-file recall at 38–85× fewer tokens than pasting
+     files; beats ripgrep on BOTH recall and cost. (Public benchmark, real OSS
+     repos: requests, click.)
+
+  🎯 Finds the RIGHT code, not just less of it — 100% gold-file recall, MRR 0.96
+     (ranks the correct file at the top). Beats the incumbent codebase-memory-mcp
+     on retrieval ranking, 0.96 vs 0.23. (Same benchmark.)
+
+  🧠 Learns how you work — a Hebbian synapse layer that learns co-edited files
+     lifts top-k retrieval hit-rate +11.7 points (71.7% → 83.3%), budget-neutral
+     (no extra tokens). This is the part a static code index structurally can't
+     copy. (Synapse A/B eval.)
+
+  🔬 Better-grounded answers — at a matched token budget, the assembled context
+     carries more of the gold facts than naive truncation: faithfulness +0.143,
+     grounding 1.00. (Faithfulness/parity gate.)
+
+Honest scope (because this sub will and should ask): the cost + accuracy rows run
+on real, pinned OSS repos and are fully reproducible. The learning + grounding
+rows are committed A/Bs on a bundled reference fixture — real, but smaller-scope,
+and I label them that way. And where it loses: a well-tuned vector RAG using the
+same encoder ties it on pure findability and is cheaper on raw tokens. That's in
+the table, not buried — NeuralMind spends the extra tokens assembling readable
+structured context to *answer*, not just to locate the file.
+
+Reproduce the headline yourself (no trust required):
+
+  git clone https://github.com/dfrostar/neuralmind && cd neuralmind
+  pip install -e . tiktoken
+  python -m evals.public.run     # clones pinned repos, prints the table
+
+The gold file for each query is the objective definition site of a named symbol —
+verifiable with one rg command, no LLM judge. Queries are pre-registered before
+tuning and every one is reported, including losses.
+
+Repo: https://github.com/dfrostar/neuralmind
+Benchmark methodology + raw data: https://github.com/dfrostar/neuralmind/blob/main/docs/benchmarks/public.md
+
+Happy to go deep on the benchmark design, the synapse learning math, or how it
+plugs into a local agent loop. Tear it apart — that's why the harness is in the
+repo.
+```
+
+## If asked "how is this different from <X> / from plain RAG"
+
+Short answer to drop in a reply: "The retrieval core *is* a local vector index —
+I'm not hiding that, the `embedding-rag` baseline in the benchmark is literally
+my own encoder in isolation. The two things on top are (1) progressive disclosure
+that assembles structured context instead of dumping chunks, and (2) the synapse
+layer that learns associations from your usage and decays unused ones. The
+benchmark gap between `neuralmind` and `embedding-rag` is exactly the cost/benefit
+of that assembly layer, measured."

--- a/docs/launch/show-hn.md
+++ b/docs/launch/show-hn.md
@@ -1,0 +1,81 @@
+# Show HN
+
+**Disclosed-maker post.** Submit yourself; post the first comment right after.
+
+---
+
+## Title
+
+```
+Show HN: NeuralMind – semantic code memory for AI agents, with an honest benchmark
+```
+
+(Alt, if you want the number in the title:
+`Show HN: NeuralMind – 38–85× less context for code questions, benchmark included`)
+
+## URL
+
+```
+https://github.com/dfrostar/neuralmind
+```
+
+## First comment (post immediately after submitting)
+
+```
+Maker here. NeuralMind is a local semantic-memory layer for AI coding agents
+(Claude Code, Cursor, Cline, anything that speaks MCP). It does two things:
+
+1. Progressive context disclosure — instead of pasting files or dumping a
+   whole vector-RAG result into the window, it assembles a compact structured
+   context (project map → relevant symbols → call edges) on demand.
+
+2. A "synapse" layer — a Hebbian graph that learns which code goes with what
+   from how you actually work, decays unused links, and runs spreading
+   activation for recall. It's the part a static code index can't copy.
+
+I got tired of token-reduction claims with no correctness number attached, so
+the headline ships with a reproducible benchmark you can run yourself:
+
+  git clone https://github.com/dfrostar/neuralmind && cd neuralmind
+  pip install -e . tiktoken
+  python -m evals.public.run
+
+It clones real, pinned OSS repos (requests, click), and scores cost AND
+correctness together — "gold-file recall" where the gold file is the objective
+definition site of a named symbol (verifiable with one rg command, no LLM
+judge). On those repos: 100% gold-file recall at 38–85× fewer tokens than
+pasting files, beating ripgrep on both axes.
+
+Where it does NOT win, stated plainly: a well-tuned vector RAG using the same
+encoder ties it on pure findability and is cheaper on raw tokens — NeuralMind
+spends those extra tokens assembling readable structured context to *answer*,
+not just locate. That's in the table.
+
+I also ran a live head-to-head vs the obvious incumbent, codebase-memory-mcp
+0.8.1, on the same repos/questions/scorer at matched retrieval depth: 100%
+recall and MRR 0.96 vs 0.23 on requests. Pure retrieval ranking on both sides,
+their most-favorable keyword mapping, raw traces committed:
+python -m evals.public.competitor
+
+Methodology + raw data: https://github.com/dfrostar/neuralmind/blob/main/docs/benchmarks/public.md
+
+100% local, no API key needed for the index. Happy to answer anything —
+especially the skeptical questions about the benchmark design.
+```
+
+## Anticipated questions — short honest answers to have ready
+
+- **"Isn't this just RAG?"** The retrieval core *is* a vector index. The
+  difference is (a) progressive disclosure assembling structured context vs
+  dumping chunks, and (b) the synapse layer that learns associations from usage.
+  The benchmark isolates this — `embedding-rag` is literally NeuralMind's own
+  encoder in isolation, so the gap shows what the assembly layer adds and costs.
+- **"You picked easy repos."** They're pinned at SHAs you can check out; queries
+  are pre-registered in `evals/public/manifest.json` before tuning; every query
+  is reported including losses. Add your own repo and re-run — it's one manifest
+  entry.
+- **"Vector RAG beats you on tokens."** Yes, on bare findability. Said so in the
+  table and the comment. The extra tokens buy assembled context to answer with.
+- **"158 languages elsewhere."** The incumbent advertises 158 (vendored
+  grammars); its own paper scores 31, and C at 0.58. We ship 7 languages at
+  measured parity and disclose what's out (macros, templates, `#ifdef`).


### PR DESCRIPTION
## What

Persist the launch materials in the repo (`docs/launch/`) so they survive across sessions and stay pinned to the shipped v0.33.0 numbers.

| File | Venue |
|---|---|
| `show-hn.md` | Hacker News — Show HN title/url/first-comment + anticipated-question answers |
| `r-localllama.md` | r/LocalLLaMA — disclosed self-post with the four data-backed benefits block + live links |
| `awesome-mcp-servers.md` | `awesome-mcp-servers` directory entry + PR description |
| `hn-warmup-comments.md` | Genuine, on-topic, disclosed comments for adjacent HN threads |
| `README.md` | Index, live anchors, four-benefit single-source table, HN posting guidance |

## Numbers cited (all from shipped surfaces)

- **38–85× fewer tokens** at 100% gold-file recall — public benchmark (`requests`, `click`)
- **MRR 0.96 vs 0.23** vs `codebase-memory-mcp` 0.8.1 — competitor head-to-head
- **+11.7 pts** top-k hit-rate (synapse A/B), **faithfulness +0.143 / grounding 1.00**
- Honest-scope caveats carried in every post (vector RAG ties on findability + is cheaper on raw tokens; learning/grounding are reference-fixture A/Bs)

## Ethical constraint (by design)

Everything here is **first-person disclosed-maker only**. No unaffiliated end-user framing, no sockpuppet/persona content, no platform-rule evasion. If a venue won't allow a disclosed maker to post, we don't post there in disguise.

## Scope

Docs-only — no code, no version bump. Not a `feat:`/`fix:`, so it won't trigger a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015zHhQQ32QXMaT4cc7h7s8E

---
_Generated by [Claude Code](https://claude.ai/code/session_015zHhQQ32QXMaT4cc7h7s8E)_