### PR TITLE
docs: enrich schema.org JSON-LD on docs pages (SEO)

### DIFF
--- a/docs/about.html
+++ b/docs/about.html
@@ -9,17 +9,29 @@
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
-      "@type": "Article",
+      "@type": "TechArticle",
       "headline": "About NeuralMind — Semantic Code Intelligence with Brain-like Memory",
-      "description": "How NeuralMind gives AI coding agents persistent memory: a brain-like synapse layer that learns associations from how you use the codebase, progressive context disclosure for 40–70× token reduction, an Obsidian-style graph view, an MCP server, and a built-in install doctor.",
+      "description": "How NeuralMind gives AI coding agents persistent memory: a brain-like synapse layer that learns associations from how you use the codebase, progressive context disclosure for 40–70× token reduction, a bundled tree-sitter code graph indexing ten languages (Python, TypeScript, Go, Rust, Java, C, C++, C#, Ruby, PHP), an Obsidian-style graph view, an MCP server, and a built-in install doctor.",
       "author": { "@type": "Person", "name": "Darren Frost" },
-      "about": "AI coding agents, semantic code intelligence, token optimization",
+      "publisher": { "@type": "Person", "name": "Darren Frost" },
+      "about": "AI coding agents, semantic code intelligence, token optimization, multi-language code indexing",
+      "keywords": "AI coding agent memory, code intelligence, token reduction, Hebbian synapses, MCP server, tree-sitter code graph, ten-language code indexing",
       "url": "https://dfrostar.github.io/neuralmind/about.html",
+      "mainEntityOfPage": "https://dfrostar.github.io/neuralmind/about.html",
       "isPartOf": {
         "@type": "SoftwareApplication",
+        "@id": "https://dfrostar.github.io/neuralmind/#software",
         "name": "NeuralMind",
         "applicationCategory": "DeveloperApplication",
-        "softwareVersion": "0.22.0"
+        "operatingSystem": "Linux, macOS, Windows",
+        "softwareVersion": "0.37.0",
+        "downloadUrl": "https://pypi.org/project/neuralmind/",
+        "license": "https://opensource.org/licenses/MIT",
+        "isAccessibleForFree": true,
+        "sameAs": [
+          "https://github.com/dfrostar/neuralmind",
+          "https://pypi.org/project/neuralmind/"
+        ]
       }
     }
     </script>

