### PR TITLE
docs: close the recurring critique — Limits page, runnable benchmarks/, SWE-bench retrieval harness, security refresh + coverage scorecard

### DIFF
--- a/README.md
+++ b/README.md
@@ -1907,6 +1907,7 @@ Only if you install the git post-commit hook with `neuralmind init-hook .`. Othe
 |----------|---------|
 | **[Business Case](docs/BUSINESS-CASE.md)** | Fact-based ROI argument with provable claims, math you can plug your numbers into, and three concrete scenarios |
 | **[Honest Assessment](docs/HONEST-ASSESSMENT.md)** | Skeptic's companion — when NeuralMind isn't worth installing, what the headline numbers don't measure |
+| **[Critique Coverage](docs/CRITIQUE-COVERAGE.md)** | The recurring external critique mapped point-by-point to where it's addressed, what's partial, and what's honestly deferred (and why) |
 | **[Enterprise Use Cases](docs/ENTERPRISE.md)** | Regulated industries, on-premise, multi-team — what to know before pitching internally |
 | **[Setup Guide](https://github.com/dfrostar/neuralmind/wiki/Setup-Guide)** | First-time setup for Claude Code, Claude Desktop, Cursor, any LLM |
 | **[CLI Reference](https://github.com/dfrostar/neuralmind/wiki/CLI-Reference)** | All commands and options |

--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ Two docs you should read before forming an opinion. Both are linked from this se
 
 - **[docs/BUSINESS-CASE.md](docs/BUSINESS-CASE.md)** — the compelling pitch, with provable numbers. Every claim is a single command away from being verified on your own code. ROI math with assumptions you can change. Three concrete scenarios. Read this if you're evaluating whether to bring NeuralMind to your team.
 - **[docs/HONEST-ASSESSMENT.md](docs/HONEST-ASSESSMENT.md)** — the skeptic's companion. When NeuralMind isn't worth installing. What "40–70×" actually means (and doesn't). Where the community-benchmark sample is too small to extrapolate. Read this if you want to know what could go wrong before adopting.
+- **[docs/wiki/Limits-and-Failure-Modes.md](docs/wiki/Limits-and-Failure-Modes.md)** — once installed, *where it stops working*: when a single ~2.5K-token query isn't enough (wide multi-file refactors) and what to do instead, the repo-size/index-time envelope, and the per-language support matrix listing what's **explicitly not modeled** (C/C++ macros & templates, dynamic-dispatch resolution, SQL `ALTER`, proto imports). The runnable evidence lives in **[benchmarks/](benchmarks/README.md)**.
 
 The headline you can stand on: **retrieval reduction is measured in CI on every commit** (open any closed PR in the [PR list](https://github.com/dfrostar/neuralmind/pulls?q=is%3Apr+is%3Aclosed) — each one has a sticky benchmark comment with current numbers) and **reproduces in 30 seconds on a fresh clone** via `bash scripts/demo.sh`. Real-world repos have submitted **46–66×** but n=2 — your number comes from `neuralmind benchmark . --contribute` on your code.
 
@@ -1917,6 +1918,8 @@ Only if you install the git post-commit hook with `neuralmind init-hook .`. Othe
 | **[Architecture](https://github.com/dfrostar/neuralmind/wiki/Architecture)** | 4-layer progressive disclosure design |
 | **[Integration Guide](https://github.com/dfrostar/neuralmind/wiki/Integration-Guide)** | MCP, CI/CD, VS Code native extension, JetBrains |
 | **[Troubleshooting](https://github.com/dfrostar/neuralmind/wiki/Troubleshooting)** | Common issues and fixes |
+| **[Limits & Failure Modes](https://github.com/dfrostar/neuralmind/wiki/Limits-and-Failure-Modes)** | Where it stops working: when one query isn't enough, the repo-size envelope, and the per-language support matrix (what's indexed *and what isn't*) |
+| **[Benchmarks (run them yourself)](benchmarks/README.md)** | One-command index + runner for every benchmark harness, plus an honest "what we don't measure yet" (SWE-bench, Aider agent-loop, multi-competitor) |
 | **[Roadmap](ROADMAP.md)** | What's shipping next, where we want help, what's out of scope |
 | **[Future-Proofing Plan](docs/FUTURE-PROOFING-PLAN.md)** | 8-initiative engineering plan for sustainability and scale |
 | **[Brain-like Learning](docs/brain_like_learning.md)** | Design rationale for the learning system |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -21,11 +21,11 @@ guidance is "stay on latest." Because NeuralMind is local-first with
 no exfiltration surface, the patch urgency for older versions is
 typically low.
 
-| Version | Status              | Notes                                        |
-| ------- | ------------------- | -------------------------------------------- |
-| 0.11.x  | :white_check_mark:  | Current release; fixes land here.            |
-| 0.10.x  | :warning:           | Critical fixes only.                         |
-| ≤ 0.9.x | :x:                 | Unsupported — `pip install --upgrade neuralmind`. |
+| Version  | Status              | Notes                                        |
+| -------- | ------------------- | -------------------------------------------- |
+| 0.41.x   | :white_check_mark:  | Current release; fixes land here.            |
+| 0.40.x   | :warning:           | Critical fixes only.                         |
+| ≤ 0.39.x | :x:                 | Unsupported — `pip install --upgrade neuralmind`. |
 
 The supported window will widen when we tag v1.0.0.
 
@@ -82,15 +82,19 @@ Please include the following information:
 
 NeuralMind processes code from your projects. Here's what you should know:
 
-1. **Local Processing.** All embeddings are generated and stored locally using ChromaDB. The Hebbian synapse layer (v0.4+) and the directional transitions table (v0.11+) are SQLite-backed and also local.
-2. **No External Transmission.** Code is not sent to external servers (unless you point ChromaDB at a remote backend yourself).
-3. **Storage Locations.**
-   - Vector index: `<project>/graphify-out/neuralmind_db/`
-   - Synapse store + transitions: `<project>/.neuralmind/synapses.db`
+1. **Local Processing.** All embeddings are generated and stored locally. Since v0.29 the default backend is **ChromaDB-free** — embeddings come from a bundled `all-MiniLM-L6-v2` **ONNX** model run on `onnxruntime` (CPU), and vectors are stored in the on-disk `turbovec` index. There is **no cloud embedding API call** on any backend. The Hebbian synapse layer (v0.4+) and the directional transitions table (v0.11+) are SQLite-backed and also local.
+2. **No External Transmission.** Code is not sent to external servers. The only outbound network event in the default install is a **one-time, SHA256-pinned** download of the ONNX model archive into `~/.cache/neuralmind/onnx_models/` (a static S3 artifact, not an API; a corrupted/swapped download fails loudly). Pre-stage it via `NEURALMIND_ONNX_MODEL_DIR` for air-gapped installs and there is **no network at install, build, query, or runtime**.
+3. **Storage Locations** (all under the project, never committed unless noted):
+   - Vector index (turbovec default, or ChromaDB if selected): `<project>/graphify-out/neuralmind_db/`
+   - Input graph: `<project>/graphify-out/graph.json`; canonical IR (v0.23+): `<project>/.neuralmind/ir.json` (+ `ir.meta.json`)
+   - Synapse store + directional transitions + namespaces: `<project>/.neuralmind/synapses.db`
+   - BM25 keyword index (v0.38+): `<project>/.neuralmind/bm25_index.json`
    - Auto-memory file consumed by Claude Code: `<project>/.neuralmind/SYNAPSE_MEMORY.md`
    - PostToolUse Bash recovery cache (v0.10+): `<project>/.neuralmind/last_output.json` (single-slot, 2 MB cap, atomic writes)
    - Event log for the graph-view stream (v0.6+): `<project>/.neuralmind/events.jsonl`
-4. **What gets persisted.** Edge weights, transition counts, and the most recent Bash command's stdout/stderr (the latter capped). Source code itself is not duplicated into these files — only references (node ids, file paths).
+   - MCP audit trail (v0.41): `<project>/.neuralmind/audit_events.jsonl`
+   - **Committed** team-memory bundle (v0.30+, opt-in): `<project>/.neuralmind-team-memory.json` — travels with `git clone` (learned weights only, no source)
+4. **What gets persisted.** Edge weights, transition counts, BM25 token postings, the most recent Bash command's stdout/stderr (capped), and MCP audit events. Source code itself is **not** duplicated into these files — only references (node ids, file paths). The committed team-memory bundle holds learned associations, not code.
 
 ### Best Practices for Enterprise Deployments
 
@@ -136,10 +140,16 @@ NeuralMind processes code from your projects. Here's what you should know:
 
 ### Known Security Considerations
 
-1. **ChromaDB.** We rely on ChromaDB for vector storage. Monitor their security advisories.
+1. **ChromaDB (opt-in fallback since v0.29).** ChromaDB is **no longer the default
+   backend**. On mainstream platforms (Linux, Apple Silicon, Windows x64) the default
+   is the ChromaDB-free `turbovec`/ONNX stack, so ChromaDB's dependency tree — and the
+   advisory below — are **absent from the default install** entirely. ChromaDB is only
+   pulled in as a transparent fallback on platforms turbovec has no wheel for (Intel
+   macOS, Windows ARM) or when you explicitly select the `chroma` backend. If you do
+   run ChromaDB, monitor their advisories.
 
    - **CVE-2026-45829 / GHSA-f4j7-r4q5-qw2c (chromadb ≥ 1.0.0, CRITICAL) —
-     not exploitable in NeuralMind.**
+     not in the default install, and not exploitable even when ChromaDB is used.**
      This is a pre-authentication remote code-execution flaw in ChromaDB's
      *client/server* HTTP API (`/api/v2/.../collections`), triggered by a
      malicious model repository when `trust_remote_code=true`. NeuralMind
@@ -158,11 +168,21 @@ NeuralMind processes code from your projects. Here's what you should know:
        [GHSA-f4j7-r4q5-qw2c](https://github.com/advisories/GHSA-f4j7-r4q5-qw2c) ·
        [upstream issue](https://github.com/chroma-core/chroma/issues/6717).
 
-2. **MCP Server.** If using the MCP server (`neuralmind.mcp_server`), be aware:
+2. **MCP Server.** If using the MCP server (`neuralmind.mcp_server`, **14 tools**), be aware:
    - It runs locally over stdio by default — no network port is opened.
-   - RBAC is enabled by default with three roles: `admin` (all tools), `builder` (retrieval tools — `wakeup`, `query`, `search`, `build`, `stats`, `benchmark`, `skeleton`), `reader` (read-only retrieval). The synapse-family tools (`synaptic_neighbors`, `synapse_stats`, `synapse_decay`, `next_likely`, `export_synapse_memory`) are **admin-only by default**.
-   - If you customize the role policy in `neuralmind/mcp_security.py`, audit it the same way you would any access-control change.
-   - Audit events are written to `<project>/.neuralmind/audit.jsonl` on every tool call.
+   - RBAC is enabled by default (`neuralmind/mcp_security.py`) with three roles:
+     - `admin` — all tools.
+     - `builder` — `wakeup`, `query`, `search`, `build`, `stats`, `benchmark`, `skeleton`.
+     - `reader` — the same retrieval set **minus `build`**.
+     - Everything else is **admin-only by default**: the synapse family
+       (`synaptic_neighbors`, `synapse_stats`, `synapse_decay`, `next_likely`,
+       `export_synapse_memory`) plus the learning/feedback tools (`feedback`, `review`).
+   - A per-actor **rate limiter** (`RateLimiter`, default 60 calls/min) is enforced
+     alongside RBAC.
+   - If you customize the role policy (backend config `security.roles` or
+     `neuralmind/mcp_security.py`), audit it the same way you would any access-control change.
+   - Audit events — actor, role, tool, RBAC decision, rate-limit hits — are written to
+     `<project>/.neuralmind/audit_events.jsonl` on every tool call.
 
 3. **Claude Code hooks (PostToolUse, UserPromptSubmit, SessionStart, PreCompact).** Hooks execute the `neuralmind` CLI locally with the agent's environment.
    - Hooks are installed by explicit user action (`neuralmind install-hooks`) — never silently.
@@ -179,11 +199,46 @@ NeuralMind processes code from your projects. Here's what you should know:
 
 6. **Directional transitions (v0.11+).** The `synapse_transitions` table records `(from_node, to_node)` pairs derived from the watcher's edit order. The data shape is the same as the existing undirected synapses; the same local-only / no-exfiltration guarantees apply.
 
-7. **Dependencies.** Keep them updated:
-   ```bash
-   pip install --upgrade neuralmind
-   ```
-   CycloneDX SBOM is attached to every release ([air-gapped install walkthrough](docs/use-cases/air-gapped.md)).
+7. **Team memory bundle (v0.30+).** `neuralmind memory publish` writes a **committed** `<project>/.neuralmind-team-memory.json` that teammates inherit on their next session/build. Threat model: import is **MAX-merge only** (it can never *weaken* a teammate's existing weights), is written **only** to the `shared` namespace (never `personal`/`branch`), is content-hash-gated (imported once), and is subject to normal decay — so a malicious or over-eager bundle cannot permanently distort recall. It carries learned associations, **not source code**. Disable inheritance with `NEURALMIND_TEAM_MEMORY=0` (fail-open). Namespaces (v0.24+) keep `branch:`/`personal`/`shared`/`ephemeral` memory partitioned so a branch spike can't pollute `main`.
+
+8. **Schema/artifact indexing (v0.40+).** OpenAPI/AsyncAPI (`.yaml`/`.yml`), SQL DDL (`.sql`), and Protocol Buffers (`.proto`) are indexed as `document` nodes alongside code. These can surface API/DB schemas in query results — apply the same secret-scanning hygiene you would for code (strip credentials from spec files before indexing). Plain YAML config without an `openapi`/`asyncapi`/`swagger` key is silently skipped.
+
+9. **Reuse-feedback hook (v0.38+).** Edit/Write PostToolUse matchers detect when freshly-written code reaches for symbols already in the graph and feed that **reuse** signal into the synapse layer. Data flow is local only: file path + extracted symbol tokens → a synapse weight update; no diff or file content is stored. Disable with `NEURALMIND_REUSE_FEEDBACK=0`. The opt-in selector autotuner (`NEURALMIND_SELECTOR_AUTOTUNE=1`, v0.26+) likewise reads only local query-success signals to adjust L2 recall depth.
+
+10. **Dependencies.** Keep them updated:
+    ```bash
+    pip install --upgrade neuralmind
+    ```
+    A **CycloneDX JSON** SBOM (`neuralmind-vX.Y.Z.sbom.json`, generated by Anchore `syft` over the full transitive tree) is attached to every release — see `.github/workflows/sbom.yml` and the [air-gapped install walkthrough](docs/use-cases/air-gapped.md).
+
+### Privacy & behaviour controls (environment variables)
+
+Every persistence/learning surface has an off-switch. For a locked-down or
+air-gapped deployment, these are the knobs a security reviewer cares about
+(defaults reflect a normal install; all are read from the process environment):
+
+| Variable | Effect | Default |
+|---|---|---|
+| `NEURALMIND_MEMORY=0` | Disable local query-event logging | on |
+| `NEURALMIND_LEARNING=0` | Disable Hebbian synapse learning from interactions | on |
+| `NEURALMIND_SYNAPSE_INJECT=0` | Don't inject spreading-activation recall at prompt time | on |
+| `NEURALMIND_SYNAPSE_EXPORT=0` | Don't write `SYNAPSE_MEMORY.md` / Claude Code auto-memory | on |
+| `NEURALMIND_TEAM_MEMORY=0` | Don't import the committed team-memory bundle | on |
+| `NEURALMIND_REUSE_FEEDBACK=0` | Disable the Edit/Write reuse-feedback signal | on |
+| `NEURALMIND_OUTPUT_CACHE=0` | Disable the Bash recovery cache (`last_output.json`) | on |
+| `NEURALMIND_EVENT_LOG=0` | Disable the `events.jsonl` graph-view bridge | on |
+| `NEURALMIND_BYPASS=1` | Skip output compression for a single command | off |
+| `NEURALMIND_SELECTOR_AUTOTUNE=1` | Opt **in** to selector auto-tuning (local query signals only) | off |
+| `NEURALMIND_PRECISION=1` | Opt **in** to SCIP compiler-accurate call edges | off |
+| `NEURALMIND_BM25=0` | Disable BM25 hybrid keyword search | on |
+| `NEURALMIND_NAMESPACE=<name>` | Override the memory namespace (else resolved from git branch) | branch-resolved |
+| `NEURALMIND_ONNX_MODEL_DIR=<dir>` | Use a pre-staged ONNX model (air-gapped; skips the one-time download) | `~/.cache/neuralmind/onnx_models/` |
+| `NEURALMIND_NO_DAEMON=1` | Force direct mode (no warm-state daemon) | off |
+
+Compression-tuning knobs (`NEURALMIND_BASH_TAIL`, `NEURALMIND_BASH_MAX_CHARS`,
+`NEURALMIND_BASH_SMALL`, `NEURALMIND_SEARCH_MAX`, `NEURALMIND_OFFLOAD_THRESHOLD`,
+`NEURALMIND_OUTPUT_CACHE_MAX`) change *how much* output is kept locally, not
+*whether* anything leaves the machine — nothing does.
 
 ---
 
@@ -289,4 +344,4 @@ We thank all security researchers who help keep NeuralMind and its users safe.
 
 ---
 
-_This security policy is subject to change. Last updated: 2026-05-28 (v0.11.0 — covers PostToolUse hooks, MCP RBAC defaults, directional transitions, recovery cache, watcher trust model)._
+_This security policy is subject to change. Last updated: 2026-06-30 (v0.41.0 — ChromaDB-free ONNX default + no-cloud embedding story, the 14-tool MCP surface with builder/reader RBAC + per-actor rate limiting + `audit_events.jsonl`, the team-memory bundle threat model, schema-artifact indexing, the reuse-feedback hook, memory namespaces, and the full privacy/behaviour env-var table)._

--- a/bench/swe_bench/REPRODUCE.md
+++ b/bench/swe_bench/REPRODUCE.md
@@ -1,0 +1,40 @@
+# SWE-bench retrieval — reproduce
+
+This directory holds committed results from the SWE-bench **retrieval** eval
+(`evals/swe_bench/`). It measures gold-patch-file recall@k / MRR — *not* an
+end-to-end issue solve-rate. See [`evals/swe_bench/README.md`](../../evals/swe_bench/README.md)
+for the honest scope.
+
+## Status
+
+No `results.json` is committed yet. By design, this harness derives its corpus
+from the **canonical SWE-bench dataset at run time** rather than hardcoding
+base-commit SHAs / gold files, so a real run on a machine with `datasets` + network
+is what produces the numbers here. We do not commit fabricated or placeholder
+metrics.
+
+## Run it
+
+```bash
+pip install -e ".[dev]" datasets tiktoken
+python -m evals.swe_bench.runner --run --dataset princeton-nlp/SWE-bench_Lite --limit 50
+# writes bench/swe_bench/results.json
+```
+
+Each task is scored by cloning `github.com/<repo>` at the task's `base_commit`,
+building a NeuralMind index, querying the `problem_statement`, and checking whether
+the gold-patch files land in the retrieved context — via the same
+`neuralmind.quality` scorer the public benchmark uses.
+
+## Verify offline (no network, no dataset)
+
+```bash
+python -m evals.swe_bench.runner --selfcheck       # schema + parser + metric math
+python -m unittest tests.test_swe_bench_harness     # hermetic unit tests
+```
+
+## What a committed `results.json` will contain
+
+`harness`, `dataset`, `oracle: gold-patch-files`, `n_scored`, `n_skipped` (with
+reasons), a `summary` (mean gold-file recall, found-rate, MRR, median tokens), and
+per-task rows. Every skipped task is reported with its reason — no silent drops.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -51,6 +51,7 @@ the same checks that run on every PR.
 | 6 | **Competitor head-to-head** — scored retrieval ranking vs `codebase-memory-mcp 0.8.1` | `python -m evals.public.competitor` | `pip install codebase-memory-mcp==0.8.1` | [`bench/public/competitor/`](../bench/public/competitor/) |
 | 7 | **Latency / memory / disk** — turbovec vs chroma index size, search p50/p95, RSS | `python benchmark_turbovec.py --out results.json` | none | [`BENCHMARK_TURBOVEC.md`](../BENCHMARK_TURBOVEC.md) |
 | 8 | **Your own repo** — reduction ratio, tokens/query, est. monthly savings | `neuralmind benchmark .` | none | — |
+| 9 | **SWE-bench retrieval** — does NeuralMind surface the files a real fix edits? (gold-patch-file recall@k / MRR) | `python -m evals.swe_bench.runner --run` | `pip install datasets` + network | [`bench/swe_bench/`](../bench/swe_bench/REPRODUCE.md) (offline gate: `--selfcheck`) |
 
 Useful variants of #8:
 
@@ -84,20 +85,22 @@ The critique that asks "where are the independent benchmarks?" is partly right.
 These gaps are real and **not** papered over with invented numbers — they're
 tracked on [`ROADMAP.md`](../ROADMAP.md):
 
-- **SWE-bench / agent-loop task completion.** Every harness here scores
-  **retrieval** (does the right code land in the window?), not end-to-end
-  **issue-resolution** accuracy. NeuralMind is a context layer; wiring it behind a
-  full agent on SWE-bench and reporting solve-rate deltas is unbuilt.
+- **SWE-bench *solve-rate*.** Harness #9 now scores SWE-bench **retrieval**
+  (gold-patch-file recall) — the layer NeuralMind controls. The end-to-end
+  **issue-resolution solve-rate** (wiring NeuralMind behind a full coding agent and
+  running the SWE-bench test harness) is **scaffolded but unbuilt**: it needs an LLM
+  API key and a sandboxed agent loop. We won't publish a solve-rate we haven't run —
+  see [`evals/swe_bench/README.md`](../evals/swe_bench/README.md).
 - **Aider polyglot *agent* accuracy.** We compare *features* against Aider's
   repo-map ([`docs/comparisons/vs-aider-repomap.md`](../docs/comparisons/vs-aider-repomap.md))
   and score our own retrieval, but there is no head-to-head "Aider+LLM vs
   NeuralMind+LLM solve-rate per language" number.
 - **Scored head-to-heads beyond one competitor.** Harness #6 scores exactly one
-  incumbent (`codebase-memory-mcp`). Bloop, Sourcegraph Cody, Continue/Cline, and
-  Headroom have **qualitative** comparison pages
-  ([`docs/comparisons/`](../docs/comparisons/README.md)) but no reproducible scored
-  runs — their differing interfaces (server, IDE extension, HTTP proxy) make
-  fair-play normalization real work.
+  incumbent (`codebase-memory-mcp`). The exact reproducibility status of Bloop,
+  Sourcegraph Cody, Continue/Cline, and Headroom — what's adaptable vs. blocked by
+  accounts / no headless interface / wrong axis — is documented in
+  [`evals/public/COMPETITORS.md`](../evals/public/COMPETITORS.md), with the
+  fairness contract a new adapter must meet.
 - **Independent third-party runs.** The public benchmark is reproducible, but the
   published numbers are still maintainer-run. Outside runs — *especially*
   disappointing ones (e.g. "8× not 50× on my Rust monorepo") — are the single most
@@ -111,3 +114,6 @@ tracked on [`ROADMAP.md`](../ROADMAP.md):
 
 If you close any of these with real data, a PR is welcome — that's exactly the
 contribution the project most needs.
+
+> The full external critique mapped point-by-point to coverage (closed / partial /
+> deferred) lives in [`docs/CRITIQUE-COVERAGE.md`](../docs/CRITIQUE-COVERAGE.md).

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,113 @@
+# `benchmarks/` — run the numbers yourself
+
+> "Trust me bro" is not a benchmark. Every headline NeuralMind claims is produced
+> by code in this repo, most of it **gated in CI**, and you can re-run all of it
+> from a source checkout. This folder is the **index + one-command runner** for
+> those harnesses — the harness code itself lives under
+> [`evals/`](../evals/), [`bench/`](../bench/), and
+> [`tests/benchmark/`](../tests/benchmark/).
+
+The harnesses pre-date this folder; they were just scattered across three trees
+with no single entry point. This page is that entry point, plus an honest
+statement of **what is *not* measured yet**. Methodology write-up:
+[`docs/benchmarks/public.md`](../docs/benchmarks/public.md); rendered results:
+[`docs/wiki/Benchmarks.md`](../docs/wiki/Benchmarks.md).
+
+---
+
+## Quick start
+
+```bash
+# from a source checkout (the eval gold sets ship in the repo, not the pip wheel)
+pip install -e ".[dev]" tiktoken
+
+# the deterministic, offline, CI-gated suite — no network, no API key:
+bash benchmarks/run_all.sh
+
+# add the real-OSS-repo public benchmark (clones pinned repos, needs network):
+bash benchmarks/run_all.sh --public
+
+# add the scored competitor head-to-head (needs: pip install codebase-memory-mcp==0.8.1):
+bash benchmarks/run_all.sh --competitor
+
+# everything except the opt-in LLM-judged arm:
+bash benchmarks/run_all.sh --all
+```
+
+Each harness prints a report and **exits non-zero if it falls below its gate** —
+the same checks that run on every PR.
+
+---
+
+## The harnesses
+
+| # | What it measures | Command | Network / key | Committed results |
+|---|---|---|---|---|
+| 1 | **Token reduction + learning + synapse A/B** (CI floor 4.0×) | `python -m tests.benchmark.run` | none | [`tests/benchmark/`](../tests/benchmark/) (golden queries; report printed on run) |
+| 2 | **Answer quality** — faithfulness Δ at *matched budget* vs naive truncation | `python -m evals.faithfulness.runner --run` | none | `evals/faithfulness/` |
+| 3 | **Onboarding lift** — does an agent inheriting committed team memory retrieve better cold? | `python -m evals.onboarding.runner --run` | none | `evals/onboarding/` |
+| 4 | **Backend parity** — turbovec vs ChromaDB + multi-language structural parity | `python -m evals.parity.run` | none | `evals/parity/` |
+| 5 | **Public benchmark** — cost *and* recall vs full-file / ripgrep / vector-RAG on **real pinned OSS repos** (`requests`, `click`) | `python -m evals.public.run` | network (clones repos) | [`bench/public/`](../bench/public/) |
+| 6 | **Competitor head-to-head** — scored retrieval ranking vs `codebase-memory-mcp 0.8.1` | `python -m evals.public.competitor` | `pip install codebase-memory-mcp==0.8.1` | [`bench/public/competitor/`](../bench/public/competitor/) |
+| 7 | **Latency / memory / disk** — turbovec vs chroma index size, search p50/p95, RSS | `python benchmark_turbovec.py --out results.json` | none | [`BENCHMARK_TURBOVEC.md`](../BENCHMARK_TURBOVEC.md) |
+| 8 | **Your own repo** — reduction ratio, tokens/query, est. monthly savings | `neuralmind benchmark .` | none | — |
+
+Useful variants of #8:
+
+- `neuralmind benchmark . --quality` — precision@k / recall@k / MRR / answerability
+  over the golden polyglot suites (contributor/CI self-test).
+- `neuralmind benchmark . --public` — reproduce harness #5 against the pinned repos.
+- `neuralmind benchmark . --public --judge` — opt-in LLM-judged answerability arm
+  (needs `ANTHROPIC_API_KEY`; **never runs in CI**; the recall table is
+  byte-identical with or without it; transcripts written under `bench/public/judge/`).
+- `neuralmind benchmark . --contribute` — emit a schema-ready JSON blob to paste
+  into a [community-benchmark submission](https://github.com/dfrostar/neuralmind/issues/new?template=community-benchmark.yml).
+  Nothing is uploaded.
+
+---
+
+## What the numbers say (short version)
+
+Full tables on the [Benchmarks](../docs/wiki/Benchmarks.md) page. Headline:
+**100% gold-file recall at 38–85× fewer tokens** than pasting files on real OSS
+repos, beating `ripgrep` on *both* recall and cost; **+0.143** faithfulness at a
+matched budget; **+11.7 pts** top-k hit-rate from the synapse layer
+(budget-neutral). We also report where NeuralMind **doesn't** win — a well-tuned
+vector RAG ties it on pure findability and is cheaper on raw tokens, and the
+competitor row is **pure retrieval ranking**, not their LLM-agent loop.
+
+---
+
+## What we don't measure yet (honestly)
+
+The critique that asks "where are the independent benchmarks?" is partly right.
+These gaps are real and **not** papered over with invented numbers — they're
+tracked on [`ROADMAP.md`](../ROADMAP.md):
+
+- **SWE-bench / agent-loop task completion.** Every harness here scores
+  **retrieval** (does the right code land in the window?), not end-to-end
+  **issue-resolution** accuracy. NeuralMind is a context layer; wiring it behind a
+  full agent on SWE-bench and reporting solve-rate deltas is unbuilt.
+- **Aider polyglot *agent* accuracy.** We compare *features* against Aider's
+  repo-map ([`docs/comparisons/vs-aider-repomap.md`](../docs/comparisons/vs-aider-repomap.md))
+  and score our own retrieval, but there is no head-to-head "Aider+LLM vs
+  NeuralMind+LLM solve-rate per language" number.
+- **Scored head-to-heads beyond one competitor.** Harness #6 scores exactly one
+  incumbent (`codebase-memory-mcp`). Bloop, Sourcegraph Cody, Continue/Cline, and
+  Headroom have **qualitative** comparison pages
+  ([`docs/comparisons/`](../docs/comparisons/README.md)) but no reproducible scored
+  runs — their differing interfaces (server, IDE extension, HTTP proxy) make
+  fair-play normalization real work.
+- **Independent third-party runs.** The public benchmark is reproducible, but the
+  published numbers are still maintainer-run. Outside runs — *especially*
+  disappointing ones (e.g. "8× not 50× on my Rust monorepo") — are the single most
+  valuable contribution; `--contribute` makes one in a copy-paste.
+- **Large-real-repo quality & incremental latency.** Gated quality is on a small
+  fixture + two real OSS repos; 1M–10M LOC quality and "200-file `git pull`
+  re-index in N ms" are "trust the gate," not benchmarked. See
+  [Limits & Failure Modes](../docs/wiki/Limits-and-Failure-Modes.md).
+- **Customer case studies.** None published. We won't fabricate dashboard
+  screenshots.
+
+If you close any of these with real data, a PR is welcome — that's exactly the
+contribution the project most needs.

--- a/benchmarks/run_all.sh
+++ b/benchmarks/run_all.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+#
+# benchmarks/run_all.sh — one-command runner for NeuralMind's benchmark harnesses.
+#
+# This is a thin sequencer over harnesses that already live under evals/, bench/,
+# and tests/benchmark/. It runs each as its own process and stops on the first
+# gate failure (set -e), so a non-zero exit means a real regression.
+#
+# Usage:
+#   bash benchmarks/run_all.sh              # deterministic, offline, CI-gated suite
+#   bash benchmarks/run_all.sh --public     # + public benchmark (clones pinned repos; needs network)
+#   bash benchmarks/run_all.sh --competitor # + scored vs codebase-memory-mcp (needs that pip install)
+#   bash benchmarks/run_all.sh --all        # everything except the opt-in LLM-judged arm
+#
+# The LLM-judged answerability arm is intentionally NOT run here: it needs
+# ANTHROPIC_API_KEY, never runs in CI, and the recall table is byte-identical with
+# or without it. Run it explicitly with:
+#   neuralmind benchmark . --public --judge
+
+set -euo pipefail
+
+# Resolve the repo root from this script's location so it works from any CWD.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+cd "${REPO_ROOT}"
+
+RUN_PUBLIC=0
+RUN_COMPETITOR=0
+PYTHON="${PYTHON:-python}"
+
+for arg in "$@"; do
+  case "${arg}" in
+    --public)     RUN_PUBLIC=1 ;;
+    --competitor) RUN_COMPETITOR=1 ;;
+    --all)        RUN_PUBLIC=1; RUN_COMPETITOR=1 ;;
+    -h|--help)
+      sed -n '2,22p' "${BASH_SOURCE[0]}"
+      exit 0
+      ;;
+    *)
+      echo "unknown flag: ${arg} (try --help)" >&2
+      exit 2
+      ;;
+  esac
+done
+
+run_step() {
+  # run_step "<label>" <command...>
+  local label="$1"; shift
+  echo ""
+  echo "=============================================================="
+  echo ">> ${label}"
+  echo "   \$ $*"
+  echo "=============================================================="
+  "$@"
+}
+
+# --- Deterministic, offline, CI-gated suite (always runs) --------------------
+run_step "1/4  Token reduction + learning + synapse A/B (CI floor 4.0x)" \
+  "${PYTHON}" -m tests.benchmark.run
+run_step "2/4  Answer quality — faithfulness delta at matched budget" \
+  "${PYTHON}" -m evals.faithfulness.runner --run
+run_step "3/4  Onboarding lift — committed team memory" \
+  "${PYTHON}" -m evals.onboarding.runner --run
+run_step "4/4  Backend parity — turbovec vs ChromaDB + multi-language" \
+  "${PYTHON}" -m evals.parity.run
+
+# --- Opt-in: public benchmark on real OSS repos (network) --------------------
+if [[ "${RUN_PUBLIC}" -eq 1 ]]; then
+  run_step "public  Cost + recall vs full-file/ripgrep/vector-RAG on real repos" \
+    "${PYTHON}" -m evals.public.run
+fi
+
+# --- Opt-in: scored competitor head-to-head ----------------------------------
+if [[ "${RUN_COMPETITOR}" -eq 1 ]]; then
+  if ! "${PYTHON}" -c "import codebase_memory_mcp" >/dev/null 2>&1; then
+    echo "" >&2
+    echo "competitor step needs the competitor installed:" >&2
+    echo "  pip install codebase-memory-mcp==0.8.1" >&2
+    exit 1
+  fi
+  run_step "competitor  Scored retrieval ranking vs codebase-memory-mcp 0.8.1" \
+    "${PYTHON}" -m evals.public.competitor
+fi
+
+echo ""
+echo "All requested benchmarks passed their gates."

--- a/docs/CRITIQUE-COVERAGE.md
+++ b/docs/CRITIQUE-COVERAGE.md
@@ -1,0 +1,67 @@
+# Critique coverage scorecard
+
+NeuralMind gets a recurring, fair external critique: "the repo sells the happy
+path — where's the *here's where it sucks* section, the independent benchmarks,
+the security specifics, the power-user internals?" This page is the durable answer:
+the critique's points mapped to **where each is addressed**, what's **partial**,
+and what's **honestly deferred** (and why).
+
+Legend: ✅ closed · ◐ partial · ⏸ deferred (measurement/data work, not docs — we
+don't fabricate numbers, case studies, or audits).
+
+## 1. Independent / third-party benchmarks
+
+| Point | Status | Where |
+|---|:--:|---|
+| Reproducible benchmark on real repos (not vendor fixtures) | ✅ | Public benchmark on pinned `requests`/`click` — [`docs/benchmarks/public.md`](benchmarks/public.md), traces in [`bench/public/`](../bench/public/) |
+| Runnable `benchmarks/` folder | ✅ | [`benchmarks/README.md`](../benchmarks/README.md) + `run_all.sh` |
+| SWE-bench accuracy | ◐ | **Retrieval** measured ([`evals/swe_bench/`](../evals/swe_bench/README.md)); end-to-end **solve-rate** ⏸ scaffolded (needs an agent loop + API key) |
+| Aider polyglot agent accuracy | ⏸ | Feature comparison exists ([`vs-aider-repomap`](comparisons/vs-aider-repomap.md)); no agent-loop solve-rate |
+| Head-to-head vs competitors | ◐ | One scored live (`codebase-memory-mcp`); the rest with exact blockers in [`evals/public/COMPETITORS.md`](../evals/public/COMPETITORS.md) |
+| Independent (non-maintainer) runs | ⏸ | Reproducible + invited (`neuralmind benchmark . --contribute`); outside runs still accumulating |
+
+## 2. Failure modes & limits
+
+| Point | Status | Where |
+|---|:--:|---|
+| When compressed context fails / when to bypass | ✅ | [Limits & Failure Modes §1](wiki/Limits-and-Failure-Modes.md#1-when-the-compressed-context-is-enough--and-when-it-isnt) |
+| Repo-size / index-time / memory / disk envelope | ✅ | [Limits & Failure Modes §2](wiki/Limits-and-Failure-Modes.md#2-repo-size-index-time-memory--disk-envelope) |
+| Language coverage (what's indexed *and not*) | ✅ | [Limits & Failure Modes §3](wiki/Limits-and-Failure-Modes.md#3-language-support-matrix) |
+
+## 3. Real-world usage data
+
+| Point | Status | Where |
+|---|:--:|---|
+| Staleness / incremental re-index behaviour | ◐ | Explained ([Limits §2](wiki/Limits-and-Failure-Modes.md#2-repo-size-index-time-memory--disk-envelope)); no published latency SLA |
+| MCP / IDE integration setup | ✅ | [Integration Guide](wiki/Integration-Guide.md) + `neuralmind install-mcp --all` |
+| MCP / IDE latency numbers + UX | ⏸ | Not yet benchmarked |
+| Customer case studies | ⏸ | None published — we won't fabricate dashboard screenshots |
+
+## 4. Security & privacy
+
+| Point | Status | Where |
+|---|:--:|---|
+| Supply chain / what's in the package | ✅ | [`SECURITY.md`](../SECURITY.md) + `pyproject.toml` deps |
+| Telemetry | ✅ | Zero, actively suppressed — [`SECURITY.md`](../SECURITY.md), `neuralmind/__init__.py` |
+| SBOM | ✅ | CycloneDX per release — `.github/workflows/sbom.yml` |
+| Cloud vs local embeddings | ✅ | 100% local ONNX — [Architecture: Embedding model](wiki/Architecture.md#embedding-strategy), [`SECURITY.md`](../SECURITY.md) |
+| Env-var / off-switch inventory | ✅ | [`SECURITY.md` → privacy/behaviour controls](../SECURITY.md) |
+| Third-party security audit | ⏸ | None exists — disclosed honestly, not implied |
+
+## 5. Engineering internals for power users
+
+| Point | Status | Where |
+|---|:--:|---|
+| Chunking / L0–L3 progressive disclosure | ✅ | [Architecture: 4-Layer Progressive Disclosure](wiki/Architecture.md) |
+| Embedding model spec + swappability | ✅ | [Architecture: Embedding model](wiki/Architecture.md#embedding-strategy) |
+| Index format + inspect/export | ✅ | [Architecture: Index format & debugging](wiki/Architecture.md) |
+| Debug "why did a query miss?" | ✅ | `query --trace/--explain/--relevance`, `probe`, `doctor` — [Architecture](wiki/Architecture.md) |
+
+## The honest bottom line
+
+The **documentation-shaped** gaps are closed; the **measurement/data-shaped** ones
+(⏸) are real but require running evals with API keys, building agent loops, or data
+we don't have — so they're tracked openly on [`ROADMAP.md`](../ROADMAP.md) and
+listed in [`benchmarks/README.md`](../benchmarks/README.md) rather than papered over
+with invented numbers. That honesty *is* the position — see
+[`HONEST-ASSESSMENT.md`](HONEST-ASSESSMENT.md).

--- a/docs/HONEST-ASSESSMENT.md
+++ b/docs/HONEST-ASSESSMENT.md
@@ -15,7 +15,10 @@ sharpen the honesty are welcome.
 > isn't enough, the repo-size envelope, and the per-language support
 > matrix with explicitly-unsupported features — see
 > [Limits & Failure Modes](wiki/Limits-and-Failure-Modes.md). For the
-> reproducible numbers, see [`benchmarks/`](../benchmarks/README.md).
+> reproducible numbers, see [`benchmarks/`](../benchmarks/README.md). For the
+> recurring external critique mapped point-by-point to where each item is
+> addressed (or honestly deferred), see
+> [Critique Coverage](CRITIQUE-COVERAGE.md).
 
 ---
 

--- a/docs/HONEST-ASSESSMENT.md
+++ b/docs/HONEST-ASSESSMENT.md
@@ -10,6 +10,13 @@ This document represents the project's stance, drafted with AI
 assistance and reviewed by the maintainer. Pull requests that
 sharpen the honesty are welcome.
 
+> **Operational companion:** this page is about *whether to install*.
+> For *where it stops working once installed* — when a single query
+> isn't enough, the repo-size envelope, and the per-language support
+> matrix with explicitly-unsupported features — see
+> [Limits & Failure Modes](wiki/Limits-and-Failure-Modes.md). For the
+> reproducible numbers, see [`benchmarks/`](../benchmarks/README.md).
+
 ---
 
 ## TL;DR

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -236,6 +236,11 @@
     <priority>0.5</priority>
   </url>
   <url>
+    <loc>https://dfrostar.github.io/neuralmind/wiki/Limits-and-Failure-Modes.html</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
     <loc>https://dfrostar.github.io/neuralmind/wiki/Scheduling-Guide.html</loc>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>

--- a/docs/wiki/Architecture.md
+++ b/docs/wiki/Architecture.md
@@ -477,10 +477,31 @@ def allocate_budget(query_complexity: float) -> TokenBudget:
 
 ### Embedding Model
 
-NeuralMind uses ChromaDB's default embedding function, which typically uses:
-- **Model**: `all-MiniLM-L6-v2` (or similar)
-- **Dimensions**: 384
-- **Type**: Sentence transformers
+NeuralMind embeds **100% locally** — there is **no cloud embedding API call**, on
+any backend ([`SECURITY.md`](https://github.com/dfrostar/neuralmind/blob/main/SECURITY.md)).
+The model is **pinned**, not "default / or similar":
+
+- **Model**: `all-MiniLM-L6-v2` — `_MODEL_NAME` in
+  [`neuralmind/onnx_embedder.py`](https://github.com/dfrostar/neuralmind/blob/main/neuralmind/onnx_embedder.py)
+- **Dimensions**: 384 (`OnnxMiniLMEmbedder.dim`)
+- **Max tokens / batch**: 256 / 32
+- **Runtime**: `onnxruntime` (CPU), tokenized with `tokenizers` — the bundled
+  ChromaDB-free path (default on Linux / Apple Silicon / Windows x64 since v0.29.0)
+- **Model fetch**: one-time download of a **SHA256-pinned** archive
+  (`_ARCHIVE_SHA256`) into `~/.cache/neuralmind/onnx_models/`; a corrupted or swapped
+  download **fails loudly**. Pre-stage it for air-gapped installs via
+  `NEURALMIND_ONNX_MODEL_DIR` — no network at build, query, or runtime thereafter.
+- **Backend parity**: the ONNX embedder produces vectors **byte-identical** to
+  ChromaDB's `all-MiniLM-L6-v2` (verified cosine 1.0, max elementwise diff 0.0), so
+  the `turbovec` (TurboQuant, 8–16× smaller index) and `chroma` backends retrieve
+  equivalently — only the index representation differs.
+
+**Can I swap the model?** Not as a supported knob today, and deliberately so: the
+embedder is the same one ChromaDB pins, and the community-detection ids and synapse
+edge keys are computed against *these* vectors. Swapping the encoder would
+invalidate a warm synapse store and the parity guarantee above. If you need a
+different encoder, that's a code change to `onnx_embedder.py` / the backend, not a
+config flag — and you'd rebuild the index and re-warm memory from scratch.
 
 ### What Gets Embedded
 
@@ -904,8 +925,55 @@ have their edges softened so they surface less.
 
 ---
 
+## Index format & debugging (power-user reference)
+
+You don't have to treat the index as a black box. Everything below is on-disk and
+inspectable, and there's a command for "why did my query miss?"
+
+### What's on disk
+
+| Artifact | Path | Format | Inspect with |
+|---|---|---|---|
+| **Code graph** | `graphify-out/graph.json` | plain JSON (nodes + edges + rationale) | any JSON tool; `embedder.get_file_nodes()` / `get_file_edges()` |
+| **Vector index** | `graphify-out/neuralmind_db/` | ChromaDB `PersistentClient` (SQLite) **or** turbovec (TurboQuant) | `neuralmind stats`; backend-specific |
+| **Synapse store** | `.neuralmind/synapses.db` | SQLite (edge weights + directional transitions + namespaces + tuner meta) | `neuralmind memory inspect`; `sqlite3` |
+| **Memory export** | `.neuralmind/SYNAPSE_MEMORY.md` | Markdown (auto-loaded by Claude Code) | read it directly |
+| **Event log** | `.neuralmind/events.jsonl` | JSONL activity stream | `neuralmind savings`; the graph view |
+
+The IR is **schema-versioned** and round-trips losslessly — `neuralmind validate`
+checks the contract **without a vector backend**, so you can verify graph integrity
+in CI before embedding.
+
+### "Why did this query return *that*?"
+
+The retrieval path is transparent and reproducible (same query + same index ⇒ same
+context). The inspection surface, from cheapest to deepest:
+
+| Command | Answers |
+|---|---|
+| `neuralmind stats` | node count, community distribution, resolved backend, db path |
+| `neuralmind doctor` | is every subsystem healthy (graph, index, synapses, MCP, hooks)? + exact fix commands |
+| `neuralmind validate` | does the graph satisfy the versioned IR contract? (no backend needed) |
+| `neuralmind query … --trace` | per-layer candidates, cluster scoring with **vector-vs-synapse attribution**, final hits |
+| `neuralmind query … --explain` | human-readable "why this context" — L0–L3 token budget, communities loaded, top search hits, synapses that fired (implies `--trace`) |
+| `neuralmind query … --relevance` | machine-readable per-file/per-node `relevance` sidecar: vector **score**, synapse **boost**, **recall flag**, **line spans** (also `neuralmind_query(include_relevance=true)`) |
+| `neuralmind probe` | label-free self-test — queries each symbol by its *rationale* (not its name) and reports retrieval blind spots (~0.79 MRR with real gaps disclosed) |
+| `neuralmind savings` | cumulative token savings vs estimated full-codebase cost, per query, from the event log |
+| `neuralmind review` | spreading-activation co-break candidates for the current `git diff` (also `neuralmind_review` MCP tool) |
+| `neuralmind memory inspect` | synapse contribution by namespace (`branch:` / `personal` / `shared` / `ephemeral`); `memory export` dumps a versioned JSON bundle |
+
+If `--trace` shows the gold file *did* embed but ranked low, the usual causes are:
+a weak/missing docstring (the rationale layer carries semantic signal — see
+[Embedding Strategy](#embedding-strategy)), a cold synapse store (recall warms with
+use — [Learning Guide](Learning-Guide)), or a question that needs more breadth than
+one budget holds (see [Limits & Failure Modes](Limits-and-Failure-Modes)).
+
+---
+
 ## See Also
 
+- [Limits & Failure Modes](Limits-and-Failure-Modes.md) - Where it stops working, and what to do then
+- [Benchmarks & Results](Benchmarks.md) - Every measured, CI-gated number + reproduction commands
 - [API Reference](API-Reference.md) - Python API documentation
 - [CLI Reference](CLI-Reference.md) - Command-line interface
 - [Integration Guide](Integration-Guide.md) - MCP and tool integrations

--- a/docs/wiki/Benchmarks.md
+++ b/docs/wiki/Benchmarks.md
@@ -98,10 +98,21 @@ The opt-in `turbovec` backend (Google **TurboQuant**) can embed *and* search wit
 | Python | (gold-fact eval above) | — | — |
 | TypeScript | 54 | **54 (100%)** | 0 |
 | Go | 45 | **45 (100%)** | 0 |
+| Rust | 49 | **49 (100%)** | 0 |
+| Java | 52 | **52 (100%)** | 0 |
+| C | 47 | **47 (100%)** | 0 |
+| C++ | 51 | **51 (100%)** | 0 |
+| C# | 52 | **52 (100%)** | 0 |
+| Ruby | 46 | **46 (100%)** | 0 |
+| PHP | 54 | **54 (100%)** | 0 |
 
 The built-in tree-sitter backend matches graphify symbol-for-symbol on the
-reference fixtures; an optional SCIP pass replaces heuristic call edges with
-compiler-accurate ones. All gated by `evals/parity/run.py`.
+reference fixtures for **all ten bundled languages** (Python plus the nine above);
+an optional SCIP pass replaces heuristic call edges with compiler-accurate ones.
+All gated by `evals/parity/run.py` (coverage floor 90%, zero dangling edges) — the
+numbers above are emitted live by the parity gate on every PR. Per-language *answer
+quality* (vs structural coverage) is still Python-first; see
+[Limits & Failure Modes](Limits-and-Failure-Modes#3-language-support-matrix).
 
 ## What we *don't* claim
 

--- a/docs/wiki/FAQ.md
+++ b/docs/wiki/FAQ.md
@@ -148,6 +148,9 @@ neuralmind build . --backend postgres --db-url postgresql://...
 - 1M LOC → 500MB-2GB
 - 10M LOC → 5-20GB
 
+> Full size / index-time / memory envelope — with the honest "not yet measured at
+> scale" caveats — is on the [Limits & Failure Modes](Limits-and-Failure-Modes#2-repo-size-index-time-memory--disk-envelope) page.
+
 **Compress if needed:**
 ```bash
 # Delete old indexes
@@ -163,11 +166,17 @@ neuralmind build . --optimize
 
 ### "Does NeuralMind support my language?"
 
-**Supported:**
-- Python, JavaScript/TypeScript, Java, C++, Go, Rust, C#, PHP, Ruby, SQL
+**Supported (built-in tree-sitter, no graphify needed):**
+- Python, TypeScript/JavaScript, Go, Rust, Java, C, C++, C#, Ruby, PHP
+- Plus schema/doc artifacts: Markdown, OpenAPI/AsyncAPI (YAML), SQL DDL, Protocol Buffers
 
 **Partial support:**
-- Other languages (graphify has limited AST extraction)
+- Other languages can be indexed as plaintext (less precise)
+
+> The per-language [support matrix](Limits-and-Failure-Modes#3-language-support-matrix)
+> spells out exactly what's indexed *and what's explicitly not modeled* per language
+> (C/C++ macros & templates, dynamic-dispatch call resolution, SQL `ALTER`/`SELECT`,
+> proto imports, OpenAPI `$ref`, …).
 
 **If not supported:**
 ```bash

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -154,7 +154,8 @@ sections.
 | [Usage Guide](Usage-Guide) | End-to-end examples for every command |
 | [CLI Reference](CLI-Reference) | All CLI commands, flags, and output shapes |
 | [API Reference](API-Reference) | Python API (`NeuralMind`, `ContextResult`, `TokenBudget`) |
-| [Architecture](Architecture) | How the 4-layer progressive disclosure system works |
+| [Architecture](Architecture) | How the 4-layer progressive disclosure system works — incl. the embedding-model spec + index inspection/debugging reference |
+| [Limits & Failure Modes](Limits-and-Failure-Modes) | Where it stops working: when one query isn't enough, the repo-size envelope, and the per-language support matrix |
 | [Integration Guide](Integration-Guide) | MCP, CI/CD, VS Code, JetBrains, any-LLM piping |
 | [Scheduling Guide](Scheduling-Guide) | Automate audits with Windows Task Scheduler, GitHub Actions, or cron |
 | [Learning Guide](Learning-Guide) | Opt-in memory + the brain-like synapse layer that learns associations from how you use the codebase (Hebbian co-activation with decay), the single learning system since v0.25.0 |

--- a/docs/wiki/Limits-and-Failure-Modes.md
+++ b/docs/wiki/Limits-and-Failure-Modes.md
@@ -1,0 +1,200 @@
+# Limits & Failure Modes
+
+The honest "here's where it breaks" page. [`HONEST-ASSESSMENT.md`](https://github.com/dfrostar/neuralmind/blob/main/docs/HONEST-ASSESSMENT.md)
+answers *should you install it*; this page answers *where does it stop working,
+and what do I do then*. Everything here is sourced from the shipped code and
+release notes — no aspirational claims. If a number is an estimate, it says so.
+
+If you came here from a "trust-me-bro numbers" critique: the reproducible
+evidence lives on the **[Benchmarks](Benchmarks)** page and in
+[`benchmarks/`](https://github.com/dfrostar/neuralmind/blob/main/benchmarks/README.md);
+this page is the companion list of the rough edges those benchmarks *don't*
+paper over.
+
+---
+
+## 1. When the compressed context is enough — and when it isn't
+
+A NeuralMind query assembles four layers with hard token caps
+([`neuralmind/context_selector.py`](https://github.com/dfrostar/neuralmind/blob/main/neuralmind/context_selector.py)):
+
+| Layer | What it carries | Default cap |
+|---|---|---:|
+| **L0** identity | project name, description, stats | **150 tok** |
+| **L1** summary | top code clusters, type distribution, report digest | **600 tok** |
+| **L2** on-demand | the communities semantic search + synapse recall pulled in | **800 tok** |
+| **L3** search | the individual vector + BM25 hits, re-ranked by synapse energy | **1,000 tok** |
+
+So a single query tops out at roughly **~2.5K tokens** of assembled context (the
+caps are ceilings — most queries land well under). That budget is tuned for the
+question NeuralMind is built to answer:
+
+> *"Find and explain the code that bears on **this** question."*
+
+**Where it's enough.** Locating the right files/symbols, understanding one
+subsystem, answering "how does X work", seeding a focused change. The faithfulness
+eval shows that at a **matched budget**, smart selection beats naive truncation
+(**+0.143 expected-fact recall**, [Benchmarks](Benchmarks)) — i.e. the ~2.5K
+tokens are *better-chosen* tokens, not just fewer.
+
+**Where it gets thin.** A single ~2.5K-token window is a poor fit for work that
+genuinely needs *broad* context at once:
+
+- **Wide refactors touching many files simultaneously.** Renaming a symbol used in
+  30 files, or a cross-cutting signature change, needs more breadth than one query
+  budget holds. Retrieval finds the *seeds*; it doesn't hand you all 30 sites in
+  one shot.
+- **"Read everything and reason globally" tasks.** Whole-architecture rewrites,
+  global invariants, "find every place that could be affected." These are
+  O(repo) by nature; NeuralMind is O(query) by design (see
+  [`HONEST-ASSESSMENT.md`](https://github.com/dfrostar/neuralmind/blob/main/docs/HONEST-ASSESSMENT.md#what-4070-reduction-actually-means)).
+- **Answers that depend on prose NeuralMind didn't index.** If the "why" lives in a
+  Confluence page or a PR description, it isn't in the graph.
+
+### What to do when one query isn't enough
+
+You are not stuck with the default budget. In rough order of reach:
+
+1. **`neuralmind review`** — instead of one query, seed spreading activation from
+   the files you're *already* changing (`git diff --name-only`) and surface the
+   **co-break candidates** you forgot to touch. This is the right tool for a
+   multi-file change; it's also the `neuralmind_review` MCP tool so the agent can
+   call it before proposing edits.
+2. **Raise L2 recall depth.** The selector's L2 depth is clamped to
+   `[L2_RECALL_K_MIN=2, L2_RECALL_K_MAX=6]`; the opt-in autotuner
+   (`NEURALMIND_SELECTOR_AUTOTUNE=1`) widens it from the re-query rate. Inspect the
+   current state with `neuralmind self-improve status`.
+3. **Run several targeted queries**, one per concern, rather than one broad query.
+   Retrieval is cheap; breadth comes from *more* queries, not a bigger single one.
+4. **Bypass compression entirely for a tool call.** `NEURALMIND_BYPASS=1` skips the
+   PostToolUse compression so the agent reads the full output of one `Read`/`Bash`/
+   `Grep` — use it when you knowingly need the whole file in front of the model.
+
+> **Rule of thumb.** If the task is "understand / locate / seed", trust the query.
+> If it's "rewrite across the repo at once", use `review` to enumerate the blast
+> radius first, then widen or bypass for the files that matter.
+
+---
+
+## 2. Repo-size, index-time, memory & disk envelope
+
+NeuralMind has run on **1M+ LOC** codebases. The figures below are **rough
+estimates** for planning, not measured SLAs — the rigorously-measured numbers are
+the CI token-reduction floor and the public-benchmark recall on real OSS repos
+(see [Benchmarks](Benchmarks)); large-real-repo *quality* and *latency* are
+explicitly **not yet measured at scale** (a known gap on
+[`ROADMAP.md`](https://github.com/dfrostar/neuralmind/blob/main/ROADMAP.md)).
+
+| Repo size | First build | Disk (index) | Notes |
+|---|---|---|---|
+| ~5K LOC | seconds | a few MB | below this, skip NeuralMind and paste the code |
+| 100K LOC | minutes | 50–100 MB | comfortable |
+| 500K LOC | minutes | 200–500 MB | comfortable |
+| 1M LOC | ~10–20 min | 500 MB–2 GB | the `~10–20 min for a 50K-line repo` setup line in [`HONEST-ASSESSMENT.md`](https://github.com/dfrostar/neuralmind/blob/main/docs/HONEST-ASSESSMENT.md#setup-cost-realistic) scales up here |
+| 10M LOC | trust-the-gate | 5–20 GB | not exercised in CI; turbovec's 8–16× smaller vectors matter most here |
+
+Rules that hold regardless of size:
+
+- **First build is the cost; re-builds are incremental.** `neuralmind watch --reindex`
+  re-parses only changed files and re-embeds only their nodes — unchanged nodes are
+  skipped by a content-hash check
+  ([`neuralmind/embedder.py`](https://github.com/dfrostar/neuralmind/blob/main/neuralmind/embedder.py)),
+  so editing a handful of files costs a handful of files' work, not a full rescan.
+- **`git pull` of 200 files re-indexes those 200 files, not the repo.** The
+  content-hash skip is per-node, so a large pull touches only what actually changed.
+  Honest caveat: there is **no published "200 files = N ms" latency number** yet —
+  it's incremental by construction, but the wall-clock curve isn't benchmarked.
+- **Disk is reclaimable.** The whole index regenerates from source; delete
+  `graphify-out/neuralmind_db/` (or `.neuralmind/`) and rebuild.
+- **Turbovec shrinks the memory/disk footprint** ~8–16× vs ChromaDB float32 vectors
+  at retrieval parity — the lever that makes large monorepos practical
+  ([Benchmarks → ChromaDB-free](Benchmarks)).
+
+If a build OOMs on a very large tree, build incrementally and see
+[Troubleshooting](Troubleshooting).
+
+---
+
+## 3. Language support matrix
+
+NeuralMind's built-in **tree-sitter** backend indexes the ten languages below with
+**no graphify dependency** (`neuralmind build .` works standalone), plus four
+non-code schema/document artifacts. Structural coverage is **parity-gated in CI**
+(symbol-for-symbol vs graphify, zero dangling edges) — but parity is *structural
+correctness*, **not** per-language retrieval-quality scoring. The gold-fact /
+faithfulness evals are still **Python-first**; quality on the other languages is
+proven *structurally*, not yet *measured for answer quality* (gap tracked on
+[`ROADMAP.md`](https://github.com/dfrostar/neuralmind/blob/main/ROADMAP.md)).
+
+Source of truth for the parser: `_SUFFIX_LANG` in
+[`neuralmind/graphgen.py`](https://github.com/dfrostar/neuralmind/blob/main/neuralmind/graphgen.py).
+
+### Code languages (tree-sitter)
+
+| Language | Suffixes | Indexed | Honestly **not** modeled |
+|---|---|---|---|
+| **Python** | `.py` | full reference language; the eval gold set | — |
+| **TypeScript** | `.ts` `.tsx` | types, functions, imports — 100% parity gate | type-level-only constructs are best-effort |
+| **Go** | `.go` | types, funcs, methods, imports — 100% parity gate | — |
+| **Rust** | `.rs` | structs, enums, traits, `impl` blocks, fields, free fns; `impl Trait for T`→`inherits`; `use`→`imports_from`; doc comments→rationale | macro-generated items; `target/` skipped |
+| **Java** | `.java` | classes/interfaces/enums/records, methods, ctors, fields; `extends`/`implements`→`inherits`; `import`→`imports_from`; Javadoc→rationale | — |
+| **C#** | `.cs` | class/interface/struct/record/enum, methods/ctors, fields/props/enum members; `base_list`→`inherits`; `using`→`imports_from` | — |
+| **C** | `.c` `.h` | functions, struct/union/enum + fields/consts, typedefs; `#include "x.h"`→`imports_from`; header/impl pair collated | **macros not indexed as symbols**; `#ifdef` not evaluated |
+| **C++** | `.cpp` `.cc` `.cxx` `.hpp` `.hh` `.hxx` | classes w/ member methods/fields, namespace-qualified ids, the C set above; base classes→`inherits` | **templates not specialized**; macros not indexed; `#ifdef` not evaluated |
+| **Ruby** | `.rb` | `class`/`module`→type, `def`/`def self.`→function, constants→symbol; `Foo < Bar`→`inherits`; `require_relative`→`imports_from` | **no receiver-type call resolution**; `include`/`extend` mixins not modeled as inheritance; `attr_accessor` not emitted as fields |
+| **PHP** | `.php` | class/interface/trait/enum→type, methods/fns→function, props/consts/enum cases→symbol; `extends`/`implements`→`inherits`; `use`→`imports_from`; `/** */`→rationale | **no `$obj->method` receiver-type resolution**; `require`/`include` path imports not modeled; trait-`use`-in-class-body not modeled as inheritance |
+
+**Calls are heuristic by default** across all languages (best-effort, disclosed
+per release). For **compiler-accurate** `calls`/`inherits` edges on Python /
+TypeScript / Go, set `NEURALMIND_PRECISION=1` with a SCIP index (off by default,
+[v0.17.0](https://github.com/dfrostar/neuralmind/blob/main/RELEASE_NOTES_v0.17.0.md)).
+
+### Schema & document artifacts (no tree-sitter parse)
+
+| Artifact | Suffixes | Indexed | Honestly **not** modeled |
+|---|---|---|---|
+| **Markdown** | `.md` `.markdown` | file + one `document` node per heading | — |
+| **OpenAPI / AsyncAPI** | `.yaml` `.yml` *(with an `openapi`/`asyncapi`/`swagger` key)* | one node per path+method (`POST /payments/charge`), per schema component, per channel | **`$ref` resolution**; plain YAML config is silently skipped (not an error) |
+| **SQL DDL** | `.sql` | one node per `CREATE TABLE/VIEW/PROCEDURE/FUNCTION/TRIGGER/INDEX/TYPE` | **`ALTER` / `SELECT` not modeled** |
+| **Protocol Buffers** | `.proto` | one node per `message` / `service` / `rpc` / `enum` | **`import` edges not modeled** |
+
+**GraphQL** is planned for
+[v0.42.0](https://github.com/dfrostar/neuralmind/blob/main/ROADMAP.md). Any other
+file type can be indexed as plaintext (less precise) rather than parsed.
+
+### Polyglot-monorepo guidance
+
+Retrieval quality tracks **graph quality**, which tracks **per-language parser
+quality**. A monorepo whose value is concentrated in a weak-coverage area (heavy
+C++ template metaprogramming, macro-defined APIs, generated code) will see a lower
+real-world ratio than the headline range — this is called out directly in
+[`HONEST-ASSESSMENT.md`](https://github.com/dfrostar/neuralmind/blob/main/docs/HONEST-ASSESSMENT.md#when-neuralmind-is-not-worth-it).
+Practical move: index the strong-coverage languages and lean on `grep`/SCIP for the
+weak ones; the tools compose.
+
+---
+
+## 4. The honest "thin evidence" list
+
+Carried over from [`HONEST-ASSESSMENT.md`](https://github.com/dfrostar/neuralmind/blob/main/docs/HONEST-ASSESSMENT.md#what-we-havent-measured-well-yet)
+so it lives next to the limits it qualifies:
+
+- **End-to-end cost** is **3–10×** on a real workload, *not* 40–70× — the headline
+  is a *retrieval-input-token* reduction, not a total-bill reduction.
+- **Per-language answer quality** is gated *structurally*, not *for answer
+  faithfulness* — the faithfulness gold set is Python-first.
+- **Large-real-repo quality and incremental latency** are "trust the gate," not yet
+  measured at scale.
+- **Community benchmarks** are still a small, mostly-maintainer-seeded set — outside
+  numbers (even disappointing ones) are the most valuable contribution. Run
+  `neuralmind benchmark . --contribute`.
+
+For what the project *deliberately doesn't measure yet* (SWE-bench, Aider
+agent-loop accuracy, multi-competitor head-to-heads), see the **"What we don't
+measure yet"** section of [`benchmarks/README.md`](https://github.com/dfrostar/neuralmind/blob/main/benchmarks/README.md).
+
+---
+
+*See also:* [Benchmarks](Benchmarks) · [Architecture](Architecture) · [FAQ](FAQ) ·
+[Troubleshooting](Troubleshooting) ·
+[HONEST-ASSESSMENT.md](https://github.com/dfrostar/neuralmind/blob/main/docs/HONEST-ASSESSMENT.md)

--- a/evals/public/COMPETITORS.md
+++ b/evals/public/COMPETITORS.md
@@ -1,0 +1,50 @@
+# Competitor benchmarks — what's reproducibly scorable, and what isn't
+
+The recurring critique asks for scored head-to-heads vs Bloop, Sourcegraph Cody,
+Continue/Cline, and Tejas Headroom. We run exactly one **live, scored** competitor
+today (`codebase-memory-mcp`) and we're honest about why the others aren't here yet:
+a fair, *reproducible* retrieval benchmark needs a competitor that can be driven
+**headless, on a pinned repo, with no account**, and that returns ranked files we
+can score on the **same** def-site / gold-patch oracle every NeuralMind backend uses.
+
+This file is the durable record of that status. It is **not** a list of excuses —
+where a tool *is* tractable (Bloop), the adapter seam is ready; where it isn't, the
+exact blocker is named so a contributor knows what it would take.
+
+## Status matrix
+
+| Competitor | Status | What it is | Blocker / how to unblock |
+|---|---|---|---|
+| **codebase-memory-mcp** (DeusData) | ✅ **scored, live** | Local single-binary semantic code memory, headless CLI | None — see [`competitor.py`](competitor.py) + [`bench/public/competitor/`](../../bench/public/competitor/). Reproduce: `pip install codebase-memory-mcp==0.8.1 && python -m evals.public.competitor` |
+| **Bloop** | ◐ **adaptable** | Local Rust code-search app (vector + keyword) | Adapter seam matches `competitor.py` (index → semantic query → ranked files → `BackendResult`). Needs a verified **headless** invocation against a pinned checkout; its current distribution is GUI/server-first. Contribution-ready. |
+| **Sourcegraph Cody** | ✗ **account-gated** | Server-hosted, org-wide code context | Cody's context API requires a Sourcegraph instance + auth token; results depend on server-side indexing we can't pin per-commit. Not reproducible without an account, so any number would be unauditable. |
+| **Continue / Cline** | ✗ **no headless retrieval** | IDE agent runtimes (VS Code / JetBrains extensions) | These are *agent runtimes* that consume a context layer; they expose no headless "retrieve files for this query" CLI to score in isolation. The honest comparison is architectural (see [`docs/comparisons/vs-continue-cline.md`](../../docs/comparisons/vs-continue-cline.md)), not a retrieval head-to-head. |
+| **Tejas Headroom** | ✗ **wrong axis** | Universal context **compression** proxy | Headroom compresses what flows to the model; it is not a code *retriever* and returns no ranked file list, so gold-file recall doesn't apply. The right comparison is **compression ratio at fixed fidelity**, a different benchmark — tracked separately. See [`docs/comparisons/vs-headroom.md`](../../docs/comparisons/vs-headroom.md). |
+
+## The fairness contract (any new competitor must meet it)
+
+Lifted from the `codebase-memory-mcp` row so a new adapter is apples-to-apples:
+
+1. **Headless + pinned.** Driven by CLI/API against a repo checked out at an exact
+   commit — no GUI, no account, no server-side index we can't reproduce.
+2. **Ranked files out.** Returns a ranked list of files (or chunks → files) we can
+   cap at the shared retrieval depth (`SEM_LIMIT = 8`, matched to the vector-RAG
+   baseline) and score with the **same** `neuralmind.quality` code.
+3. **Most-favorable reproducible input.** If the interface differs (e.g. a keyword
+   array vs free text), pick the *best-for-the-competitor* reproducible mapping and
+   say so — no per-query hand-tuning.
+4. **Pin the version, commit the raw traces.** Exact version, verbatim CLI, and
+   per-query JSON traces committed under `bench/public/<competitor>/`.
+5. **Fail closed.** Absent binary / errored call → clean skip, never a stale or
+   fabricated result.
+
+A new adapter that satisfies this drops in next to `run_competitor` and is scored
+by the existing harness — no metric math is reinvented.
+
+## Honest framing of the one live row
+
+The `codebase-memory-mcp` head-to-head is **pure retrieval ranking** (no LLM agent
+loop on either side — the same way we test NeuralMind's own `search`). We use the
+competitor's *most-favorable* reproducible keyword mapping, and we cite its
+*published* LLM-agent figures as-is rather than reproduce them. So the win is on
+reproducible retrieval ranking, not on agent-driven published numbers.

--- a/evals/swe_bench/README.md
+++ b/evals/swe_bench/README.md
@@ -1,0 +1,61 @@
+# SWE-bench retrieval eval
+
+**Does NeuralMind's retrieval surface the files a real bug-fix actually edits?**
+
+This harness answers the most-requested benchmark question — "how does it do on
+SWE-bench?" — at the layer NeuralMind actually operates: **retrieval**. For each
+SWE-bench task it takes the issue text (`problem_statement`) and scores whether
+NeuralMind puts the **gold-patch files** (the files the maintainer's accepted fix
+touches) into the context window — objective gold, no LLM judge, deterministic.
+
+```bash
+python -m evals.swe_bench.runner --selfcheck            # offline gate (no net, no deps)
+pip install datasets                                    # for the real corpus
+python -m evals.swe_bench.runner --run --limit 20       # score retrieval on real tasks
+python -m evals.swe_bench.runner --run --json           # machine-readable report
+```
+
+## What it measures — and what it doesn't
+
+| | This harness | The full SWE-bench leaderboard |
+|---|---|---|
+| **Question** | Did the right *files* reach the window? | Did the issue get *fixed*? |
+| **Oracle** | Gold-patch files (objective) | Test suite pass/fail |
+| **Needs an LLM?** | No | Yes (a full coding agent) |
+| **What it isolates** | NeuralMind's *retrieval* | An agent's *whole* solve loop |
+
+NeuralMind is a context layer, not an agent. Retrieval recall is the honest thing
+*it* controls; issue solve-rate depends on whichever agent consumes the context.
+So this harness scores recall@k / MRR of the gold-patch files — the same metric,
+from the same `neuralmind.quality` scorer, that gates the public benchmark.
+
+**The end-to-end solve-rate arm is intentionally not built yet** (it needs an
+`ANTHROPIC_API_KEY` and a sandboxed agent loop). Its interface — a future
+`--solve` flag that wraps NeuralMind's context behind an agent and runs the
+SWE-bench test harness — is sketched here so it can be added without reshaping the
+runner. We will not publish a solve-rate number we haven't actually run.
+
+## Why there are no committed leaderboard numbers (yet)
+
+By design. The corpus is **derived from the canonical SWE-bench dataset at run
+time** (`princeton-nlp/SWE-bench_Lite` via HuggingFace `datasets`), and gold files
+are parsed from each task's `patch`. We deliberately **don't hardcode** base-commit
+SHAs or gold-file lists in the repo — that's exactly the kind of stale, possibly
+mis-stated data the project avoids. The only committed data is
+[`fixture.json`](fixture.json), a tiny **synthetic** set that the offline
+`--selfcheck` and the hermetic test ([`tests/test_swe_bench_harness.py`](../../tests/test_swe_bench_harness.py))
+use to verify the patch parser and the metric math without a network.
+
+Real numbers land in [`bench/swe_bench/`](../../bench/swe_bench/REPRODUCE.md) when
+the harness is run with `datasets` installed and network access. Contributions of
+real runs — including disappointing ones — are welcome.
+
+## How it's wired (reuses the public-benchmark seam)
+
+- `gold_files_from_patch(patch)` — parse the unified diff's `+++ b/…` post-images
+  to basenames (the gold key). Pure stdlib, unit-tested.
+- `_checkout_task(repo, base_commit, dest)` — single-commit fetch of
+  `github.com/<repo>` at the exact SHA, fail-closed (reuses `evals/public/run.py`
+  git helpers).
+- scoring — `evals/public/backends.run_neuralmind` + `neuralmind.quality`, identical
+  to every other NeuralMind retrieval measurement.

--- a/evals/swe_bench/__init__.py
+++ b/evals/swe_bench/__init__.py
@@ -1,0 +1,5 @@
+"""SWE-bench *retrieval* eval — does NeuralMind surface the files a real fix edits?
+
+This package measures **retrieval**, not end-to-end issue resolution. See
+``runner.py`` and ``README.md`` for the honest scope and how to run it.
+"""

--- a/evals/swe_bench/fixture.json
+++ b/evals/swe_bench/fixture.json
@@ -1,0 +1,23 @@
+{
+  "_about": "SYNTHETIC fixture for `runner.py --selfcheck` and the hermetic unit test. These are NOT real SWE-bench tasks and carry no SHAs — the real corpus is derived from the canonical SWE-bench dataset at `--run` time (see README.md), so we never hardcode (and risk mis-stating) instance base_commits or gold patches. This fixture exists only to validate the patch→gold-files parser and the recall metric math offline, with zero network and zero heavy deps.",
+  "tasks": [
+    {
+      "instance_id": "synthetic__demo-1",
+      "repo": "synthetic/demo",
+      "base_commit": "0000000000000000000000000000000000000000",
+      "language": "python",
+      "problem_statement": "Session does not persist cookies across redirects; fix the rebuild step.",
+      "patch": "diff --git a/src/demo/sessions.py b/src/demo/sessions.py\n--- a/src/demo/sessions.py\n+++ b/src/demo/sessions.py\n@@ -10,6 +10,7 @@ class Session:\n     def rebuild_auth(self, prepared_request, response):\n-        pass\n+        prepared_request.headers.update(self.cookies)\ndiff --git a/src/demo/cookies.py b/src/demo/cookies.py\n--- a/src/demo/cookies.py\n+++ b/src/demo/cookies.py\n@@ -1,2 +1,3 @@\n class CookieJar:\n+    persist = True\n",
+      "expected_gold_files": ["sessions.py", "cookies.py"]
+    },
+    {
+      "instance_id": "synthetic__demo-2",
+      "repo": "synthetic/demo",
+      "base_commit": "1111111111111111111111111111111111111111",
+      "language": "python",
+      "problem_statement": "Timeout exception is not raised when the connect deadline elapses.",
+      "patch": "diff --git a/src/demo/exceptions.py b/src/demo/exceptions.py\n--- a/src/demo/exceptions.py\n+++ b/src/demo/exceptions.py\n@@ -5,3 +5,5 @@ class RequestError(Exception):\n+class Timeout(RequestError):\n+    pass\n",
+      "expected_gold_files": ["exceptions.py"]
+    }
+  ]
+}

--- a/evals/swe_bench/runner.py
+++ b/evals/swe_bench/runner.py
@@ -1,0 +1,276 @@
+"""SWE-bench *retrieval* eval runner — gold-patch-file recall, no LLM agent loop.
+
+    python -m evals.swe_bench.runner --selfcheck          # offline gate (no deps, no net)
+    python -m evals.swe_bench.runner --run --limit 20      # real run (clones repos; heavy deps)
+    python -m evals.swe_bench.runner --run --dataset princeton-nlp/SWE-bench_Lite --json
+
+What this measures, and what it does **not**
+--------------------------------------------
+For each SWE-bench task we take the **issue text** (`problem_statement`) and ask:
+does NeuralMind's retrieval surface the file(s) the *gold patch* actually edits?
+The oracle is objective — the set of files the maintainer's accepted fix touches,
+parsed straight from the task's ``patch`` — so there is **no LLM judge** and the
+score is deterministic. This is the retrieval analog of SWE-bench, exactly how we
+already test NeuralMind's own ``search``/``query`` (gold-file recall@k + MRR).
+
+It is **not** an end-to-end *issue-resolution* solve-rate. Wiring NeuralMind
+behind a full coding agent and measuring whether the issue gets fixed is a
+separate, opt-in arm that needs an LLM API key; the interface is sketched in
+``README.md`` (``--solve``, future) and is deliberately not faked here.
+
+Honesty notes
+-------------
+* We never hardcode SWE-bench base-commit SHAs or gold files in the repo. The real
+  corpus is derived from the **canonical dataset** at ``--run`` time (``datasets``
+  / HuggingFace) and gold files are parsed from each task's ``patch``. The only
+  committed data is ``fixture.json`` — a tiny **synthetic** set used solely by
+  ``--selfcheck`` and the unit test to validate the parser + metric math offline.
+* Pure standard library at import time (plus ``neuralmind.quality``, which is
+  stdlib-only) so ``--selfcheck`` runs in a minimal environment and gates CI. The
+  heavy ``--run`` machinery (``datasets``, ``neuralmind.core``, the
+  ``evals.public`` backends) is imported lazily inside ``_run``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+from neuralmind import quality  # stdlib-only module; safe to import at load time
+
+FIXTURE_PATH = Path(__file__).with_name("fixture.json")
+DEFAULT_DATASET = "princeton-nlp/SWE-bench_Lite"
+DEFAULT_WORK_DIR = Path(".swe-bench-work")
+DEFAULT_OUT = Path("bench/swe_bench")
+KS = (1, 3, 5, 8)
+
+# A unified-diff post-image path line: ``+++ b/path/to/file.py`` (optionally with a
+# trailing tab + timestamp on non-git diffs). ``/dev/null`` means a deletion.
+_PLUS_LINE = re.compile(r"^\+\+\+ (?:b/)?(.+?)(?:\t.*)?$")
+
+
+def gold_files_from_patch(patch: str) -> list[str]:
+    """The basenames of the files a unified-diff ``patch`` edits (post-image).
+
+    Objective oracle: the files the accepted fix touches. We key by **basename**
+    to match how the retrieval backends project hits to gold files (see
+    ``evals/public/backends.py``). ``/dev/null`` post-images (pure deletions) are
+    skipped. Order-preserving and de-duplicated.
+    """
+    names: list[str] = []
+    seen: set[str] = set()
+    for line in patch.splitlines():
+        m = _PLUS_LINE.match(line)
+        if not m:
+            continue
+        path = m.group(1).strip()
+        if not path or path == "/dev/null":
+            continue
+        name = Path(path).name
+        if name and name not in seen:
+            seen.add(name)
+            names.append(name)
+    return names
+
+
+# --------------------------------------------------------------------------- #
+# Offline self-check (dependency-free gate; what CI can run)
+# --------------------------------------------------------------------------- #
+
+
+def load_fixture(path: str | Path = FIXTURE_PATH) -> dict[str, Any]:
+    return json.loads(Path(path).read_text(encoding="utf-8"))
+
+
+def selfcheck(path: str | Path = FIXTURE_PATH) -> int:
+    """Validate the corpus schema, the patch→gold parser, and the metric math
+    offline. Returns a process exit code (0 = pass)."""
+    failures: list[str] = []
+    data = load_fixture(path)
+    tasks = data.get("tasks")
+    if not isinstance(tasks, list) or not tasks:
+        print("FAIL: fixture has no tasks", file=sys.stderr)
+        return 1
+
+    required = {"instance_id", "repo", "base_commit", "problem_statement", "patch"}
+    for t in tasks:
+        missing = required - set(t)
+        if missing:
+            failures.append(f"{t.get('instance_id', '?')}: missing keys {sorted(missing)}")
+            continue
+        # The parser must recover the expected gold files from the patch.
+        got = gold_files_from_patch(t["patch"])
+        want = t.get("expected_gold_files")
+        if want is not None and got != want:
+            failures.append(f"{t['instance_id']}: gold parse {got} != expected {want}")
+
+    # Metric-math sanity: a perfect ranking scores recall@1 == 1.0 and MRR == 1.0;
+    # a gold file at rank 2 scores reciprocal_rank == 0.5. Uses the SAME scorer the
+    # real run gates on, so a metric regression is caught here without any network.
+    perfect = quality.evaluate_query("m", ["a.py", "b.py"], ["a.py"], ks=KS)
+    if perfect.recall.get(1) != 1.0 or perfect.reciprocal_rank != 1.0:
+        failures.append("metric: perfect ranking did not score 1.0")
+    rank2 = quality.evaluate_query("m", ["x.py", "a.py"], ["a.py"], ks=KS)
+    if rank2.reciprocal_rank != 0.5:
+        failures.append(f"metric: gold@rank2 MRR {rank2.reciprocal_rank} != 0.5")
+
+    if failures:
+        for f in failures:
+            print(f"FAIL: {f}", file=sys.stderr)
+        return 1
+    print(f"selfcheck OK — {len(tasks)} fixture task(s), parser + metric math verified")
+    return 0
+
+
+# --------------------------------------------------------------------------- #
+# Real run (off the CI default — clones repos, needs the retrieval stack)
+# --------------------------------------------------------------------------- #
+
+
+def _load_dataset_tasks(dataset: str, limit: int | None) -> list[dict[str, Any]]:
+    """Load tasks from the canonical SWE-bench dataset (HuggingFace ``datasets``).
+
+    Returns ``[]`` if ``datasets`` isn't installed or the dataset can't be loaded,
+    so the runner skips cleanly rather than inventing data."""
+    try:
+        from datasets import load_dataset  # type: ignore
+    except Exception:
+        print(
+            "datasets not installed — `pip install datasets` to run against the real "
+            "SWE-bench corpus. Skipping (no fabricated tasks).",
+            file=sys.stderr,
+        )
+        return []
+    try:
+        ds = load_dataset(dataset, split="test")
+    except Exception as exc:  # network / auth / unknown dataset
+        print(f"could not load dataset {dataset!r}: {exc}", file=sys.stderr)
+        return []
+    rows = list(ds)
+    if limit is not None:
+        rows = rows[:limit]
+    return rows
+
+
+def _checkout_task(repo: str, base_commit: str, dest: Path) -> Path | None:
+    """Fetch exactly ``base_commit`` of ``github.com/<repo>`` into ``dest``.
+
+    Single-commit fetch (no full history), fail-closed: returns ``None`` on any
+    error or if HEAD can't be confirmed at the requested SHA."""
+    from evals.public.run import _git, _head  # reuse the public-benchmark git helpers
+
+    url = f"https://github.com/{repo}.git"
+    try:
+        if not (dest / ".git").exists():
+            dest.mkdir(parents=True, exist_ok=True)
+            _git(["git", "-C", str(dest), "init", "-q"], timeout=30)
+            _git(["git", "-C", str(dest), "remote", "add", "origin", url], timeout=30)
+        _git(["git", "-C", str(dest), "fetch", "--depth", "1", "origin", base_commit], timeout=300)
+        _git(["git", "-C", str(dest), "checkout", "-q", "FETCH_HEAD"], timeout=60)
+    except Exception:
+        return None
+    return dest if _head(dest) == base_commit else None
+
+
+def _run(
+    dataset: str = DEFAULT_DATASET,
+    limit: int | None = None,
+    work_dir: Path = DEFAULT_WORK_DIR,
+    out: Path | None = DEFAULT_OUT,
+) -> dict[str, Any]:
+    """Score NeuralMind retrieval over real SWE-bench tasks. Heavy, off-CI."""
+    from evals.public import backends  # lazy: pulls neuralmind + tokenizer
+    from evals.public.run import _aggregate, _build_nm
+
+    tasks = _load_dataset_tasks(dataset, limit)
+    work_dir.mkdir(parents=True, exist_ok=True)
+    results: list[Any] = []
+    rows: list[dict[str, Any]] = []
+    skipped: list[dict[str, str]] = []
+
+    for t in tasks:
+        iid = t["instance_id"]
+        gold = gold_files_from_patch(t.get("patch", ""))
+        if not gold:
+            skipped.append({"instance_id": iid, "reason": "no gold files in patch"})
+            continue
+        src = _checkout_task(t["repo"], t["base_commit"], work_dir / iid)
+        if src is None:
+            skipped.append({"instance_id": iid, "reason": "checkout unavailable"})
+            continue
+        nm = _build_nm(src)
+        if nm is None:
+            skipped.append({"instance_id": iid, "reason": "retrieval stack unavailable"})
+            continue
+        r = backends.run_neuralmind(iid, t["problem_statement"], gold, nm)
+        results.append(r)
+        rows.append({"instance_id": iid, "gold_files": gold, **r.to_dict()})
+
+    report = {
+        "harness": "swe_bench_retrieval",
+        "dataset": dataset,
+        "oracle": "gold-patch-files",
+        "n_scored": len(results),
+        "n_skipped": len(skipped),
+        "summary": _aggregate(results) if results else {},
+        "tasks": rows,
+        "skipped": skipped,
+    }
+    if out is not None and results:
+        out.mkdir(parents=True, exist_ok=True)
+        (out / "results.json").write_text(json.dumps(report, indent=2), encoding="utf-8")
+    return report
+
+
+# --------------------------------------------------------------------------- #
+# CLI
+# --------------------------------------------------------------------------- #
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="SWE-bench retrieval eval for NeuralMind")
+    ap.add_argument(
+        "--selfcheck", action="store_true", help="offline schema + metric gate (no net)"
+    )
+    ap.add_argument("--run", action="store_true", help="score retrieval on the real dataset")
+    ap.add_argument("--dataset", default=DEFAULT_DATASET, help="HuggingFace dataset id")
+    ap.add_argument("--limit", type=int, default=None, help="cap the number of tasks")
+    ap.add_argument("--work-dir", default=str(DEFAULT_WORK_DIR))
+    ap.add_argument("--out", default=str(DEFAULT_OUT), help="where to write results.json")
+    ap.add_argument("--json", action="store_true", help="emit the report as JSON to stdout")
+    args = ap.parse_args(argv)
+
+    if args.run:
+        report = _run(
+            dataset=args.dataset,
+            limit=args.limit,
+            work_dir=Path(args.work_dir),
+            out=Path(args.out) if args.out else None,
+        )
+        if args.json:
+            print(json.dumps(report, indent=2))
+        else:
+            s = report["summary"]
+            print(
+                f"SWE-bench retrieval ({report['dataset']}): scored {report['n_scored']}, "
+                f"skipped {report['n_skipped']}"
+            )
+            if s:
+                print(
+                    f"  mean gold-file recall {s['mean_recall']} · found-rate "
+                    f"{s['found_rate']} · MRR {s['mean_mrr']} · median tokens {s['median_tokens']}"
+                )
+            if report["n_scored"] == 0:
+                print("  (no tasks scored — see skip reasons above; needs `datasets` + network)")
+        return 0
+
+    # Default to the offline gate (also the `--selfcheck` path).
+    return selfcheck()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/test_swe_bench_harness.py
+++ b/tests/test_swe_bench_harness.py
@@ -1,0 +1,68 @@
+"""SWE-bench retrieval harness — hermetic tests (no network, no heavy deps).
+
+The real run (`python -m evals.swe_bench.runner --run`) clones repos and needs the
+retrieval stack; these tests pin the patch→gold-files parser, the fixture schema,
+and the offline self-check so the harness can't silently drift.
+
+    python -m pytest tests/test_swe_bench_harness.py
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from evals.swe_bench import runner
+
+
+class GoldPatchParserTests(unittest.TestCase):
+    def test_basic_git_diff(self) -> None:
+        patch = (
+            "diff --git a/src/pkg/sessions.py b/src/pkg/sessions.py\n"
+            "--- a/src/pkg/sessions.py\n"
+            "+++ b/src/pkg/sessions.py\n"
+            "@@ -1 +1 @@\n-x\n+y\n"
+        )
+        self.assertEqual(runner.gold_files_from_patch(patch), ["sessions.py"])
+
+    def test_multiple_files_ordered_and_deduped(self) -> None:
+        patch = (
+            "+++ b/a/one.py\n"
+            "+++ b/b/two.py\n"
+            "+++ b/a/one.py\n"  # duplicate basename collapses
+        )
+        self.assertEqual(runner.gold_files_from_patch(patch), ["one.py", "two.py"])
+
+    def test_dev_null_skipped(self) -> None:
+        # A pure deletion has a /dev/null post-image — not a gold file to retrieve.
+        patch = "--- a/gone.py\n+++ /dev/null\n"
+        self.assertEqual(runner.gold_files_from_patch(patch), [])
+
+    def test_non_git_diff_with_timestamp(self) -> None:
+        patch = "+++ b/pkg/exceptions.py\t2026-01-01 00:00:00\n"
+        self.assertEqual(runner.gold_files_from_patch(patch), ["exceptions.py"])
+
+    def test_empty_patch(self) -> None:
+        self.assertEqual(runner.gold_files_from_patch(""), [])
+
+
+class FixtureAndSelfcheckTests(unittest.TestCase):
+    def test_fixture_matches_parser(self) -> None:
+        data = runner.load_fixture()
+        self.assertTrue(data["tasks"])
+        for t in data["tasks"]:
+            self.assertEqual(
+                runner.gold_files_from_patch(t["patch"]),
+                t["expected_gold_files"],
+                msg=f"fixture {t['instance_id']} gold parse drifted",
+            )
+
+    def test_selfcheck_passes_offline(self) -> None:
+        self.assertEqual(runner.selfcheck(), 0)
+
+    def test_main_default_is_selfcheck(self) -> None:
+        self.assertEqual(runner.main([]), 0)
+        self.assertEqual(runner.main(["--selfcheck"]), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

Closes the documentation gaps external critics keep raising ("missing
independent benchmarks / failure modes / security specifics / engineering
internals") — **without fabricating numbers or re-documenting what already
exists**. A four-way audit (v0.41.0) found most of the critique already answered;
this PR adds only the genuinely-missing surfaces and refreshes the stale ones.

Fixes # (no issue — addresses the recurring "where does it break / where's the
runnable evidence" feedback)

### Commit 1 — doc-gap fill (docs-only)

- **`docs/wiki/Limits-and-Failure-Modes.md`** (new): when the ~2.5K-token
  compressed context is enough vs. when to widen/bypass (wide multi-file
  refactors); the repo-size/index-time/memory envelope; and a **per-language
  support matrix** listing what's indexed **and what's explicitly not modeled**.
- **`benchmarks/`** (new): a top-level index + `run_all.sh` over the harnesses that
  already live in `evals/`/`bench/`/`tests/benchmark/`, plus an honest "what we
  don't measure yet".
- **`docs/wiki/Architecture.md`**: sharpened embedding-model facts + an index-format
  & "why did this query miss?" debugging reference.
- Cross-linking across Home, FAQ, HONEST-ASSESSMENT, README, sitemap.

### Commit 2 — refresh, harnesses, coverage scorecard

- **Refreshed stale docs**: `SECURITY.md` rewritten to v0.41.0 reality (supported
  versions; ChromaDB reframed as opt-in — default is local ChromaDB-free ONNX, no
  cloud embedding API; the current 14-tool MCP surface + builder/reader RBAC + rate
  limiting + `audit_events.jsonl`; team-memory threat model; schema-artifact
  indexing; reuse-feedback hook; a full **privacy/behaviour env-var table**).
  `docs/wiki/Benchmarks.md` parity table expanded from TS/Go to **all 9** non-Python
  languages with current gate numbers.
- **Measurement harness — `evals/swe_bench/`**: a SWE-bench **retrieval** eval
  scoring whether NeuralMind surfaces the **gold-patch files** for each issue
  (objective oracle, no LLM judge), reusing the `evals/public` backends +
  `neuralmind.quality` scorer. The corpus is **derived from the canonical SWE-bench
  dataset at run time** (no hardcoded SHAs); a tiny synthetic fixture + offline
  `--selfcheck` gate the patch parser and metric math. End-to-end **solve-rate** is
  scaffolded + documented, **not faked**.
- **`evals/public/COMPETITORS.md`**: reproducibility matrix for the named
  competitors (codebase-memory-mcp scored live; Bloop adaptable; Cody / Continue /
  Headroom blocked by accounts / no headless interface / wrong axis) + a fairness
  contract.
- **`docs/CRITIQUE-COVERAGE.md`**: the recurring critique mapped point-by-point to
  closed / partial / deferred, cross-linked from README, HONEST-ASSESSMENT, and
  benchmarks/.

## Type of Change

- [x] 📝 Documentation update
- [x] 🧪 Test update (new hermetic harness tests)

## How Has This Been Tested?

- [x] Unit tests
- [x] Manual testing

### Test Configuration

* **Test command**: `python -m unittest tests.test_swe_bench_harness tests.test_competitor_adapter`

- `python -m evals.swe_bench.runner --selfcheck` → exits 0 offline (no network, no
  heavy deps); `--run` without `datasets` **skips cleanly** (scores 0, no fabricated
  tasks).
- New harness tests (8) + existing competitor-adapter tests (8) pass.
- `ruff check` and `black --check --target-version py310` clean on the new Python.
- Every doc claim traces to source (env vars → grep of `neuralmind/`; MCP tools →
  `mcp_server.py`; RBAC → `mcp_security.py`; parity numbers → the live parity-gate
  CI comment; version → `.release-please-manifest.json`; audit file → `audit.py`;
  ONNX spec → `onnx_embedder.py`). All new doc links resolve.

## Documentation & discoverability

- [x] Docs answer *"what does the user/agent now see?"*
- [x] `README.md` updated (docs table + "read before forming an opinion" section)
- [ ] `docs/index.html` + `docs/about.html` — N/A (no release/version change; this
      is a docs-gap fill, not a feature)
- [x] `docs/wiki/*.md` updated (Limits, Architecture, Benchmarks, FAQ, Home) — syncs
      to the live wiki automatically
- [x] SEO: `docs/sitemap.xml` updated with the new wiki page URL
- [x] I did **not** edit `CHANGELOG.md` or hand-bump the `pyproject.toml` version
      (release-please owns these)

## Additional Notes

Honesty boundary held throughout: **no fabricated** benchmark numbers, case
studies, or "audited by X" claims. The items that can't be filled with honest docs
— SWE-bench end-to-end solve-rate, scored runs vs account-gated competitors,
customer case studies, a third-party audit — are documented as deferred (with the
exact blocker) in `benchmarks/README.md`, `evals/public/COMPETITORS.md`, and
`docs/CRITIQUE-COVERAGE.md`, and tracked on `ROADMAP.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016p4TSQA7jvRUUTTo31d2Jt