### PR TITLE
feat: expand public benchmark corpus with flask + rich (4 repos, 40 queries)

### DIFF
--- a/docs/benchmarks/public.md
+++ b/docs/benchmarks/public.md
@@ -26,7 +26,7 @@ python -m evals.public.run          # clones the pinned repos, prints the table
 
 | Decision | Why |
 |---|---|
-| **Real, recognizable repos** — `requests`, `click`, pinned to release SHAs | Anyone can `git checkout <sha>` and audit. No vendor fixture. |
+| **Real, recognizable repos** — `requests`, `click`, `flask`, `rich`, pinned to release SHAs | Anyone can `git checkout <sha>` and audit. No vendor fixture. Household-name repos, not cherry-picked easy ones. |
 | **Objective gold, no LLM judge** | Each query's gold file is the **definition site** of a named symbol, verifiable with one `rg` command. A baseline "answers" iff the gold file lands in its assembled context. Deterministic, nothing to rig. |
 | **Cost + correctness reported jointly** | The headline is "recall at N× fewer tokens," never a lone ratio. |
 | **Strong baselines, disclosed** | Not just naive whole-file dumps — we include keyword (`ripgrep`) and a function-level vector RAG using the *same encoder* NeuralMind uses. |
@@ -158,10 +158,22 @@ headline stays primary.
 
 ## Extending the corpus
 
-The corpus is intentionally focused, not exhaustive. Add a repo by appending to
-`evals/public/manifest.json` (pin the commit, give each query an objective
-def-site gold file) and re-running. Community-contributed real-repo numbers go
-through the existing `neuralmind benchmark . --contribute` path.
+The corpus spans **four pinned repos / 40 pre-registered queries**: `requests`
+(14) and `click` (7) — the original headline pair, with committed numbers above
+— plus **`flask` @ `c12a5d87` (10)** and **`rich` @ `7f580bdc` (9)**, added to
+harden the "you picked easy repos" critique with two more household-name
+projects. Every `flask`/`rich` query's gold file is the **objective definition
+site** of its named symbol, verified with `rg` against the pinned commit (e.g.
+`class Flask` in `app.py`, `class Console` in `console.py`) — pre-registered in
+`evals/public/manifest.json` *before* any run, exactly as the methodology
+requires (gold first, numbers second). Their cost+correctness rows regenerate
+with `python -m evals.public.run` (the committed `requests`/`click` snapshot
+stays a subset of the manifest, so nothing is fabricated in between).
+
+Add a repo the same way: append to `evals/public/manifest.json` (pin the commit,
+give each query an objective def-site gold file) and re-run. Community-contributed
+real-repo numbers go through the existing `neuralmind benchmark . --contribute`
+path.
 
 ## Competitor head-to-head — `codebase-memory-mcp` 0.8.1
 

--- a/evals/public/manifest.json
+++ b/evals/public/manifest.json
@@ -152,6 +152,142 @@
           "shape": "cross-file"
         }
       ]