--- a/docs/index.html
+++ b/docs/index.html
@@ -19,19 +19,53 @@
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
-      "@type": "SoftwareApplication",
-      "name": "NeuralMind",
-      "applicationCategory": "DeveloperApplication",
-      "operatingSystem": "Linux, macOS, Windows",
-      "description": "Persistent memory and semantic code intelligence for AI coding agents. Local-first code indexing with 40–70× per-query token reduction, a brain-like synapse layer that learns associations from how you use the codebase, an Obsidian-style graph view, an MCP server, and a built-in install doctor. Works with Claude Code, Cursor, Cline, Continue, and any MCP-compatible agent.",
-      "url": "https://dfrostar.github.io/neuralmind/",
-      "downloadUrl": "https://pypi.org/project/neuralmind/",
-      "softwareVersion": "0.33.0",
-      "license": "https://opensource.org/licenses/MIT",
-      "programmingLanguage": "Python",
-      "operatingSystemRequirements": "Python 3.10+",
-      "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
-      "author": { "@type": "Person", "name": "Darren Frost" }
+      "@graph": [
+        {
+          "@type": "SoftwareApplication",
+          "@id": "https://dfrostar.github.io/neuralmind/#software",
+          "name": "NeuralMind",
+          "applicationCategory": "DeveloperApplication",
+          "applicationSubCategory": "AI coding agent memory & code intelligence",
+          "operatingSystem": "Linux, macOS, Windows",
+          "description": "Persistent memory and semantic code intelligence for AI coding agents. Local-first code indexing with 40–70× per-query token reduction, a brain-like synapse layer that learns associations from how you use the codebase, an Obsidian-style graph view, an MCP server, and a built-in install doctor. Works with Claude Code, Cursor, Cline, Continue, and any MCP-compatible agent.",
+          "url": "https://dfrostar.github.io/neuralmind/",
+          "downloadUrl": "https://pypi.org/project/neuralmind/",
+          "installUrl": "https://pypi.org/project/neuralmind/",
+          "softwareVersion": "0.37.0",
+          "datePublished": "2025-05-01",
+          "license": "https://opensource.org/licenses/MIT",
+          "isAccessibleForFree": true,
+          "programmingLanguage": "Python",
+          "operatingSystemRequirements": "Python 3.10+",
+          "codeRepository": "https://github.com/dfrostar/neuralmind",
+          "keywords": "AI coding agent memory, code intelligence, token reduction, RAG, MCP server, knowledge graph, Hebbian synapses, progressive context disclosure, tree-sitter code graph, multi-language code indexing",
+          "featureList": [
+            "Progressive L0–L3 context disclosure for 40–70× per-query token reduction",
+            "Brain-like Hebbian synapse layer that learns associations from how you use the codebase (+11.7 pts hit-rate, budget-neutral)",
+            "Bundled tree-sitter code graph indexing ten languages out of the box: Python, TypeScript, Go, Rust, Java, C, C++, C#, Ruby, PHP",
+            "Honest public benchmark: 100% gold-file recall at 38–85× fewer tokens vs pasting files, on pinned real OSS repos",
+            "MCP server for Claude Code, Cursor, Cline, Continue, and any MCP-compatible agent",
+            "Obsidian-style local graph view and a recovery cache for dropped tool output",
+            "100% local — no code leaves your machine"
+          ],
+          "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
+          "author": { "@type": "Person", "name": "Darren Frost" },
+          "publisher": { "@type": "Person", "name": "Darren Frost" },
+          "sameAs": [
+            "https://github.com/dfrostar/neuralmind",
+            "https://pypi.org/project/neuralmind/"
+          ]
+        },
+        {
+          "@type": "WebSite",
+          "@id": "https://dfrostar.github.io/neuralmind/#website",
+          "name": "NeuralMind",
+          "url": "https://dfrostar.github.io/neuralmind/",
+          "description": "Persistent memory for AI coding agents — 40–70× cheaper code questions, a synapse layer that learns your codebase, and a bundled ten-language code graph.",
+          "about": { "@id": "https://dfrostar.github.io/neuralmind/#software" },
+          "inLanguage": "en"
+        }
+      ]
     }
     </script>
     <link rel="preconnect" href="https://fonts.googleapis.com">


### PR DESCRIPTION
## What

Closes the **schema.org JSON-LD** SEO gap flagged in `CLAUDE.md`. Both docs pages already carried a thin JSON-LD block with **stale versions** (`0.33.0` on index, `0.22.0` on about); this enriches them into current, richer structured data for better Google rich results.

## Changes

**`docs/index.html`** — single `SoftwareApplication` → a `@graph` of:
- `SoftwareApplication` (`@id`-anchored) with a real **`featureList`** (ten-language tree-sitter indexing, the Hebbian synapse learning lift, the honest public benchmark, MCP server, local graph view), **`keywords`**, **`sameAs`** (GitHub + PyPI), `codeRepository`, `isAccessibleForFree`, and **`softwareVersion` bumped to `0.37.0`**.
- a `WebSite` node linked to the software via `about` → `@id`.

**`docs/about.html`** — `Article` → **`TechArticle`** with `publisher`, `keywords`, `mainEntityOfPage`, and an `isPartOf` `SoftwareApplication` (`@id`-linked to the index node, `softwareVersion 0.37.0`, `sameAs`).

## Verification

Both embedded JSON-LD blocks were parsed and validated as well-formed JSON (`@type`: `SoftwareApplication` + `WebSite`; `TechArticle`). No claims that can't be backed (no fabricated `aggregateRating`). Docs-only — no behavior change.

## Notes

- `docs:` commit (no release-please bump); rides along in the pending batched v0.37.0 release per the agreed cadence. Held as a draft for merge approval.
- This completes the roadmap trio you set: (a) C#/Ruby/PHP languages, (b) corpus expansion (#271), (c) schema.org JSON-LD (this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DuSKbERBLmC1Q9D3WVP2XN)_