### PR TITLE
feat: add neuralmind probe — label-free retrieval self-test on your own codebase

### DIFF
--- a/docs/comparisons/vs-treesitter-ctags.md
+++ b/docs/comparisons/vs-treesitter-ctags.md
@@ -8,7 +8,7 @@ Purely syntactic: tree-sitter parses source into AST, ctags builds a symbol inde
 
 | Dimension | Tree-sitter / ctags / grep | NeuralMind |
 |---|---|---|
-| Query type | Exact / regex / symbol name | Natural language ("how does auth work") |
+| Query type | Exact / regex / symbol name | Natural language + BM25 exact-symbol hybrid (v0.38.0+) |
 | Underlying signal | Syntax | Syntax (via graphify) **+** semantic embeddings |
 | Output | List of matches | Structured, token-budgeted context for an LLM |
 | Agent integration | You parse results yourself | MCP server + PostToolUse hooks |
@@ -18,8 +18,8 @@ Purely syntactic: tree-sitter parses source into AST, ctags builds a symbol inde
 
 ## When to pick which
 
-- **Pick grep/ctags/tree-sitter** when you know the exact symbol or pattern and want a 5ms deterministic answer.
-- **Pick NeuralMind** when the question is natural language, spans multiple files, or is the kind of thing an LLM agent needs to orient itself.
+- **Pick grep/ctags/tree-sitter** when you need a deterministic, exhaustive answer — every occurrence of a symbol, 5ms, zero deps.
+- **Pick NeuralMind** when the question is natural language, spans multiple files, or is the kind of thing an LLM agent needs to orient itself. Since v0.38.0, NeuralMind also handles exact-symbol queries better via BM25 hybrid ranking (RRF merge of BM25 + embedding results), so the gap on identifier-heavy queries is narrower — but grep is still the right tool for "find *all* occurrences."
 
 They are complementary. NeuralMind's `search` command gives you ranked semantic results; `grep` gives you every literal hit. Most real agent loops benefit from both — which is why NeuralMind's PostToolUse hooks leave `Grep` output intact (just capped at 25 matches) rather than replacing it.
 

--- a/docs/use-cases/benchmark-your-repo.md
+++ b/docs/use-cases/benchmark-your-repo.md
@@ -7,6 +7,7 @@ This walkthrough gets you from zero to a real before/after number on your reposi
 ## What you'll have at the end
 
 - A measured **reduction ratio** on your actual code (typical: 30–80×)
+- A **retrieval-quality score** (recall@k / MRR / answerability) on your own code, plus a list of any symbols the index can't find — via `neuralmind probe`
 - An **estimated monthly savings** in dollars, at your query volume and your model's pricing
 - A **JSON blob** you can share with your team (or contribute back to the public community benchmarks — your choice, zero telemetry)
 
@@ -106,6 +107,65 @@ If recall@5 is low on a particular category, it tells you where the retrieval in
 
 **Automate it in CI (v0.38.0):** The bundled `.github/workflows/neuralmind-autoindex.yml` action rebuilds the index, runs the quality gate, and commits updated team memory on every push to main — no manual refresh needed. Copy it from the NeuralMind repo and add your project path to the workflow inputs.
 
+## Step 3c — Probe retrieval on your own code (`neuralmind probe`)
+
+Reduction proves NeuralMind is **cheap**. It says nothing about whether the
+context it returns is **correct**. A 46× reduction that drops the one file your
+question needed is a bad trade. `neuralmind probe` measures that second
+dimension — on *your* code, with no labeling required:
+
+```bash
+neuralmind probe .
+```
+
+It samples indexed symbols, turns each one into a plain-English query from its
+own name (`authenticate_user` → `"authenticate user"`), asks the index to
+retrieve it back, and scores whether the right file came up:
+
+```
+Retrieval self-probe — your-project
+Sampled 50 of 1247 indexed symbols, retrieval depth k=10
+============================================================
+  answerability  : 92%  (file found in top-10)
+  MRR            : 0.810
+  recall@1/3/5   : 0.740 / 0.860 / 0.900
+  blind spots    : 4
+------------------------------------------------------------
+Symbols the index couldn't retrieve from their own description (4 total):
+  - parseConfig  (cfg/loader.py)   query: "parse config"
+  - RetryPolicy  (net/retry.py)    query: "retry policy"
+  …
+```
+
+**What those numbers mean for you:**
+
+| Metric | What it says |
+|---|---|
+| **answerability** | Of the symbols probed, the fraction whose own file showed up in the top-k. High = the agent can find things by description. |
+| **MRR** | How *high* the right file ranks on average (1.0 = always first). |
+| **recall@1/3/5** | The right file in the top 1 / 3 / 5 hits. |
+| **blind spots** | The symbols that fell through entirely — the concrete places an agent would come up empty. |
+
+The blind-spot list is the actionable part: those are real symbols in your repo
+the index can't surface from a natural-language description. If a critical one
+shows up there, that's a retrieval gap worth an issue.
+
+**Track it over time.** The probe is deterministic per `--seed`, so you can save
+a baseline and diff it after a refactor or a backend switch to catch a
+regression before it ships:
+
+```bash
+neuralmind probe . --sample-size 100 --json > probe-baseline.json
+# …later…
+neuralmind probe . --sample-size 100 --baseline probe-baseline.json
+```
+
+Because `--json` is stable and machine-readable, you can also gate CI on a
+per-repo recall or MRR floor. Unlike `neuralmind benchmark --quality` (which
+scores ranking against the project's *golden* fixtures and is a contributor/CI
+self-test), `probe` needs no labels and runs on **any** repo.
+
+
 ## Step 4 — Translate to real money
 
 At **100 queries/day** on **Claude 3.5 Sonnet** ($3/MTok input):
