### PR TITLE
docs: refresh launch handoff to v0.37.0 state

### DIFF
--- a/docs/launch/NEXT-SESSION.md
+++ b/docs/launch/NEXT-SESSION.md
@@ -1,39 +1,47 @@
 # Session handoff — launch readiness
 
-**Last updated:** 2026-06-20 · **State:** v0.30→v0.34 shipped & merged to `main`
+**Last updated:** 2026-06-21 · **State:** v0.30→v0.37 shipped & merged to `main`
 **Copy-paste this whole file into the next session's first message to resume with full context.**
 
 ---
 
 ## ▶ Do this first (next session, in order)
 
-1. **Merge the v0.34.0 release-please PR.** It opens automatically after the
-   answerability `feat:` (#264) merged; merging it tags `v0.34.0` and fires the
-   PyPI + GHCR publish. Nothing else ships until this lands. (Tell the session
-   "merge the release-please PR and watch it to green.") Never hand-edit the
-   version/CHANGELOG — release-please owns them.
-2. **Generate + commit the answerability transcripts** (optional but
-   recommended). The `--judge` harness shipped in v0.34.0 but `bench/public/judge/`
-   is empty. Run `neuralmind benchmark --public --judge` with `ANTHROPIC_API_KEY`
-   set (costs real tokens) and commit the transcripts, so the launch posts can
-   show a concrete answerability table, not just "run it yourself."
-3. **Launch — maker's move, disclosed only.** Copy is ready in `docs/launch/`
+1. **Nothing is blocked on code.** The value-ordered roadmap *and* the next
+   breadth tier are all shipped and released (v0.30→v0.37, see table below).
+   The remaining work is **execution + proof + discovery**, not engineering.
+2. **Generate + commit the answerability transcripts** (the one remaining
+   *proof* item). The `--judge` harness shipped in v0.34.0 but
+   `bench/public/judge/` is still empty. Run
+   `neuralmind benchmark --public --judge` with `ANTHROPIC_API_KEY` set (costs
+   real tokens) and commit the transcripts, so the launch posts show a concrete
+   answerability table instead of "run it yourself." This directly pre-empts the
+   "recall ≠ answering" critique a serious reviewer will raise. **Still blocked
+   on a key in the session env.**
+3. **Two GitHub-UI edits only the maker can do** (no API in the agent toolset
+   sets these; paste-ready copy is in this session's history / below):
+   - Repo **About → description + Topics** — add the comparison/complementary
+     terms (`codebase-memory-mcp-alternative`, `headroom-alternative`,
+     `ponytail`, `context-engineering-stack`, `graphify-alternative`) so the
+     surface search engines weight most carries them.
+   - **v0.37.0 Release body** — swap the raw changelog for the umbrella notes
+     (`RELEASE_NOTES_v0.37.0.md`) + the honest comparison footer.
+4. **Launch — maker's move, disclosed only.** Copy is ready in `docs/launch/`
    (Show HN, r/LocalLLaMA, awesome-mcp PR, warm-up comments). Post as yourself.
    The disclosed-maker-only rule below is non-negotiable.
-4. **Pick the next roadmap item** (all four value-ordered ones are shipped),
-   ranked: (a) **more languages** (C#/Ruby/PHP) behind the
-   `_SUFFIX_LANG`→`_EXTRACTORS` seam — additive, parity-gated; (b) **expand the
-   benchmark corpus** beyond `requests`/`click`; (c) **schema.org JSON-LD** on
-   docs pages (the SEO gap in CLAUDE.md).
 
 ## TL;DR for the next session
 
-NeuralMind is **launch-ready**. Five releases shipped (v0.30→v0.34): team
-memory, the honest public benchmark, C/C++, the competitor head-to-head, and the
-opt-in LLM-judged answerability arm. Public-facing positioning is the **four
-data-backed benefits**, and the launch copy lives in `docs/launch/`. The
+NeuralMind is **launch-ready and feature-complete for this arc**. Eight releases
+shipped (v0.30→v0.37): team memory, the honest public benchmark, C/C++, the
+live competitor head-to-head, the opt-in LLM-judged answerability arm, then the
+**full language-breadth tier (C#, Ruby, PHP → ten languages)**, a **4-repo /
+40-query benchmark corpus** (`requests`, `click`, `flask`, `rich`), and
+**schema.org JSON-LD** on the docs pages. Public-facing positioning is the
+**four data-backed benefits**, and the launch copy lives in `docs/launch/`. The
 remaining work is **execution** (the maker posts to HN / r/LocalLLaMA /
-awesome-mcp) plus the next roadmap item. Nothing is blocked on code.
+awesome-mcp), the **answerability transcripts** (needs a key), and two
+**GitHub-UI edits** (About/topics, Release body). Nothing is blocked on code.
 
 The one hard standing rule, carried across sessions: **disclosed-maker only**
 for all outreach. No unaffiliated-end-user posts, no sockpuppet/persona
@@ -44,29 +52,37 @@ every time — keep declining it; the benchmark credibility is the whole asset.
 
 ## What shipped this arc (done — on `main`, released)
 
-| Version | Feature | PR | Evidence |
-|---|---|---|---|
-| v0.30.0 | **Team memory** — commit learned synapse signal; teammates' agents inherit it (`.neuralmind-team-memory.json`, `shared` namespace, content-hash idempotent, fail-open) | shipped within #257 | `tests/test_team_memory.py` |
-| v0.31.0 | **Honest public benchmark** — `neuralmind benchmark --public`, gold-file recall (objective def-site oracle, no LLM judge), cost+correctness jointly | #257 | `evals/public/`, `docs/benchmarks/public.md` |
-| v0.32.0 | **C / C++ extractors** — tree-sitter backend now 7 languages, proven at parity (100% coverage, 0 dangling) | #259-ish | `tests/test_graphgen.py` (C/CExtractorEdgeCase) |
-| v0.33.0 | **Live competitor head-to-head** vs `codebase-memory-mcp` 0.8.1 — same repos/questions/scorer, raw traces committed | #259/#260 | `evals/public/competitor.py`, `bench/public/competitor/` |
-| v0.34.0 | **Opt-in LLM-judged answerability arm** (`--judge`) — each backend answered from its real window by a pinned model, graded vs. the def-site gold anchor; closes the "recall ≠ answering" gap | #264 | `evals/public/judge.py`, `bench/public/judge/` (transcripts TODO) |
-| (docs) | **Four-benefit positioning** across README + docs + wiki | #261 | README "Why NeuralMind" |
-| (docs) | **Launch kit** — this folder | #263 | `docs/launch/` |
+| Version | Feature | Evidence |
+|---|---|---|
+| v0.30.0 | **Team memory** — commit learned synapse signal; teammates' agents inherit it (`.neuralmind-team-memory.json`, `shared` namespace, content-hash idempotent, fail-open) | `tests/test_team_memory.py` |
+| v0.31.0 | **Honest public benchmark** — `neuralmind benchmark --public`, gold-file recall (objective def-site oracle, no LLM judge), cost+correctness jointly | `evals/public/`, `docs/benchmarks/public.md` |
+| v0.32.0 | **C / C++ extractors** — tree-sitter backend → 7 languages, proven at parity (100% coverage, 0 dangling) | `tests/test_graphgen.py` |
+| v0.33.0 | **Live competitor head-to-head** vs `codebase-memory-mcp` 0.8.1 — same repos/questions/scorer, raw traces committed | `evals/public/competitor.py`, `bench/public/competitor/` |
+| v0.34.0 | **Opt-in LLM-judged answerability arm** (`--judge`) — each backend answered from its real window by a pinned model, graded vs. the def-site gold anchor | `evals/public/judge.py`, `bench/public/judge/` (transcripts TODO) |
+| v0.35.0 | **C# extractor** — eighth language (`.cs`), 52/52 symbols (100%), 0 dangling | `RELEASE_NOTES_v0.35.0.md` |
+| v0.36.0 | **Ruby extractor** — ninth language (`.rb`), 46/46 symbols (100%), 0 dangling | `RELEASE_NOTES_v0.36.0.md` |
+| v0.37.0 | **PHP extractor** — tenth language (`.php`), 54/54 symbols (100%), 0 dangling; **benchmark corpus → 4 repos / 40 queries** (`flask` + `rich`); **schema.org JSON-LD** on docs pages | `RELEASE_NOTES_v0.37.0.md` (umbrella) |
+| (seo) | **Complementary-app comparison keywords** propagated to PyPI metadata (Headroom / Ponytail / codebase-memory-mcp / graphify), matching the docs `<meta>` cluster | `pyproject.toml` keywords (PR #274) |
+| (docs) | **Four-benefit positioning** + **launch kit** | README "Why NeuralMind", `docs/launch/` |
+
+The bundled tree-sitter backend now indexes **ten languages** out of the box:
+Python, TypeScript, Go, Rust, Java, C, C++, C#, Ruby, PHP — the C#/Ruby/PHP
+breadth tier is **complete**.
 
 ## Current state of the repo
 
-- `main` includes v0.34.0's `feat:` (#264 merged); the **v0.34.0 release-please PR
-  will open automatically** — merging it tags the release and publishes.
-- PRs #263 (launch kit) and #264 (answerability arm) are **merged**.
-- Outstanding: merge the release PR; optionally generate the `bench/public/judge/`
-  transcripts (needs `ANTHROPIC_API_KEY`). See "▶ Do this first" at the top.
+- `main` is at **v0.37.0** (PyPI + GHCR published, GitHub Release tagged).
+- The GHCR auto-publish gap is permanently fixed (the release-please workflow
+  dispatches the GHCR build on tag).
+- Outstanding (all non-code): answerability transcripts (needs
+  `ANTHROPIC_API_KEY`); the two GitHub-UI edits (About/topics, Release body);
+  the launch itself.
 
 ## The four data-backed benefits (single source of truth: README "Why NeuralMind")
 
 | Benefit | Result | Where measured |
 |---|---|---|
-| Cheaper context | 100% gold-file recall at **38–85× fewer tokens** vs pasting files; beats `ripgrep` on both axes | public benchmark (`requests`, `click`) |
+| Cheaper context | 100% gold-file recall at **38–85× fewer tokens** vs pasting files; beats `ripgrep` on both axes | public benchmark (`requests`, `click`, `flask`, `rich`) |
 | Finds the *right* code | 100% recall, **MRR 0.96**; beats `codebase-memory-mcp` ranking (0.96 vs 0.23) | same benchmark |
 | Learns how you work | Hebbian synapses **+11.7 pts** hit-rate (71.7%→83.3%), budget-neutral | synapse A/B |
 | Better-grounded answers | matched budget: **faithfulness +0.143, grounding 1.00** | parity/faithfulness gate |
@@ -76,35 +92,54 @@ reproducible; learning+grounding are reference-fixture A/Bs (real, smaller-scope
 a well-tuned vector RAG ties on findability and is cheaper on raw tokens — shown
 in the table, not hidden.
 
+## Complementary apps we compare to (honest, backed by in-repo docs)
+
+These compose with NeuralMind as the **context-engineering stack** (retrieval →
+transport → generation), each with a disclosed comparison doc that concedes
+where the other tool leads:
+
+- **Headroom** (`chopratejas/headroom`) — transport-layer compression →
+  `docs/comparisons/vs-headroom.md`
+- **Ponytail** (`DietrichGebert/ponytail`) — generation steering →
+  `docs/comparisons/context-engineering-stack.md`
+- **codebase-memory-mcp** — the live head-to-head → `docs/benchmarks/public.md`
+
+Paste-ready GitHub copy (the maker applies these by hand):
+
+> **About description:** Persistent memory + semantic code intelligence for AI
+> coding agents. 100% local, 40–70× cheaper code questions. Composes with
+> Headroom (transport compression) and Ponytail (generation steering) as the
+> context-engineering stack; benchmarked head-to-head vs codebase-memory-mcp.
+
+> **Topics:** ai-coding-agents · mcp-server · claude-code · cursor ·
+> code-intelligence · semantic-code-search · token-optimization ·
+> context-engineering · knowledge-graph · hebbian-learning · local-first ·
+> tree-sitter · rag · codebase-memory-mcp-alternative · headroom-alternative ·
+> ponytail · context-engineering-stack · graphify-alternative · code-memory-mcp ·
+> retrieval-benchmark
+
 ---
 
 ## Recommended next steps (in priority order)
 
-1. **Merge #263** once you're happy with the post copy (held for your okay;
-   docs-only, won't trigger a release).
-2. **Execute the launch** — you, as the disclosed maker:
+1. **Generate the answerability transcripts** (`bench/public/judge/`) — the one
+   proof item left; needs `ANTHROPIC_API_KEY`. Commit them so launch posts show
+   a concrete table.
+2. **Apply the two GitHub-UI edits** (About/topics, Release body) — copy above.
+3. **Execute the launch** — you, as the disclosed maker:
    - Submit the Show HN (`docs/launch/show-hn.md`), post the first comment
      immediately, be around to answer for the first few hours.
    - Post the r/LocalLLaMA self-post (`docs/launch/r-localllama.md`).
    - Open the awesome-mcp-servers PR (`docs/launch/awesome-mcp-servers.md`).
    - Use the warm-up comments (`docs/launch/hn-warmup-comments.md`) only on
      genuinely relevant threads, disclosed.
-3. **Pick the next roadmap item** (see candidates below). The value-ordered
-   four are done; the next tier is about deepening the proof and breadth.
-
-### Candidate next roadmap items (not yet started)
-
-- **Opt-in LLM-judged answerability arm** for the public benchmark
-  (`--judge`, publish model+prompt+transcripts as a clearly-labeled *secondary*
-  signal). Already scoped as "planned" in `docs/benchmarks/public.md`. Directly
-  answers the "recall ≠ answering" critique a serious reviewer will raise.
-- **schema.org JSON-LD** (`SoftwareApplication` / `Article`) on docs pages —
-  an explicit SEO gap noted in CLAUDE.md as of v0.10.0; richer Google results.
-- **More languages** behind the same `_SUFFIX_LANG` → `_EXTRACTORS` seam
-  (C# / Ruby / PHP are the obvious breadth adds; each is additive + parity-gated).
-- **Expand the public benchmark corpus** beyond `requests`/`click` (one
-  `manifest.json` entry per repo with def-site gold) to harden "you picked easy
-  repos."
+4. **Pick the next roadmap item** when ready (the breadth tier is done):
+   - **Deepen the proof** — more benchmark repos / languages in the public
+     corpus; publish the answerability arm as a standing secondary signal.
+   - **Compiler-accurate calls** — promote the opt-in SCIP precision pass from
+     experimental toward default for languages that support it.
+   - **More languages** behind the same `_SUFFIX_LANG` → `_EXTRACTORS` seam
+     (e.g. Kotlin, Swift, Scala) — each additive + parity-gated, one per PR.
 
 ---
 
@@ -115,8 +150,12 @@ in the table, not hidden.
   okay** → merge → release-please cuts the release. Docs+SEO ship in the *same*
   PR as the feature.
 - **Fresh branch per feature** (avoids the CI-trigger dead-end).
-- **Never** bump `pyproject.toml` / manifest / `CHANGELOG.md` by hand —
-  release-please owns versioning off `feat:`/`fix:` commits.
+- **Never** bump `pyproject.toml` version / manifest / `CHANGELOG.md` by hand —
+  release-please owns versioning off `feat:`/`fix:` commits. (Package *keywords*
+  in `pyproject.toml` are fair game; only the version line is off-limits.)
+- **Batch-release option:** hold the release PR and land several features, then
+  force the target version with a `Release-As: X.Y.Z` commit footer + umbrella
+  release notes (the v0.37.0 pattern).
 - **Benchmarks deterministic:** `NEURALMIND_SYNAPSE_INJECT=0` for fixed numbers.
 - **Bar for any public/benchmark work:** must pass engineering + Reddit scrutiny
   by serious technicians. Report losses, pin versions, commit raw traces.
@@ -129,6 +168,9 @@ in the table, not hidden.
 - Launch copy: `docs/launch/` (README is the index).
 - Benchmark methodology + raw data: `docs/benchmarks/public.md`,
   `bench/public/`.
+- Comparison docs: `docs/comparisons/` (vs Headroom, the context-engineering
+  stack, vs generic RAG, vs prompt caching).
 - Reproduce headline: `python -m evals.public.run`; competitor:
   `python -m evals.public.competitor`.
+- Per-language parity gate: `python -m evals.parity.run`.
 - Architecture + shipping checklist: `CLAUDE.md`.


### PR DESCRIPTION
## What

Refreshes `docs/launch/NEXT-SESSION.md`, which was stale (still said "v0.30→v0.34 shipped"). Brings it to the current **v0.30→v0.37** reality so the next session resumes with accurate context.

Updated:
- **Shipped table** → adds v0.35 (C#), v0.36 (Ruby), v0.37 (PHP + corpus expansion to 4 repos/40 queries + schema.org JSON-LD), and the PyPI comparison-keyword propagation (#274). The C#/Ruby/PHP breadth tier is recorded as **complete — ten languages**.
- **"Do this first"** → reframed around what's actually left: the answerability transcripts (blocked on `ANTHROPIC_API_KEY`), the two maker-only GitHub-UI edits (About/Topics, Release body), and the launch. Nothing blocked on code.
- **New "complementary apps we compare to"** section recording the honest, in-repo-backed comparison set (Headroom / Ponytail / codebase-memory-mcp) + paste-ready About description and Topics.
- **Cadence notes** → clarifies that `pyproject.toml` *keywords* are editable by hand (only the version line is off-limits) and records the batch-release `Release-As:` pattern.

## Scope

Docs-only; won't trigger a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DuSKbERBLmC1Q9D3WVP2XN)_