### PR TITLE
docs: umbrella v0.37.0 release notes + Release-As 0.37.0

### DIFF
--- a/RELEASE_NOTES_v0.37.0.md
+++ b/RELEASE_NOTES_v0.37.0.md
@@ -1,8 +1,31 @@
-# NeuralMind v0.37.0 — PHP joins the bundled backend (ten languages)
+# NeuralMind v0.37.0 — ten languages, a bigger benchmark, richer SEO
 
 **Release Date:** June 2026
 
-## TL;DR
+## What's in this release
+
+v0.37.0 lands the full **language-breadth tier** plus benchmark and discovery
+work in one release. The bundled tree-sitter backend goes from seven to **ten
+languages** — adding **C#, Ruby, and PHP**, each proven at the same
+structural-parity gate (100% symbol coverage vs a committed gold, zero dangling
+edges):
+
+| Change | What | Evidence |
+|---|---|---|
+| **C# extractor** | eighth language (`.cs`) | 52/52 symbols (100%), 0 dangling — see [`RELEASE_NOTES_v0.35.0.md`](RELEASE_NOTES_v0.35.0.md) |
+| **Ruby extractor** | ninth language (`.rb`) | 46/46 symbols (100%), 0 dangling — see [`RELEASE_NOTES_v0.36.0.md`](RELEASE_NOTES_v0.36.0.md) |
+| **PHP extractor** | tenth language (`.php`) | 54/54 symbols (100%), 0 dangling — detailed below |
+| **Benchmark corpus** | the honest public benchmark expands `requests`/`click` → **+ `flask` + `rich`** (4 repos, 40 pre-registered def-site queries) | `evals/public/manifest.json`, `docs/benchmarks/public.md` |
+| **SEO** | richer schema.org JSON-LD (`SoftwareApplication` + `WebSite`, `TechArticle`) on the docs pages | `docs/index.html`, `docs/about.html` |
+
+The bundled backend now indexes **Python, TypeScript, Go, Rust, Java, C, C++,
+C#, Ruby, PHP** out of the box, completing the C#/Ruby/PHP breadth tier. The rest
+of this note details the PHP extractor (the headline tenth language); the C# and
+Ruby deep-dives are in their per-language notes linked above.
+
+---
+
+## TL;DR — PHP, the tenth language
 
 The bundled tree-sitter backend now indexes **PHP** (`.php`) — taking NeuralMind
 to **ten languages** (Python, TypeScript, Go, Rust, Java, C, C++, C#, Ruby, PHP)


### PR DESCRIPTION
## What

Reconciles the **batched-release version** before publishing. Per the batch decision, C#, Ruby, PHP, the benchmark-corpus expansion, and the JSON-LD SEO refresh all ship as **one** release. release-please computed `0.35.0` (a single minor bump), but the entire public surface already advertises **v0.37.0** (README/index/about banners, CLI-Reference, use-cases, JSON-LD).

This commit:
1. Carries a **`Release-As: 0.37.0`** footer so release-please retitles the pending release PR (#268) to **v0.37.0** — matching the shipped docs. PyPI goes 0.34.0 → 0.37.0.
2. Turns **`RELEASE_NOTES_v0.37.0.md` into the umbrella** for the whole release (a "What's in this release" table covering C#/Ruby/PHP/corpus/JSON-LD, linking the per-language deep-dives `RELEASE_NOTES_v0.35.0.md`/`v0.36.0.md`, keeping the PHP detail as the headline). `release.yml` attaches this file as the GitHub Release body.

## Why not 0.35.0

Accepting 0.35.0 would require reverting all the already-merged v0.37.0 doc/banner/JSON-LD work back down. Forcing 0.37.0 is the least-change, internally-consistent path and honors the "one release" decision.

Docs-only; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DuSKbERBLmC1Q9D3WVP2XN)_