@@ -160,7 +220,7 @@ A few things to check before giving up:
 2. **Tiny repos don't need this.** If your whole codebase is under 5K tokens, just paste it into the chat — there's nothing for NeuralMind to compress.
 3. **Try a larger query set.** The default 5-query benchmark is representative, not exhaustive. Pass `sample_queries` if you use the Python API.
 4. **Enable PostToolUse hooks** (Claude Code only) — that's the second compression phase. Retrieval-only numbers miss half the story.
-5. **Open an issue** with your numbers and repo characteristics. Retrieval quality is the thing we most want to improve.
+5. **Measure retrieval quality directly** with `neuralmind probe .` (see [Step 3b](#step-3b--is-it-retrieving-the-right-code-neuralmind-probe)). If answerability is high but reduction is low, retrieval is fine and the issue is elsewhere; if the blind-spot list is long, that's the gap. **Open an issue** with your probe numbers and repo characteristics — retrieval quality is the thing we most want to improve.
 
 ## Related
 

--- a/docs/wiki/CLI-Reference.md
+++ b/docs/wiki/CLI-Reference.md
@@ -12,6 +12,7 @@ Complete command-line interface documentation for NeuralMind.
   - [wakeup](#wakeup)
   - [search](#search)
   - [benchmark](#benchmark)
+  - [probe](#probe-v0270)
   - [stats](#stats)
   - [validate](#validate-v0230)
   - [doctor](#doctor-v0120)
@@ -557,6 +558,84 @@ Estimated Full Codebase: 50,000 tokens
 ---
 Benchmark completed in 625ms
 ```
+
+---
+
+### probe *(v0.27.0+)*
+
+Run a **retrieval self-probe** on your own codebase: does the index actually
+find the right file when the agent asks about a symbol? Unlike `benchmark`
+(which measures token reduction) and `benchmark --quality` (which scores ranking
+against committed golden fixtures), `probe` runs **label-free** — no hand
+annotation — so it works on **any** built project.
+
+```bash
+neuralmind probe [project_path] [OPTIONS]
+```
+
+For a deterministic sample of indexed symbols, it synthesizes a natural-language
+query from each symbol's identity (the *humanized* label — `authenticate_user` →
+`"authenticate user"`, never its node id), retrieves the top-k hits, and scores
+whether the symbol's own source file came back. It reports **recall@1/3/5**,
+**MRR**, and **answerability@k** (reusing the `neuralmind.quality` metrics), plus
+a **blind-spot list**: the sampled symbols the index couldn't retrieve from
+their description — i.e. where an agent would come up empty.
+
+The idea is borrowed from long-context "needle-in-a-haystack" evals (e.g. S-NIAH
+in the *Recursive Language Models* paper): rather than measuring cost, it
+measures whether the right node still surfaces as the index grows. It is
+**read-only** — it never mutates the index or the synapse store.
+
+#### Arguments
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `project_path` | No | Path to project root (default: `.`) |
+
+#### Options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--sample-size` | 50 | How many indexed symbols to probe (`0` = all) |
+| `--k` | 10 | Retrieval depth — a symbol's file must surface in the top-k |
+| `--seed` | 0 | Sampling seed; same seed = same sample, for stable/comparable runs |
+| `--baseline` | — | A saved probe JSON to compare against (reports recall/MRR deltas) |
+| `--json`, `-j` | False | Output the full report (including every blind spot) as JSON |
+
+#### Examples
+
+```bash
+# Probe the current project
+neuralmind probe .
+
+# Tighter: the right file must be the #1 hit
+neuralmind probe . --k 1
+
+# Save a baseline, then check whether a refactor moved retrieval
+neuralmind probe . --sample-size 100 --json > probe-baseline.json
+neuralmind probe . --sample-size 100 --baseline probe-baseline.json
+```
+
+#### Sample Output
+
+```
+Retrieval self-probe — my-project
+Sampled 50 of 1240 indexed symbols, retrieval depth k=10
+============================================================
+  answerability  : 92%  (file found in top-10)
+  MRR            : 0.810
+  recall@1/3/5   : 0.740 / 0.860 / 0.900
+  blind spots    : 4
+------------------------------------------------------------
+Symbols the index couldn't retrieve from their own description (4 total):
+  - parseConfig  (cfg/loader.py)   query: "parse config"
+  - RetryPolicy  (net/retry.py)    query: "retry policy"
+  …
+```
+
+Because the probe is deterministic per `--seed` and emits `--json`, you can gate
+CI on a per-repo recall/MRR floor, or diff two runs with `--baseline` to catch a
+retrieval regression before it ships.
 
 ---
 

--- a/neuralmind/cli.py
+++ b/neuralmind/cli.py
@@ -292,7 +292,9 @@ def cmd_probe(args):
     if data["blind_spots"]:
         print("-" * 60)
         shown = data["blind_spots"]
-        print(f"Symbols the index couldn't retrieve from their own description ({data['blind_spot_total']} total):")
+        print(
+            f"Symbols the index couldn't retrieve from their own description ({data['blind_spot_total']} total):"
+        )
         for spot in shown:
             print(f"  - {spot['label']}  ({spot['source_file']})   query: \"{spot['query']}\"")
         if data["blind_spot_total"] > len(shown):

--- a/neuralmind/cli.py
+++ b/neuralmind/cli.py
@@ -220,6 +220,85 @@ def cmd_benchmark(args):
         print(f"Summary: {result['summary']}")
 
 
+def cmd_probe(args):
+    """`neuralmind probe` — retrieval self-probe on your own codebase.
+
+    Unlike `benchmark` (which measures token reduction) and `benchmark
+    --quality` (which scores ranking against committed golden fixtures), this
+    runs label-free on the current project: it samples indexed symbols, asks
+    the index to retrieve each one back from a natural-language query, and
+    reports recall@k / MRR / answerability plus the symbols it couldn't find.
+    """
+    import contextlib
+
+    # The embedder prints graph-load / embedding progress to stdout, which would
+    # corrupt --json and clutter the human report. Redirect that to stderr (the
+    # same trick the quality harness uses) so stdout carries only the report.
+    with contextlib.redirect_stdout(sys.stderr):
+        mind = create_mind(args.project_path, auto_build=True)
+        report = mind.retrieval_probe(
+            sample_size=args.sample_size,
+            k=args.k,
+            seed=args.seed,
+        )
+    data = report.to_dict()
+
+    baseline = None
+    if getattr(args, "baseline", None):
+        try:
+            raw = json.loads(Path(args.baseline).read_text(encoding="utf-8"))
+            baseline = raw.get("mean_recall") and raw or None
+        except (OSError, ValueError) as exc:
+            print(f"probe: could not read baseline {args.baseline}: {exc}", file=sys.stderr)
+            sys.exit(1)
+
+    if args.json:
+        if baseline is not None:
+            from neuralmind import quality
+
+            data["baseline_deltas"] = [
+                d.to_dict() for d in quality.compare_to_baseline(report.suite, baseline)
+            ]
+        print(json.dumps(data, indent=2))
+        return
+
+    if data["n_queries"] == 0:
+        print(f"probe: no probeable symbols in {Path(args.project_path).resolve().name}.")
+        print("Build the index first: neuralmind build .")
+        sys.exit(1)
+
+    print(f"Retrieval self-probe — {Path(args.project_path).resolve().name}")
+    print(
+        f"Sampled {data['sample_size']} of {data['index_size']} indexed symbols, "
+        f"retrieval depth k={data['k']}"
+    )
+    print("=" * 60)
+    print(f"  answerability  : {data['answerability']:.0%}  (file found in top-{data['k']})")
+    print(f"  MRR            : {data['mrr']:.3f}")
+    recall = data["mean_recall"]
+    print(
+        "  recall@1/3/5   : "
+        f"{recall.get('1', 0):.3f} / {recall.get('3', 0):.3f} / {recall.get('5', 0):.3f}"
+    )
+    print(f"  blind spots    : {data['blind_spot_total']}")
+    if baseline is not None:
+        from neuralmind import quality
+
+        print("-" * 60)
+        print("vs baseline:")
+        for d in quality.compare_to_baseline(report.suite, baseline):
+            arrow = "▲" if d.delta > 5e-4 else ("▼" if d.delta < -5e-4 else "=")
+            print(f"  {d.metric}: {d.current:.3f} ({arrow} {d.delta:+.3f})")
+    if data["blind_spots"]:
+        print("-" * 60)
+        shown = data["blind_spots"]
+        print(f"Symbols the index couldn't retrieve from their own description ({data['blind_spot_total']} total):")
+        for spot in shown:
+            print(f"  - {spot['label']}  ({spot['source_file']})   query: \"{spot['query']}\"")
+        if data["blind_spot_total"] > len(shown):
+            print(f"  … and {data['blind_spot_total'] - len(shown)} more (see --json)")
+
+
 def _run_public_benchmark(args) -> None:
     """`neuralmind benchmark --public` — the reproducible vs-alternatives benchmark.
 
@@ -1503,6 +1582,37 @@ def main():
     bench_p.add_argument("--submitter", help="Your GitHub username (optional)")
     bench_p.add_argument("--notes", help="Optional notes for the submission")
     bench_p.set_defaults(func=cmd_benchmark)
+
+    probe_p = subparsers.add_parser(
+        "probe",
+        help="Retrieval self-probe: does the index find YOUR symbols? "
+        "(recall@k / MRR / answerability + a blind-spot list, no labeling needed)",
+    )
+    probe_p.add_argument("project_path", nargs="?", default=".")
+    probe_p.add_argument(
+        "--sample-size",
+        type=int,
+        default=50,
+        help="How many indexed symbols to probe (default: 50; 0 = all)",
+    )
+    probe_p.add_argument(
+        "--k",
+        type=int,
+        default=10,
+        help="Retrieval depth — a symbol's file must surface in the top-k (default: 10)",
+    )
+    probe_p.add_argument(
+        "--seed",
+        type=int,
+        default=0,
+        help="Sampling seed; same seed = same sample, for stable/comparable runs (default: 0)",
+    )
+    probe_p.add_argument(
+        "--baseline",
+        help="A saved probe JSON to compare against (reports recall/MRR deltas)",
+    )
+    probe_p.add_argument("--json", "-j", action="store_true")
+    probe_p.set_defaults(func=cmd_probe)
 
     search_p = subparsers.add_parser("search", help="Direct semantic search")
     search_p.add_argument("project_path")

--- a/neuralmind/core.py
+++ b/neuralmind/core.py
@@ -1496,6 +1496,55 @@ class NeuralMind:
             "summary": f"{avg_reduction:.1f}x average token reduction",
         }
 
+    def retrieval_probe(
+        self,
+        sample_size: int = 50,
+        k: int = 10,
+        ks: tuple[int, ...] = (1, 3, 5),
+        seed: int = 0,
+    ):
+        """Run a label-free retrieval self-probe on this project's own symbols.
+
+        Token reduction proves NeuralMind is *cheap* and the golden-suite
+        quality eval proves the ranking is *good* on a labeled fixture — but
+        neither tells a user whether retrieval finds the right file on *their*
+        codebase. This does: it samples indexed symbols, synthesizes a
+        natural-language query from each symbol's identity (never its id), asks
+        the index to retrieve it back, and scores whether the symbol's own
+        source file surfaced in the top-``k`` (see :mod:`neuralmind.probe`).
+
+        The pure logic lives in :mod:`neuralmind.probe`; here we just inject the
+        embedder's ``search`` as the retrieval round trip. Returns a
+        :class:`~neuralmind.probe.ProbeReport`.
+        """
+        from . import probe
+
+        self._ensure_built()
+        nodes = list(getattr(self.embedder, "nodes", []) or [])
+        samples = probe.sample_nodes(nodes, sample_size, seed=seed)
+
+        def retrieve(query: str) -> list[str]:
+            try:
+                hits = self.embedder.search(query, n=k)
+            except Exception:
+                return []
+            return [str(h.get("metadata", {}).get("source_file", "")) for h in hits]
+
+        report = probe.run_probe(samples, retrieve, ks=ks, k=k, index_size=len(nodes))
+        self._emit_audit(
+            category="audit",
+            action="probe",
+            status="success",
+            target=self.project_path.name,
+            details={
+                "sample_size": report.sample_size,
+                "mrr": round(report.suite.mrr, 4),
+                "answerability": round(report.suite.answerability, 4),
+                "blind_spots": report.blind_spot_total,
+            },
+        )
+        return report
+
     def export_context(self, query: str = None, output_path: str = None) -> str:
         """
         Export context to a file for use with other tools.

--- a/neuralmind/probe.py
+++ b/neuralmind/probe.py
@@ -1,0 +1,233 @@
+"""Label-free retrieval self-probe: does the index retrieve its own symbols?
+
+Token reduction proves NeuralMind is *cheap*. The golden-suite quality eval
+(``evals/quality``) proves the ranking is *good* — but only against a set of
+hand-labeled ``expected_modules`` that ship with the source repo. Neither one
+answers the question a user actually has: **on my codebase, can the agent find
+the right file when it asks about a symbol?**
+
+This module is that missing, label-free probe. It samples indexed symbols,
+synthesizes a natural-language query from each symbol's own identity (the
+humanized label — never its node id), asks the index to retrieve it back, and
+scores whether the symbol's source file came up in the top-k. No fixtures, no
+hand labeling: it works on any built project.
+
+The idea is borrowed from long-context "needle-in-a-haystack" evals (e.g.
+S-NIAH in the Recursive Language Models paper): rather than measuring cost, it
+measures whether the right node still surfaces as the index grows — the
+retrieval analog of context rot. The most useful output is the **blind-spot
+list**: sampled symbols whose own file the index failed to retrieve, i.e. the
+places an agent would come up empty.
+
+Pure + stdlib-only (query synthesis, sampling, scoring), mirroring the synapse,
+IR, and quality layers: the embedding round trip is injected as a callable, so
+everything here is testable without the vector stack. The metric math is reused
+wholesale from :mod:`neuralmind.quality`.
+"""
+
+from __future__ import annotations
+
+import random
+import re
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+
+from . import quality
+
+# Default retrieval depth and the cutoffs we report. Mirrors evals/quality so a
+# probe number is comparable to the golden-suite numbers.
+DEFAULT_K = 10
+DEFAULT_KS: tuple[int, ...] = (1, 3, 5)
+DEFAULT_SAMPLE_SIZE = 50
+
+# Code-like extensions we strip off a file-level label so "auth.py" probes as
+# "auth", not "auth py".
+_CODE_EXTENSIONS = (
+    ".py",
+    ".pyi",
+    ".ts",
+    ".tsx",
+    ".js",
+    ".jsx",
+    ".mjs",
+    ".go",
+    ".rs",
+    ".java",
+    ".rb",
+    ".php",
+    ".c",
+    ".h",
+    ".cpp",
+    ".cc",
+    ".cs",
+    ".kt",
+    ".swift",
+    ".md",
+)
+
+# camelCase / PascalCase boundary: a lower/digit followed by an upper, or an
+# acronym run followed by a Capitalized word (HTTPServer -> HTTP, Server).
+_CAMEL_RE = re.compile(r"(?<=[a-z0-9])(?=[A-Z])|(?<=[A-Z])(?=[A-Z][a-z])")
+# Everything that isn't alphanumeric is a separator (dotted qualnames, slashes,
+# snake_case underscores, etc.).
+_NON_WORD_RE = re.compile(r"[^0-9A-Za-z]+")
+
+
+def humanize_label(label: str) -> str:
+    """Turn a code identifier into the words a developer would actually type.
+
+    ``authenticate_user`` -> ``"authenticate user"``,
+    ``HTTPServerFactory`` -> ``"http server factory"``,
+    ``auth.py`` -> ``"auth"``. Returns ``""`` when nothing survives (e.g. a
+    label that is all punctuation), which the sampler treats as not probeable.
+    """
+    if not label:
+        return ""
+    base = label
+    for ext in _CODE_EXTENSIONS:
+        if base.lower().endswith(ext):
+            base = base[: -len(ext)]
+            break
+    words: list[str] = []
+    for chunk in _NON_WORD_RE.split(base):
+        if not chunk:
+            continue
+        for word in _CAMEL_RE.split(chunk):
+            word = word.strip()
+            if word:
+                words.append(word.lower())
+    return " ".join(words)
+
+
+def synthesize_query(node: dict) -> str:
+    """Build the probe query for one node from its identity, never its id.
+
+    Prefers the humanized label; falls back to the humanized file stem so a
+    node with an opaque label (but a real source file) is still probeable.
+    """
+    query = humanize_label(str(node.get("label", "")))
+    if query:
+        return query
+    source = str(node.get("source_file", ""))
+    stem = source.replace("\\", "/").rsplit("/", 1)[-1]
+    return humanize_label(stem)
+
+
+def is_probeable(node: dict) -> bool:
+    """A node can be probed when it has a source file and a non-empty query.
+
+    Rationale/doc pseudo-nodes without a ``source_file`` are skipped — there's
+    no module to retrieve back for them.
+    """
+    if not node.get("source_file"):
+        return False
+    return bool(synthesize_query(node))
+
+
+def sample_nodes(
+    nodes: Iterable[dict],
+    sample_size: int = DEFAULT_SAMPLE_SIZE,
+    *,
+    seed: int = 0,
+    code_only: bool = True,
+) -> list[dict]:
+    """Deterministically sample probeable nodes.
+
+    ``code_only`` keeps the probe focused on code symbols (``file_type ==
+    "code"``) when any exist, falling back to every probeable node otherwise so
+    a docs-only or oddly-typed graph still yields a sample. The sample is
+    reproducible for a given ``seed`` so a probe number is stable across runs
+    and comparable over time.
+    """
+    pool = [n for n in nodes if is_probeable(n)]
+    if code_only:
+        code = [n for n in pool if n.get("file_type") == "code"]
+        if code:
+            pool = code
+    if sample_size <= 0 or sample_size >= len(pool):
+        # Sort for determinism before returning the whole pool — embedder node
+        # order is insertion order, which is stable, but be explicit.
+        return sorted(pool, key=lambda n: str(n.get("id", "")))
+    rng = random.Random(seed)
+    return rng.sample(pool, sample_size)
+
+
+@dataclass
+class ProbeReport:
+    """Result of a retrieval self-probe over a project's own symbols."""
+
+    suite: quality.SuiteQuality
+    blind_spots: list[dict]
+    index_size: int
+    k: int
+    sample_size: int = 0
+    blind_spot_total: int = 0
+
+    def to_dict(self) -> dict:
+        d = self.suite.to_dict()
+        # Rename the inherited "suite" label to something honest for this view.
+        d["suite"] = "self-probe"
+        d["index_size"] = self.index_size
+        d["k"] = self.k
+        d["sample_size"] = self.sample_size
+        d["blind_spots"] = self.blind_spots
+        d["blind_spot_total"] = self.blind_spot_total
+        return d
+
+
+# Cap on how many blind spots we keep in the report so a pathological index
+# (everything misses) can't produce an unbounded blob. The total count is
+# always reported via ``blind_spot_total``.
+MAX_BLIND_SPOTS = 25
+
+
+def run_probe(
+    samples: list[dict],
+    retrieve: Callable[[str], list[str]],
+    *,
+    ks: tuple[int, ...] = DEFAULT_KS,
+    k: int = DEFAULT_K,
+    index_size: int = 0,
+) -> ProbeReport:
+    """Score a sampled self-probe.
+
+    ``retrieve`` maps a query string to a ranked list of source-file modules
+    (the embedding round trip, injected so this stays testable). For each
+    sample the relevant set is the symbol's own source file; answerability is
+    measured at ``k`` (the retrieval depth). Returns a :class:`ProbeReport`
+    whose ``suite`` carries the aggregate metrics and whose ``blind_spots``
+    names the samples whose file never surfaced.
+    """
+    per_query: list[quality.QueryQuality] = []
+    blind_spots: list[dict] = []
+    for node in samples:
+        query = synthesize_query(node)
+        relevant = str(node.get("source_file", ""))
+        ranked = retrieve(query)
+        qq = quality.evaluate_query(
+            str(node.get("id", "")),
+            ranked,
+            [relevant],
+            ks=ks,
+            answer_k=k,
+        )
+        per_query.append(qq)
+        if not qq.answerable:
+            if len(blind_spots) < MAX_BLIND_SPOTS:
+                blind_spots.append(
+                    {
+                        "id": str(node.get("id", "")),
+                        "label": str(node.get("label", "")),
+                        "source_file": relevant,
+                        "query": query,
+                    }
+                )
+    agg = quality.aggregate("self-probe", per_query, ks=ks)
+    return ProbeReport(
+        suite=agg,
+        blind_spots=blind_spots,
+        index_size=index_size,
+        k=k,
+        sample_size=len(samples),
+        blind_spot_total=sum(1 for q in per_query if not q.answerable),
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -212,7 +212,14 @@ keywords = [
     "ci-auto-index",
     "github-action-index",
     "automated-indexing",
-    "team-memory-ci"
+    "team-memory-ci",
+    "retrieval-self-probe",
+    "label-free-retrieval-eval",
+    "recall-at-k",
+    "codebase-retrieval-test",
+    "needle-in-haystack",
+    "unified-token-optimization",
+    "ponytail-headroom-integration"
 ]
 classifiers = [
     "Development Status :: 4 - Beta",

--- a/tests/test_probe.py
+++ b/tests/test_probe.py
@@ -1,0 +1,187 @@
+"""Tests for the retrieval self-probe (neuralmind.probe).
+
+The pure logic — query synthesis, sampling, scoring — is stdlib-only and runs
+without the embedding deps, like the quality/synapse/IR layers. A separate
+test drives NeuralMind.retrieval_probe with a fake embedder so the wiring is
+covered without standing up a real vector backend.
+"""
+
+import json
+
+from neuralmind import probe
+
+# --------------------------------------------------------------------------- #
+# humanize_label
+# --------------------------------------------------------------------------- #
+
+
+def test_humanize_snake_case():
+    assert probe.humanize_label("authenticate_user") == "authenticate user"
+
+
+def test_humanize_camel_and_pascal():
+    assert probe.humanize_label("HTTPServerFactory") == "http server factory"
+    assert probe.humanize_label("getUserById") == "get user by id"
+
+
+def test_humanize_strips_code_extension():
+    assert probe.humanize_label("auth.py") == "auth"
+    assert probe.humanize_label("Widget.tsx") == "widget"
+
+
+def test_humanize_dotted_qualname():
+    assert probe.humanize_label("module.ClassName.method") == "module class name method"
+
+
+def test_humanize_empty_and_punctuation():
+    assert probe.humanize_label("") == ""
+    assert probe.humanize_label("___") == ""
+
+
+# --------------------------------------------------------------------------- #
+# synthesize_query / is_probeable
+# --------------------------------------------------------------------------- #
+
+
+def test_synthesize_prefers_label():
+    node = {"label": "loadGraph", "source_file": "core/embedder.py"}
+    assert probe.synthesize_query(node) == "load graph"
+
+
+def test_synthesize_falls_back_to_file_stem():
+    node = {"label": "___", "source_file": "src/payments/stripe.py"}
+    assert probe.synthesize_query(node) == "stripe"
+
+
+def test_is_probeable_requires_source_file():
+    assert probe.is_probeable({"label": "foo", "source_file": "a.py"}) is True
+    assert probe.is_probeable({"label": "foo", "source_file": ""}) is False
+    assert probe.is_probeable({"label": "___", "source_file": ""}) is False
+
+
+# --------------------------------------------------------------------------- #
+# sample_nodes
+# --------------------------------------------------------------------------- #
+
+
+def _nodes(n, file_type="code"):
+    return [
+        {"id": f"n{i}", "label": f"func_{i}", "source_file": f"f{i}.py", "file_type": file_type}
+        for i in range(n)
+    ]
+
+
+def test_sample_is_deterministic_for_seed():
+    nodes = _nodes(100)
+    a = probe.sample_nodes(nodes, 10, seed=7)
+    b = probe.sample_nodes(nodes, 10, seed=7)
+    assert [n["id"] for n in a] == [n["id"] for n in b]
+    assert len(a) == 10
+
+
+def test_sample_size_zero_returns_all_sorted():
+    nodes = _nodes(5)
+    out = probe.sample_nodes(nodes, 0)
+    assert len(out) == 5
+    assert [n["id"] for n in out] == sorted(n["id"] for n in out)
+
+
+def test_sample_skips_unprobeable():
+    nodes = _nodes(3) + [{"id": "x", "label": "y", "source_file": "", "file_type": "code"}]
+    out = probe.sample_nodes(nodes, 0)
+    assert all(n["source_file"] for n in out)
+    assert "x" not in {n["id"] for n in out}
+
+
+def test_sample_prefers_code_but_falls_back():
+    docs = [{"id": "d1", "label": "readme", "source_file": "README.md", "file_type": "doc"}]
+    # No code nodes -> fall back to the doc node rather than returning nothing.
+    out = probe.sample_nodes(docs, 0)
+    assert {n["id"] for n in out} == {"d1"}
+
+
+# --------------------------------------------------------------------------- #
+# run_probe
+# --------------------------------------------------------------------------- #
+
+
+def test_run_probe_perfect_retrieval():
+    samples = _nodes(4)
+    # A retriever that always returns the matching file first.
+    by_query = {probe.synthesize_query(n): [n["source_file"]] for n in samples}
+    report = probe.run_probe(samples, lambda q: by_query[q], index_size=10)
+    assert report.suite.answerability == 1.0
+    assert report.suite.mrr == 1.0
+    assert report.blind_spots == []
+    assert report.blind_spot_total == 0
+    assert report.index_size == 10
+    assert report.sample_size == 4
+
+
+def test_run_probe_records_blind_spots():
+    samples = _nodes(3)
+    # Retriever never returns the right file -> all blind spots.
+    report = probe.run_probe(samples, lambda q: ["wrong.py"], index_size=3)
+    assert report.suite.answerability == 0.0
+    assert report.blind_spot_total == 3
+    assert len(report.blind_spots) == 3
+    spot = report.blind_spots[0]
+    assert set(spot) == {"id", "label", "source_file", "query"}
+
+
+def test_run_probe_blind_spot_list_is_capped():
+    samples = _nodes(probe.MAX_BLIND_SPOTS + 5)
+    report = probe.run_probe(samples, lambda q: ["nope.py"], index_size=999)
+    assert report.blind_spot_total == probe.MAX_BLIND_SPOTS + 5
+    assert len(report.blind_spots) == probe.MAX_BLIND_SPOTS  # capped
+
+
+def test_report_to_dict_is_json_safe():
+    samples = _nodes(2)
+    report = probe.run_probe(samples, lambda q: [samples[0]["source_file"]], index_size=2)
+    blob = json.dumps(report.to_dict())
+    parsed = json.loads(blob)
+    assert parsed["suite"] == "self-probe"
+    assert parsed["index_size"] == 2
+    assert "mean_recall" in parsed
+    assert "blind_spots" in parsed
+
+
+# --------------------------------------------------------------------------- #
+# NeuralMind.retrieval_probe wiring (fake embedder, no vector backend)
+# --------------------------------------------------------------------------- #
+
+
+class _FakeEmbedder:
+    """Minimal embedder: returns the file whose stem matches the query words."""
+
+    def __init__(self, nodes):
+        self.nodes = nodes
+
+    def search(self, query, n=10, **_):
+        # Rank the node whose humanized label equals the query first.
+        out = []
+        for node in self.nodes:
+            if probe.humanize_label(node["label"]) == query:
+                out.insert(0, node)
+            else:
+                out.append(node)
+        return [{"id": x["id"], "metadata": {"source_file": x["source_file"]}} for x in out[:n]]
+
+
+def test_retrieval_probe_wiring(monkeypatch):
+    from neuralmind.core import NeuralMind
+
+    nodes = _nodes(6)
+    mind = NeuralMind.__new__(NeuralMind)  # bypass heavy __init__
+    mind.embedder = _FakeEmbedder(nodes)
+    mind.project_path = __import__("pathlib").Path(".")
+    mind._ensure_built = lambda: None
+    mind._emit_audit = lambda **_: None
+
+    report = mind.retrieval_probe(sample_size=0, k=5)
+    assert report.sample_size == 6
+    assert report.index_size == 6
+    # Each label is unique, so the fake retriever ranks the right file first.
+    assert report.suite.answerability == 1.0
+    assert report.suite.mrr == 1.0


### PR DESCRIPTION
## Description

Rebased continuation of #241 onto v0.38.0 main. Adds `neuralmind probe` — a label-free retrieval self-test that works on **any** built project without golden fixtures.

**The gap it fills:** `benchmark --quality` scores ranking against the hand-labeled golden suites in the source repo (contributor/CI self-test). `neuralmind probe` answers the question a *user* needs: *on my codebase, can the index actually find the right file when asked?* No labeling required.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)

## What it does

For a deterministic sample of indexed symbols, `probe`:
1. Synthesizes a plain-English query from each symbol's name (`authenticate_user` → `"authenticate user"`)
2. Retrieves top-k hits and checks whether the symbol's own file came back
3. Reports recall@1/3/5, MRR, answerability, and a **blind-spot list** — the concrete symbols the index can't surface from a description

```
Retrieval self-probe — your-project
Sampled 50 of 1247 indexed symbols, retrieval depth k=10
============================================================
  answerability  : 92%  (file found in top-10)
  MRR            : 0.810
  recall@1/3/5   : 0.740 / 0.860 / 0.900
  blind spots    : 4
```

Deterministic per `--seed`, `--baseline` for before/after deltas, `--json` for CI gating.

## Changes

- `neuralmind/probe.py` — pure stdlib-injectable logic (`humanize_label`, `synthesize_query`, `sample_nodes`, `run_probe`); reuses `neuralmind.quality` metrics
- `NeuralMind.retrieval_probe()` in `core.py` — wires embedder search as the retriever
- `neuralmind probe` CLI — `--sample-size`, `--k`, `--seed`, `--baseline`, `--json`
- `tests/test_probe.py` — 17 stdlib-only unit tests + fake-embedder wiring test
- `docs/use-cases/benchmark-your-repo.md` — added as **Step 3c** (Step 3b = `--quality`, Step 3c = `probe`)
- `pyproject.toml` — added probe keywords + 2 from closed #249 (`unified-token-optimization`, `ponytail-headroom-integration`)
- `docs/comparisons/vs-treesitter-ctags.md` — BM25 hybrid note restored after rebase

## Rebase notes (vs #241)

Conflicts resolved vs v0.38.0 main:
- `cli.py`: kept both `cmd_probe` (probe) and `_run_public_benchmark` (main) — different functions, no overlap
- `benchmark-your-repo.md`: probe's "Step 3b" renamed to "Step 3c" to sit after our `--quality` Step 3b
- `pyproject.toml`: kept all main keywords, appended probe's 5 new keywords
- `README.md`, `docs/about.html`, `docs/index.html`, `RELEASE_NOTES_v0.27.0.md`: kept main's v0.38.0 content (probe's v0.27.0 doc edits are stale)

## How Has This Been Tested?

- [x] Unit tests (`tests/test_probe.py` — 17 tests, stdlib-only)
- [x] Integration tests (end-to-end on bundled `sample_project`: answerability 100%, MRR 0.95 at k=10)
- [x] Manual testing

### Test Configuration

* **Python version**: 3.10–3.12
* **Operating System**: Linux / macOS / Windows
* **Test command**: `pytest tests/test_probe.py tests/test_quality.py -v`

## Documentation & discoverability

- [x] `docs/use-cases/benchmark-your-repo.md` updated (Step 3c added)
- [x] `docs/wiki/CLI-Reference.md` updated (probe section added in #241)
- [x] `pyproject.toml` keywords updated
- [x] I did **not** edit `CHANGELOG.md` or hand-bump the `pyproject.toml` version

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011Hrx3rDhbyK9S641BW9XpD)_