+    },
+    {
+      "name": "flask",
+      "url": "https://github.com/pallets/flask",
+      "tag": "3.0.3",
+      "commit": "c12a5d874c5a014495eb2db8a73f40037bc813ac",
+      "subdir": "src/flask",
+      "language": "python",
+      "queries": [
+        {
+          "id": "application-object",
+          "question": "the central WSGI application object you create configure and run",
+          "gold_files": ["app.py"],
+          "oracle_symbol": "class Flask"
+        },
+        {
+          "id": "blueprint-component",
+          "question": "how are modular groups of routes registered as a reusable component",
+          "gold_files": ["blueprints.py"],
+          "oracle_symbol": "class Blueprint"
+        },
+        {
+          "id": "config-object",
+          "question": "the dict-like object that loads and stores application configuration",
+          "gold_files": ["config.py"],
+          "oracle_symbol": "class Config"
+        },
+        {
+          "id": "app-context",
+          "question": "the object that binds the application to the current context so current_app works",
+          "gold_files": ["ctx.py"],
+          "oracle_symbol": "class AppContext"
+        },
+        {
+          "id": "method-view",
+          "question": "the base class for class-based views dispatched by HTTP method",
+          "gold_files": ["views.py"],
+          "oracle_symbol": "class MethodView"
+        },
+        {
+          "id": "request-wrapper",
+          "question": "the request object wrapping the incoming WSGI environ",
+          "gold_files": ["wrappers.py"],
+          "oracle_symbol": "class Request"
+        },
+        {
+          "id": "cli-group",
+          "question": "the click command group that loads the app and runs flask cli commands",
+          "gold_files": ["cli.py"],
+          "oracle_symbol": "class FlaskGroup"
+        },
+        {
+          "id": "session-interface",
+          "question": "the interface that serializes the user session into a signed secure cookie",
+          "gold_files": ["sessions.py"],
+          "oracle_symbol": "class SecureCookieSessionInterface"
+        },
+        {
+          "id": "url-building",
+          "question": "the helper that builds a url for a given endpoint by name",
+          "gold_files": ["helpers.py"],
+          "oracle_symbol": "def url_for"
+        },
+        {
+          "id": "xfile-dispatch-context",
+          "question": "how does full_dispatch_request run the view inside the RequestContext pushed for the request",
+          "gold_files": ["app.py", "ctx.py"],
+          "oracle_symbol": "Flask.full_dispatch_request + RequestContext",
+          "shape": "cross-file"
+        }
+      ]
+    },
+    {
+      "name": "rich",
+      "url": "https://github.com/Textualize/rich",
+      "tag": "v13.7.1",
+      "commit": "7f580bdcf07a3b269a0e786b6a3aa9c804f393cf",
+      "subdir": "rich",
+      "language": "python",
+      "queries": [
+        {
+          "id": "console-core",
+          "question": "the central object that renders and prints rich content to the terminal",
+          "gold_files": ["console.py"],
+          "oracle_symbol": "class Console"
+        },
+        {
+          "id": "table-renderable",
+          "question": "the renderable that lays out data in rows and columns as a table",
+          "gold_files": ["table.py"],
+          "oracle_symbol": "class Table"
+        },
+        {
+          "id": "styled-text",
+          "question": "the class holding a string together with its style spans",
+          "gold_files": ["text.py"],
+          "oracle_symbol": "class Text"
+        },
+        {
+          "id": "panel-box",
+          "question": "the renderable that draws a box with a border around content",
+          "gold_files": ["panel.py"],
+          "oracle_symbol": "class Panel"
+        },
+        {
+          "id": "color-model",
+          "question": "the type representing a parsed terminal color and its rgb triplet",
+          "gold_files": ["color.py"],
+          "oracle_symbol": "class Color"
+        },
+        {
+          "id": "syntax-highlight",
+          "question": "the renderable that syntax-highlights source code with a theme",
+          "gold_files": ["syntax.py"],
+          "oracle_symbol": "class Syntax"
+        },
+        {
+          "id": "progress-bars",
+          "question": "the class that drives animated progress bars with multiple tasks",
+          "gold_files": ["progress.py"],
+          "oracle_symbol": "class Progress"
+        },
+        {
+          "id": "markdown-render",
+          "question": "the renderable that parses and displays markdown in the terminal",
+          "gold_files": ["markdown.py"],
+          "oracle_symbol": "class Markdown"
+        },
+        {
+          "id": "xfile-console-table",
+          "question": "how does Console.render drive a Table's __rich_console__ to produce segments",
+          "gold_files": ["console.py", "table.py"],
+          "oracle_symbol": "Console.render + Table.__rich_console__",
+          "shape": "cross-file"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## What

Expands the honest public benchmark corpus from **2 → 4 repos** (and **21 → 40 pre-registered queries**) by adding two more household-name Python projects, directly hardening the "you picked easy repos" critique.

| Repo | Pin | Subdir | Queries |
|---|---|---|---|
| `requests` | `0e322af877` | `src/requests` | 14 (unchanged) |
| `click` | `874ca2bc1c` | `src/click` | 7 (unchanged) |
| **`flask`** | **3.0.3 / `c12a5d87`** | `src/flask` | **10 (new)** |
| **`rich`** | **v13.7.1 / `7f580bdc`** | `rich` | **9 (new)** |

**flask queries:** `class Flask`, `Blueprint`, `Config`, `AppContext`, `MethodView`, `Request`, `FlaskGroup`, `SecureCookieSessionInterface`, `url_for`, + a cross-file `full_dispatch_request`/`RequestContext`.
**rich queries:** `Console`, `Table`, `Text`, `Panel`, `Color`, `Syntax`, `Progress`, `Markdown`, + a cross-file `Console.render`/`Table.__rich_console__`.

## Methodology — pre-registered, def-site gold

Every new query's `gold_files` is the **objective definition site** of its `oracle_symbol`, verified with `rg` against the pinned commit (all 21 new gold-file/symbol pairs checked: `class Flask` in `app.py`, `class Console` in `console.py`, …). Per the PRD, queries are **pre-registered** — committed to `evals/public/manifest.json` *before* any run (gold first, numbers second).

The headline cost+correctness rows for flask/rich regenerate out-of-band via `python -m evals.public.run` (needs network + the embedding stack). The committed `requests`/`click` snapshot under `bench/public/` stays a **subset** of the manifest, so `test_committed_results_match_manifest_repos` and the competitor manifest-consistency test **stay green** — nothing is fabricated in between.

## What ships

- `evals/public/manifest.json` — flask + rich repo entries (pinned, def-site gold).
- `docs/benchmarks/public.md` — corpus section updated to 4 repos / 40 queries with the pre-registration note.

## Notes

- `feat:` → folds into the pending batched release (with C#/Ruby/PHP) per the agreed cadence.
- No code changes; the hermetic benchmark unit tests are unaffected. Held as a draft for merge approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DuSKbERBLmC1Q9D3WVP2XN)_