### PR TITLE
ci: auto-dispatch GHCR image build on release-please tag

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -38,11 +38,26 @@ jobs:
       # guard, so dispatch the publish explicitly against the new tag —
       # the same recovery path release.yml already supports for manual
       # runs (its `tag` input).
-      - name: Dispatch PyPI/GHCR publish for the new tag
+      - name: Dispatch PyPI publish for the new tag
         if: ${{ steps.release.outputs.release_created }}
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           gh workflow run release.yml \
+            --repo "${{ github.repository }}" \
+            -f tag="${{ steps.release.outputs.tag_name }}"
+
+      # docker-publish.yml has the same push:tags blind spot as release.yml:
+      # release-please's GITHUB_TOKEN-created tag can't fire its push:tags
+      # trigger, so the GHCR image silently never built on a release (the
+      # tags drifted v0.22 → nothing until backfilled by hand). Dispatch it
+      # explicitly here, exactly like the PyPI publish above, so the
+      # multi-arch image lands on every release without a manual run.
+      - name: Dispatch GHCR image build for the new tag
+        if: ${{ steps.release.outputs.release_created }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh workflow run docker-publish.yml \
             --repo "${{ github.repository }}" \
             -f tag="${{ steps.release.outputs.tag_name }}"


### PR DESCRIPTION
## What

Adds a `workflow_dispatch` step to `release-please.yml` that kicks off `docker-publish.yml` for the newly released tag, mirroring the existing PyPI dispatch.

## Why

While merging the v0.34.0 release-please PR and watching it to green, I found the GHCR image never builds on a release:

- `release-please.yml` dispatched **only** `release.yml` (PyPI). It never dispatched `docker-publish.yml`.
- `docker-publish.yml` triggers only on `push: tags: 'v*'` — but release-please creates tags with `GITHUB_TOKEN`, and GitHub deliberately suppresses `push`-triggered workflows from token-created tags (the anti-loop guard). This is the *exact* reason `release.yml` already uses an explicit `workflow_dispatch` step instead of relying on `push: tags`. `docker-publish.yml` never got the same treatment.

The drift is visible on the registry — published GHCR tags are `v0.12.0`, `v0.13.0/.1`, `v0.21.0`, `v0.22.0`, then nothing. **v0.23 → v0.34 images were all missing**, and every Docker run on record is a manual `workflow_dispatch` (last one 2026-06-07).

## Fix

```yaml
- name: Dispatch GHCR image build for the new tag
  if: ${{ steps.release.outputs.release_created }}
  env:
    GH_TOKEN: ${{ github.token }}
  run: |
    gh workflow run docker-publish.yml \
      --repo "${{ github.repository }}" \
      -f tag="${{ steps.release.outputs.tag_name }}"
```

`docker-publish.yml` already accepts a `tag` input on `workflow_dispatch` and checks out that ref (via `RELEASE_TAG = inputs.tag || github.ref_name`), so no changes are needed on its side. From the next release onward the multi-arch image lands automatically alongside the PyPI publish, no manual run required.

## Note on v0.34.0

The v0.34.0 PyPI publish + GitHub Release already shipped green. I manually dispatched `docker-publish.yml` for `v0.34.0` (the historical recovery path) so this release's image is backfilled; this PR removes the need to do that by hand going forward. Backfilling the older missing tags (v0.30–v0.33) can be done separately if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DuSKbERBLmC1Q9D3WVP2XN)_