### PR TITLE
chore(seo): add complementary-app comparison keywords to PyPI metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -188,8 +188,16 @@ keywords = [
     "reproducible-benchmark",
     "token-cost-benchmark",
     "codebase-memory-mcp-benchmark",
+    "codebase-memory-mcp-alternative",
+    "code-memory-mcp",
     "code-mcp-comparison",
-    "mcp-benchmark"
+    "mcp-benchmark",
+    "headroom-alternative",
+    "neuralmind-vs-headroom",
+    "ponytail-alternative",
+    "context-engineering-stack",
+    "retrieval-transport-generation",
+    "complementary-context-tools"
 ]
 classifiers = [
     "Development Status :: 4 - Beta",


### PR DESCRIPTION
## What

Aligns the PyPI search surface (`pyproject.toml` keywords) with the discovery cluster the docs `<meta>`/JSON-LD already carry, so searches for the **complementary / compared apps** also surface NeuralMind on PyPI.

The docs pages already rank for Headroom / Ponytail / codebase-memory-mcp; the package metadata lagged. Added (all backed by comparison docs already in-repo — no invented competitors):

| Keyword | Backed by |
|---|---|
| `headroom-alternative`, `neuralmind-vs-headroom` | `docs/comparisons/vs-headroom.md` (real tool `chopratejas/headroom`) |
| `ponytail-alternative`, `context-engineering-stack`, `retrieval-transport-generation`, `complementary-context-tools` | `docs/comparisons/context-engineering-stack.md` (real tool `DietrichGebert/ponytail`) |
| `codebase-memory-mcp-alternative`, `code-memory-mcp` | `docs/benchmarks/public.md` head-to-head |

## Why honest

Every term maps to a real, disclosed comparison or benchmark already shipped in the repo. The Headroom/Ponytail docs concede where those tools lead (e.g. "if compression is the whole job, there is no contest — use Headroom"). No sockpuppet positioning, no fabricated competitors.

## Scope

Metadata-only; no code or behavior change. Rides the next release to take effect on PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DuSKbERBLmC1Q9D3WVP2XN)_