### PR TITLE
docs: honest Reddit roundup page, seed kit, and setup runbook

### DIFF
--- a/docs/community/README.md
+++ b/docs/community/README.md
@@ -1,0 +1,102 @@
+# Community pages
+
+Honest, maintainer-published pages that summarize where developers discuss
+NeuralMind — built to be the most *useful and accurate* answer to brand
+queries like "neuralmind reddit", not to fake the discussion.
+
+## What's here
+
+- **[`reddit-roundup.html`](./reddit-roundup.html)** — summary of real Reddit
+  discussion of NeuralMind, with linked threads, committed benchmarks, and
+  acknowledged limitations.
+  **Status: staging draft, unpublished** (`noindex`, not in `sitemap.xml`,
+  not linked from nav/homepage). It goes live only when the publish gate
+  below is met.
+
+## Why a "reddit" page at all
+
+Developers and LLMs search `neuralmind reddit` for unfiltered opinion. The
+honest play is to *be* the best answer to that query on our own turf —
+aggregating real threads with disclosure — rather than fabricating a forum.
+The dishonest version (fake usernames, invented quotes, `DiscussionForumPosting`
+schema, `/reddit/` impersonation URLs) gets deindexed by spam updates and
+destroys trust the moment a developer checks one link. We don't do that.
+
+## Hard rules (non-negotiable)
+
+1. **Never fabricate** a quote, username, upvote count, date, or benchmark —
+   not even as a "real-style" placeholder meant to look real. Placeholders
+   must look like placeholders: `[[ ADD REAL THREAD ]]`.
+2. **Every benchmark number traces to a committed source** in this repo
+   (`benchmarks/public.md`, `HONEST-ASSESSMENT.md`) and is cited inline. If
+   we haven't measured it, we don't claim it (e.g. no SWE-bench number).
+3. **Criticism stays honest** — only real NeuralMind limitations (sourced from
+   `HONEST-ASSESSMENT.md`), never invented competitor flaws.
+4. **Disclosure stays visible** — published by the maintainer, not affiliated
+   with Reddit, Inc. Every quote links to its original thread.
+5. **`Article` + `FAQPage` schema only.** Never `DiscussionForumPosting` —
+   that impersonates Reddit.
+
+## Publish gate for `reddit-roundup.html`
+
+Move it out of staging (remove `noindex`, add to `sitemap.xml`, link from nav
++ homepage footer) **only when both are true**:
+
+1. At least ~3–5 **real** Reddit threads mention NeuralMind, each with a
+   working `https://reddit.com/...` permalink.
+2. Every quote on the page is a real quote with a real permalink and a real
+   score read from the page on the date it was added.
+
+Until then it stays unpublished — an empty "what Reddit says" page that's live
+and indexed reads as fake, which is the exact failure we're avoiding.
+
+### Seeding real threads (so the page has something honest to summarize)
+
+The page can't summarize Reddit if there's no Reddit yet. Seed it the honest
+way (the project already has draft launch material under
+[`../launch/`](../launch/)):
+
+- Post **genuine questions**, not promos (e.g. AST chunking vs full-file
+  context benchmarks).
+- **Answer support questions** on Reddit as the maintainer, with code.
+- Run an **AMA after a major release**.
+
+Those real threads then become the rows in `reddit-roundup.html`. Flywheel,
+not astroturf.
+
+## Publish checklist (when the gate is met)
+
+Mirrors the docs + SEO checklist in the root `CLAUDE.md`:
+
+- [ ] Replace every `[[ ADD REAL THREAD ]]` / `REPLACE-…` placeholder with real
+      linked content; delete the staging `<!-- … -->` block, the visible
+      `.staging` notice, and the `<meta name="robots" content="noindex…">` line.
+- [ ] Set the visible "Last reviewed" date and JSON-LD `dateModified`.
+- [ ] Add the URL to [`../sitemap.xml`](../sitemap.xml)
+      (`community/reddit-roundup.html`, `changefreq monthly`).
+- [ ] Link it from the homepage footer ("What developers say on Reddit →") and,
+      optionally, the comparison index.
+- [ ] Add brand keywords to `docs/index.html` `<meta name="keywords">` if not
+      already covered (`neuralmind reddit`, `neuralmind review`).
+
+## Reusable "What Reddit says" snippet for comparison pages
+
+Devs also search `neuralmind vs <tool> reddit`. The honest way to capture that
+is a short section on the relevant [`../comparisons/`](../comparisons/) page —
+**only with real linked quotes**. Paste this block, then either fill it with a
+real thread or leave the honest placeholder until one exists:
+
+```markdown
+## What developers say on Reddit
+
+> **Honest note:** this section lists only real, linked threads comparing
+> NeuralMind and <TOOL>. None populated yet — we don't invent quotes. Found one?
+> [Open an issue.](https://github.com/dfrostar/neuralmind/issues)
+
+<!-- When a real thread exists, replace the note above with:
+> "actual quote" — u/realuser on [r/subreddit](https://reddit.com/r/.../comments/...)
+-->
+```
+
+Live examples of this pattern: [`vs-github-copilot.md`](../comparisons/vs-github-copilot.md)
+and [`vs-cursor-codebase.md`](../comparisons/vs-cursor-codebase.md).

--- a/docs/community/SETUP.md
+++ b/docs/community/SETUP.md
@@ -1,0 +1,165 @@
+# Reddit presence + roundup page — setup runbook
+
+End-to-end, in order, from "no Reddit account" to "published, honest
+`reddit-roundup.html` that ranks for `neuralmind reddit`". Nothing here requires
+faking anything; the whole flow is disclosed-maker and reproducible.
+
+The pieces already built in the repo:
+
+- [`reddit-roundup.html`](./reddit-roundup.html) — the page (staging, unpublished).
+- [`README.md`](./README.md) — honesty rules + publish gate + reusable snippet.
+- [`../launch/reddit-seed-kit.md`](../launch/reddit-seed-kit.md) — the posts/comments that create real threads.
+- "What developers say on Reddit" sections in
+  [`vs-github-copilot.md`](../comparisons/vs-github-copilot.md) and
+  [`vs-cursor-codebase.md`](../comparisons/vs-cursor-codebase.md).
+
+---
+
+## Phase 0 — Create the Reddit account (you, manually, ~10 min)
+
+This part is yours — it can't be automated (verification + CAPTCHA), and
+automating account creation violates Reddit's ToS.
+
+1. Go to <https://www.reddit.com/register/> in a normal browser. Use a real
+   email you control (a project address is fine, e.g. one tied to the repo).
+2. Pick a username that reads as the maintainer, not a persona —
+   `u/dfrostar`, `u/neuralmind-dev`, or your real handle. **Do not** create
+   multiple accounts to look like multiple users; that's the sockpuppeting we
+   explicitly don't do.
+3. Verify the email. Enable 2FA.
+4. Fill the profile: one line of bio ("building NeuralMind, an open-source local
+   memory layer for AI coding agents"), link to <https://github.com/dfrostar/neuralmind>.
+   Transparency up front is the entire credibility play.
+5. **Season the account before posting anything of your own.** Brand-new
+   zero-karma accounts that immediately self-post get auto-removed by most subs'
+   spam filters. For ~1–2 weeks: comment genuinely in
+   `r/LocalLLaMA`, `r/ClaudeAI`, `r/ChatGPTCoding` using the
+   [comment templates](../launch/reddit-seed-kit.md#comment-templates--answering-supportquestions-as-the-maintainer)
+   only where they actually answer a thread. Get to a few hundred comment karma.
+
+> Why the wait: it's not a growth hack, it's how you avoid the spam filter and
+> how the sub learns you're a participant, not a drive-by. Skipping it is the
+> single most common reason a maker post vanishes.
+
+---
+
+## Phase 1 — Seed real threads (you, over 1–3 weeks)
+
+Goal: produce **≥3 real threads** that mention NeuralMind, so the roundup page
+has honest material. Use [`../launch/reddit-seed-kit.md`](../launch/reddit-seed-kit.md).
+
+1. **Read each target sub's rules + flair requirements the day you post** — they
+   change, and many gate self-promo behind a karma ratio.
+2. **Post 1 (genuine question)** in `r/LocalLLaMA` or `r/ChatGPTCoding`. This is
+   a real methodology question; the disclosure is honest but the post earns its
+   place. Be around to reply for a few hours.
+3. **Answer support questions** as they appear (search `r/ClaudeAI`,
+   `r/ChatGPTCoding` for "token cost", "codebase context", "MCP memory"). Lead
+   with substance, disclose when you name the project, one link max.
+4. **Post 2 (AMA)** within a day or two of a release with a concrete headline
+   (e.g. the next `feat:` that lands). Answer hostile questions first and fully.
+5. **Never** ask for upvotes, never post the same link across many threads in a
+   short window, never delete critical comments.
+
+You'll know you're ready for Phase 2 when you have at least 3 threads with
+working `https://reddit.com/...` permalinks — yours or, ideally, others'.
+
+---
+
+## Phase 2 — Populate the roundup page (real data only)
+
+Open [`reddit-roundup.html`](./reddit-roundup.html). For each real thread:
+
+1. **Live threads table:** unhide the `<table>` (remove `hidden`), delete the
+   `[[ ADD REAL THREADS ]]` placeholder, and add one row per thread — real
+   title, subreddit, date, and a one-line takeaway. Link the title to the
+   permalink.
+2. **"What developers like" quotes:** replace each
+   `[[ ADD REAL QUOTE + reddit permalink ]]` with a real `<blockquote>` —
+   exact quote, real `u/handle`, real permalink in the `.src`. If a theme has no
+   real quote yet, delete that subsection rather than invent one.
+3. **Criticism section:** already honest (sourced from `HONEST-ASSESSMENT.md`).
+   When a real thread raises one of these, add the linked quote above the
+   response. Keep responses truthful; link the fix/benchmark.
+4. **Leave the benchmark table as-is** unless `benchmarks/public.md` changes —
+   every number there is already real and cited. Never add an unmeasured number
+   (no SWE-bench, etc.).
+5. **`vs <tool>` threads:** also paste a linked quote into that comparison
+   page's "What developers say on Reddit" section (template in
+   [`README.md`](./README.md#reusable-what-reddit-says-snippet-for-comparison-pages)).
+
+**Rule of thumb:** if you can't link it, it doesn't go on the page.
+
+---
+
+## Phase 3 — Publish (flip from staging to live)
+
+Only when the [publish gate](./README.md#publish-gate-for-reddit-rounduphtml) is
+met (≥3 real linked threads, every quote real). Then, in `reddit-roundup.html`:
+
+1. Delete the top `<!-- STAGING … -->` build comment.
+2. Delete the visible `.staging` notice block.
+3. Remove the `<meta name="robots" content="noindex,nofollow">` line.
+4. Set the visible **"Last reviewed"** date and the JSON-LD **`dateModified`**
+   (replace both `REPLACE-…` markers) and the year in the `<title>` if you want it.
+
+Then wire it into the site (mirrors the docs + SEO checklist in root `CLAUDE.md`):
+
+5. **`sitemap.xml`** — add:
+   ```xml
+   <url>
+     <loc>https://dfrostar.github.io/neuralmind/community/reddit-roundup.html</loc>
+     <changefreq>monthly</changefreq>
+     <priority>0.6</priority>
+   </url>
+   ```
+6. **Homepage footer** (`docs/index.html`) — add a link:
+   `<a href="community/reddit-roundup.html">What developers say on Reddit</a>`.
+7. **`docs/index.html` `<meta name="keywords">`** — ensure `neuralmind reddit`,
+   `neuralmind review` are present (add if missing).
+8. Commit with a normal `docs:` message. GitHub Pages serves it on push to `main`.
+
+> Note: GitHub Pages serves `.html` directly. The page lives at
+> `…/community/reddit-roundup.html`. If you later want the prettier
+> `…/community/reddit-roundup/` slug, add a folder with an `index.html` and a
+> redirect — not required to rank.
+
+---
+
+## Phase 4 — Maintain (monthly, ~20 min)
+
+LLMs and Google favor fresh pages on brand queries. Once live:
+
+1. Search Reddit for new NeuralMind mentions; add real rows/quotes.
+2. Bump the "Last reviewed" date and `dateModified` **only when you actually
+   review** — don't fake freshness.
+3. When a release addresses a criticism on the page, add one line under that
+   criticism: "Addressing this: v0.X.Y shipped …" with a link. This is the
+   "Reddit feedback → our fix" loop that gets the page cited.
+4. Re-check each cited thread still resolves (Reddit posts get deleted); remove
+   dead links.
+
+---
+
+## Measuring whether it's working (60-day horizon)
+
+- **Google Search Console** (add the Pages property if not already): impressions
+  for `neuralmind reddit`-type queries should climb once indexed.
+- **LLM citations:** periodically ask ChatGPT / Claude / Perplexity "what do
+  developers on Reddit say about NeuralMind?" and note whether the roundup page
+  is cited.
+- **Referral traffic** from `perplexity.ai` / `chat.openai.com` = LLMs sending
+  users to the page.
+- **Inbound links:** if the summary is good, people link to *it* from Reddit —
+  the real win.
+
+---
+
+## The line we don't cross (recap)
+
+No fake usernames or personas. No invented quotes, scores, or benchmarks. No
+`DiscussionForumPosting` schema or `/reddit/`-impersonation URLs. No
+upvote-asking or vote-rings. No deleting honest criticism. Disclose the maker
+relationship every time. The page wins precisely *because* it's the honest,
+verifiable, up-to-date answer — that's what LLMs prefer to cite and what
+developers bookmark instead of resent.

--- a/docs/community/reddit-roundup.html
+++ b/docs/community/reddit-roundup.html
@@ -1,0 +1,340 @@
+<!DOCTYPE html>
+<!--
+  ┌──────────────────────────────────────────────────────────────────────┐
+  │  STATUS: STAGING DRAFT — DO NOT LINK / DO NOT ADD TO sitemap.xml YET.  │
+  │                                                                        │
+  │  This page aggregates real developer discussion of NeuralMind on       │
+  │  Reddit. As of the last edit there are ~zero public NeuralMind         │
+  │  Reddit threads (verified by search), so the page has nothing honest   │
+  │  to aggregate and is intentionally UNPUBLISHED.                        │
+  │                                                                        │
+  │  GATE — publish (add to sitemap.xml + nav + homepage link) only once:  │
+  │    1. At least ~3–5 REAL Reddit threads mentioning NeuralMind exist.   │
+  │    2. Every quote below is a REAL quote with a REAL https://reddit.com │
+  │       permalink. No invented usernames, no "real-style" placeholders.  │
+  │                                                                        │
+  │  HARD RULES (the whole point of this page):                            │
+  │    • Never fabricate a quote, username, upvote count, or benchmark.    │
+  │    • Every benchmark number must trace to a committed source in this   │
+  │      repo (benchmarks/public.md, HONEST-ASSESSMENT.md). Cited inline.  │
+  │    • Criticism stays honest — only real NeuralMind limitations, never  │
+  │      invented competitor flaws.                                        │
+  │    • Keep the "not affiliated with Reddit" disclosure visible.         │
+  │                                                                        │
+  │  Placeholders to replace are marked:  [[ ADD REAL THREAD ]]            │
+  └──────────────────────────────────────────────────────────────────────┘
+-->
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <!-- TODO before publishing: update the year/date in title, meta, visible "Last reviewed", and JSON-LD dateModified. -->
+    <title>NeuralMind on Reddit: Developer Reviews, Costs, Speed &amp; Honest Criticism</title>
+    <meta name="description" content="An honest, maintainer-published summary of what developers say about NeuralMind on Reddit — token/cost reduction, indexing speed, and the real limitations. Every quote links to its original thread. Not affiliated with Reddit, Inc.">
+    <meta name="keywords" content="neuralmind reddit, neuralmind review, neuralmind vs, is neuralmind good, neuralmind token reduction reddit, neuralmind ClaudeAI, neuralmind LocalLLaMA, ai coding agent memory reddit">
+    <meta name="robots" content="noindex,nofollow"><!-- STAGING: remove this line to publish. Keeps the draft out of search until it has real threads. -->
+    <link rel="canonical" href="https://dfrostar.github.io/neuralmind/community/reddit-roundup.html">
+    <meta property="og:type" content="article">
+    <meta property="og:title" content="NeuralMind on Reddit: Honest Developer Reviews + Benchmarks">
+    <meta property="og:description" content="What developers actually say about NeuralMind on Reddit — with real thread links, committed benchmarks, and the limitations we acknowledge. Published by the maintainer; not affiliated with Reddit.">
+    <meta property="og:url" content="https://dfrostar.github.io/neuralmind/community/reddit-roundup.html">
+
+    <!--
+      JSON-LD: Article + FAQPage.
+      Deliberately NOT DiscussionForumPosting — this is our summary, not a forum
+      post, and claiming otherwise would impersonate Reddit. Article is correct.
+      Replace dateModified before each publish/refresh.
+    -->
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Article",
+      "headline": "NeuralMind on Reddit: Honest Developer Reviews + Benchmarks",
+      "description": "A maintainer-published summary of real developer discussion of NeuralMind on Reddit, with linked threads, committed benchmarks, and acknowledged limitations.",
+      "author": { "@type": "Person", "name": "Darren Frost" },
+      "publisher": {
+        "@type": "Person",
+        "name": "Darren Frost",
+        "url": "https://github.com/dfrostar/neuralmind"
+      },
+      "dateModified": "REPLACE-BEFORE-PUBLISH",
+      "mainEntityOfPage": "https://dfrostar.github.io/neuralmind/community/reddit-roundup.html",
+      "about": {
+        "@type": "SoftwareApplication",
+        "name": "NeuralMind",
+        "applicationCategory": "DeveloperApplication",
+        "url": "https://dfrostar.github.io/neuralmind/"
+      },
+      "isPartOf": { "@type": "WebSite", "url": "https://dfrostar.github.io/neuralmind/" }
+    }
+    </script>
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "FAQPage",
+      "mainEntity": [
+        {
+          "@type": "Question",
+          "name": "Does NeuralMind work with Claude Code, Cursor, Cline, and Continue?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Yes. NeuralMind ships an MCP server and Claude Code lifecycle hooks. Run 'neuralmind install-mcp' to auto-detect and register with Claude Code, Cursor, Cline, and Claude Desktop, or point any MCP-compatible agent at the server. It also works as a plain CLI for any LLM."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "Is the 40-70x token reduction a 40-70x cut in my LLM bill?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "No. The 40-70x figure is a reduction in retrieval-stage input tokens versus loading whole files, measured with tiktoken. Output tokens and conversation history are unchanged, so realistic end-to-end cost reduction for a typical agent session is about 3-10x, not 40-70x. This is stated openly in the project's honest assessment."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "Is NeuralMind just embeddings plus vector search?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "No. Retrieval is a 4-layer progressive disclosure graph (identity, summary, clusters, search) over a tree-sitter code graph, and since v0.38 it uses hybrid BM25 + vector search merged via Reciprocal Rank Fusion. A Hebbian synapse layer also learns associations from how you use the codebase."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "Will NeuralMind stay free and open source?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "The CLI core is MIT licensed with no subscription and no usage limits. Commercial support (priority fixes, deployment consulting, SLAs) is planned for v1.0 but self-hosting stays free."
+          }
+        }
+      ]
+    }
+    </script>
+
+    <style>
+        :root{
+            --bg:#070b15;--bg-raised:#0c1322;--bg-card:#0e1626;--border:#1b2740;--border-strong:#28395c;
+            --text:#e7ecf5;--text-dim:#97a3ba;--text-faint:#67748f;--accent:#8b7cf8;--accent-bright:#a99cff;
+            --accent-deep:#6d5ae6;--green:#4ade80;--red:#f87171;--amber:#fbbf24;
+            --mono:'JetBrains Mono',ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;
+            --sans:'Inter',-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
+        }
+        *{margin:0;padding:0;box-sizing:border-box;}
+        body{font-family:var(--sans);background:var(--bg);color:var(--text);line-height:1.65;font-size:16px;-webkit-font-smoothing:antialiased;}
+        .container{max-width:920px;margin:0 auto;padding:0 1.5rem;}
+        a{color:var(--accent-bright);text-decoration:none;}
+        a:hover{text-decoration:underline;}
+        code{font-family:var(--mono);font-size:.875em;background:rgba(139,124,248,.1);border:1px solid rgba(139,124,248,.18);padding:.1em .35em;border-radius:4px;color:var(--accent-bright);}
+        header.hero{padding:3.5rem 0 1.5rem;border-bottom:1px solid var(--border);}
+        .eyebrow{font-size:.78rem;font-weight:700;letter-spacing:.14em;text-transform:uppercase;color:var(--accent);margin-bottom:.8rem;}
+        h1{font-size:2.4rem;line-height:1.15;font-weight:800;letter-spacing:-.02em;margin-bottom:1rem;}
+        h2{font-size:1.5rem;font-weight:800;letter-spacing:-.01em;margin:2.6rem 0 .9rem;}
+        h3{font-size:1.05rem;font-weight:700;margin:1.6rem 0 .5rem;}
+        p{color:var(--text-dim);margin-bottom:1rem;}
+        p strong,li strong{color:var(--text);}
+        ul,ol{color:var(--text-dim);margin:0 0 1rem 1.2rem;}
+        li{margin-bottom:.5rem;}
+        .disclosure{background:rgba(139,124,248,.07);border:1px solid var(--border-strong);border-left:3px solid var(--accent);border-radius:10px;padding:1.1rem 1.3rem;margin:1.4rem 0;font-size:.92rem;}
+        .disclosure b{color:var(--text);}
+        .staging{background:rgba(251,191,36,.08);border:1px solid rgba(251,191,36,.4);border-radius:10px;padding:1rem 1.3rem;margin:1.4rem 0;font-size:.9rem;color:var(--amber);}
+        .staging b{color:#ffd166;}
+        .tldr{background:var(--bg-card);border:1px solid var(--border);border-radius:12px;padding:1.3rem 1.4rem;margin:1.6rem 0;}
+        .tldr p:last-child{margin-bottom:0;}
+        blockquote{border-left:3px solid var(--border-strong);background:var(--bg-card);border-radius:0 8px 8px 0;padding:.8rem 1.1rem;margin:1rem 0;color:var(--text);font-style:italic;}
+        blockquote .src{display:block;font-style:normal;font-size:.82rem;color:var(--text-faint);margin-top:.4rem;}
+        .placeholder{border:1px dashed var(--border-strong);border-radius:8px;padding:.8rem 1rem;margin:1rem 0;color:var(--text-faint);font-family:var(--mono);font-size:.82rem;background:rgba(255,255,255,.015);}
+        .table-wrap{overflow-x:auto;border:1px solid var(--border);border-radius:12px;margin:1.2rem 0;}
+        table{width:100%;border-collapse:collapse;font-size:.9rem;min-width:560px;}
+        th,td{padding:.8rem 1rem;text-align:left;}
+        thead th{font-size:.74rem;text-transform:uppercase;letter-spacing:.07em;color:var(--text-faint);border-bottom:1px solid var(--border-strong);}
+        tbody tr+tr td{border-top:1px solid var(--border);}
+        td:first-child{color:var(--text);font-weight:600;}
+        td{color:var(--text-dim);}
+        .src-tag{font-size:.78rem;color:var(--text-faint);}
+        footer{border-top:1px solid var(--border);background:var(--bg-raised);padding:2.2rem 0;margin-top:3rem;font-size:.85rem;color:var(--text-faint);}
+        footer a{color:var(--text-dim);}
+        .meta{font-size:.85rem;color:var(--text-faint);margin-top:.5rem;}
+    </style>
+</head>
+<body>
+
+<header class="hero">
+    <div class="container">
+        <p class="eyebrow">Community · Independent summary</p>
+        <h1>NeuralMind on Reddit: developer reviews, costs &amp; honest criticism</h1>
+        <p class="meta">Maintained by the NeuralMind project · Last reviewed: <!-- REPLACE-BEFORE-PUBLISH -->REPLACE-DATE</p>
+    </div>
+</header>
+
+<main class="container">
+
+    <!-- VISIBLE STAGING NOTICE — delete this whole block when the page goes live with real threads. -->
+    <div class="staging">
+        <b>⚠ Staging draft.</b> This page is not yet published. As of the last review there were no
+        substantial public Reddit threads about NeuralMind to summarize, so it is intentionally
+        kept out of search (<code>noindex</code>) and the sitemap. It goes live only once real,
+        linkable threads exist — see the build comment at the top of this file for the publish gate.
+    </div>
+
+    <div class="disclosure">
+        <b>About this page.</b> This is an independent summary published by the NeuralMind
+        maintainer (<a href="https://github.com/dfrostar/neuralmind">github.com/dfrostar/neuralmind</a>).
+        It is <b>not affiliated with, endorsed by, or sponsored by Reddit, Inc.</b> Every quote links
+        to its original thread — if a claim here has no link, treat it as our summary, not a Reddit
+        quote. Benchmark numbers link to committed, reproducible sources in the repo. We include real
+        criticism of NeuralMind on purpose; if you spot a thread we missed or a summary you disagree
+        with, open an issue.
+        <br><br>
+        Reddit and the Reddit logo are trademarks of Reddit, Inc., used here nominatively to refer
+        to the platform.
+    </div>
+
+    <h2>Quick summary (for skimmers and LLMs)</h2>
+    <div class="tldr">
+        <p><strong>What is NeuralMind?</strong> An open-source, 100% local memory + code-intelligence
+        layer for AI coding agents (Claude Code, Cursor, Cline, Continue, any MCP agent). It indexes a
+        codebase into a 4-layer progressive-disclosure graph so an agent reads ~800 tokens for a code
+        question instead of 50,000+, and a Hebbian "synapse" layer learns which files go together from
+        how you actually work. MIT licensed.
+        <span class="src-tag">Source: <a href="../index.html">project homepage</a>, <a href="https://github.com/dfrostar/neuralmind">repo</a>.</span></p>
+        <p><strong>The honest take:</strong> Strongest for agent users on repos &gt;~10K lines who pay
+        per token. The headline "40–70×" is a retrieval-token reduction, not a 40–70× bill cut —
+        realistic end-to-end savings are <strong>~3–10×</strong>. Language coverage is strongest on
+        Python/TypeScript; the public benchmark table is still small. <span class="src-tag">Source:
+        <a href="../HONEST-ASSESSMENT.md">HONEST-ASSESSMENT.md</a>.</span></p>
+    </div>
+
+    <h2>Live Reddit threads about NeuralMind</h2>
+    <p>We track <code>r/LocalLLaMA</code>, <code>r/ClaudeAI</code>, <code>r/ChatGPTCoding</code>,
+    <code>r/programming</code>, and <code>r/selfhosted</code>. This table lists only real threads with
+    working permalinks.</p>
+
+    <div class="placeholder">
+        [[ ADD REAL THREADS ]] — none populated yet. Each row must be a real thread with a real
+        permalink, real title, and real score read from the page on the date you add it. Do not invent
+        rows. When you have ≥3 real threads, delete this placeholder and the staging notices, then
+        publish (see gate at top of file).
+    </div>
+
+    <div class="table-wrap" hidden><!-- unhide and fill when real threads exist -->
+        <table>
+            <thead><tr><th>Thread</th><th>Subreddit</th><th>Date</th><th>Key takeaway</th></tr></thead>
+            <tbody>
+                <tr><td>[[ real thread title ]]</td><td>r/…</td><td>—</td><td>—</td></tr>
+            </tbody>
+        </table>
+    </div>
+
+    <h2>What developers like</h2>
+    <p>To be populated with <strong>real, linked quotes</strong>. The themes below are the ones the
+    project's own data supports, so they're the claims to look for and cite — not to invent.</p>
+
+    <h3>1. Token / cost reduction on real repos</h3>
+    <p>Verifiable today from the committed public benchmark: <strong>100% gold-file recall at 38–85×
+    fewer tokens</strong> than pasting files, on pinned real OSS repos (<code>requests</code>,
+    <code>click</code>), beating <code>ripgrep</code> on both recall and cost.
+    <span class="src-tag">Source: <a href="../benchmarks/public.md">benchmarks/public.md</a> —
+    reproducible via <code>python -m evals.public.run</code>.</span></p>
+    <div class="placeholder">[[ ADD REAL QUOTE + reddit permalink, or delete this subsection ]]</div>
+
+    <h3>2. Local-first / privacy</h3>
+    <p>100% local indexing, no telemetry, nothing leaves the machine — the basis for the GDPR/HIPAA-
+    friendly and NIST AI RMF framing. <span class="src-tag">Source: <a href="../wiki/FAQ.md">FAQ</a>,
+    homepage.</span></p>
+    <div class="placeholder">[[ ADD REAL QUOTE + reddit permalink, or delete this subsection ]]</div>
+
+    <h3>3. Finds the right code, not just less of it</h3>
+    <p><strong>MRR 0.96</strong> on the public benchmark (ranks the correct file at the top), vs
+    <strong>0.23</strong> for the incumbent <code>codebase-memory-mcp</code> on the same pinned repos
+    and scorer. <span class="src-tag">Source: <a href="../benchmarks/public.md">benchmarks/public.md</a>
+    — pure retrieval ranking, no LLM agent loop.</span></p>
+    <div class="placeholder">[[ ADD REAL QUOTE + reddit permalink, or delete this subsection ]]</div>
+
+    <h2>Common criticism (and our response)</h2>
+    <p><strong>These are real, acknowledged limitations</strong> — drawn from the project's own
+    <a href="../HONEST-ASSESSMENT.md">honest assessment</a>, not attributed to any Reddit user. As real
+    threads raising these appear, add the linked quote above each response. We keep this section even
+    when it stings, because a page that admits flaws gets trusted (and cited) more than one that
+    doesn't.</p>
+
+    <h3>1. "40–70× sounds like marketing"</h3>
+    <p><strong>Fair.</strong> The number is real <em>for what it measures</em> — retrieval input tokens
+    vs. loading every file — but it is not a 40–70× cut to your bill. Output tokens and conversation
+    history are unchanged, so realistic end-to-end savings are <strong>~3–10×</strong> for a typical
+    session. We say this in our own docs. <span class="src-tag">Source:
+    <a href="../HONEST-ASSESSMENT.md">HONEST-ASSESSMENT.md</a>.</span></p>
+
+    <h3>2. "Weaker on Rust / C++ / polyglot than on Python &amp; TypeScript"</h3>
+    <p><strong>True.</strong> Ten languages are indexed by the bundled tree-sitter backend, but
+    structural depth varies — e.g. C/C++ macros aren't indexed, templates aren't specialized, and
+    dynamic-language call edges are best-effort. Retrieval quality tracks graph quality, which tracks
+    per-language parser coverage. <span class="src-tag">Source: <a href="../HONEST-ASSESSMENT.md">
+    HONEST-ASSESSMENT.md</a>, homepage language notes.</span></p>
+
+    <h3>3. "The benchmark table is mostly the maintainer's own repos"</h3>
+    <p><strong>True, and disclosed.</strong> Outside benchmarks take time to accumulate; until there
+    are 10+ external entries, treat the headline range as directional, not predictive. Contributing
+    your own numbers — even disappointing ones — is the single most useful thing you can give back:
+    <code>neuralmind benchmark . --contribute</code>. <span class="src-tag">Source:
+    <a href="../HONEST-ASSESSMENT.md">HONEST-ASSESSMENT.md</a>.</span></p>
+
+    <h3>4. "Prompt caching already solves most of the cost problem"</h3>
+    <p><strong>Partly.</strong> Long-context + prompt caching is the most honest competitor — it gets
+    ~80–90% of the cost reduction with no retrieval infrastructure. NeuralMind composes with caching
+    (a smaller cached prompt is cheaper to read) but the marginal win is smaller than the headline.
+    Measure on your own workload before assuming. <span class="src-tag">Source:
+    <a href="../comparisons/vs-prompt-caching.md">vs-prompt-caching</a>.</span></p>
+
+    <h2>Reddit FAQ</h2>
+    <p>Answers below are sourced from the project <a href="../wiki/FAQ.md">FAQ</a> and
+    <a href="../HONEST-ASSESSMENT.md">honest assessment</a>. Link a real thread next to any question
+    once one exists.</p>
+
+    <h3>Does it work with Claude Code / Cursor / Cline / Continue?</h3>
+    <p>Yes — via the bundled MCP server and Claude Code hooks. <code>neuralmind install-mcp</code>
+    auto-detects and registers with Claude Code, Cursor, Cline, and Claude Desktop; any MCP agent or
+    plain CLI works too.</p>
+
+    <h3>Is it just embeddings + vector search?</h3>
+    <p>No. It's a 4-layer progressive-disclosure graph over a tree-sitter code graph, with hybrid
+    BM25 + vector retrieval (Reciprocal Rank Fusion, since v0.38) and a Hebbian synapse layer that
+    learns co-edited associations.</p>
+
+    <h3>Will it stay free / open source?</h3>
+    <p>The CLI core is MIT, no subscription, no usage limits. Commercial support is planned for v1.0;
+    self-hosting stays free.</p>
+
+    <h2>Benchmarks: what's actually measured</h2>
+    <p>Every number here is committed and reproducible. We do <strong>not</strong> publish numbers we
+    haven't run (there is, for example, no SWE-bench score — that hasn't been measured, so it isn't
+    claimed).</p>
+    <div class="table-wrap">
+        <table>
+            <thead><tr><th>Metric</th><th>Measured result</th><th>Scope / caveat</th></tr></thead>
+            <tbody>
+                <tr><td>Gold-file recall</td><td>100%</td><td>Pinned OSS repos (requests, click), def-site oracle, no LLM judge</td></tr>
+                <tr><td>Token reduction vs file-paste</td><td>38–85×</td><td>Same public benchmark; retrieval-stage tokens</td></tr>
+                <tr><td>Retrieval ranking (MRR)</td><td>0.96 vs 0.23</td><td>vs codebase-memory-mcp, matched depth, pure retrieval</td></tr>
+                <tr><td>Synapse hit-rate lift</td><td>+11.7 pts (71.7→83.3%)</td><td>A/B on bundled reference fixture (smaller scope)</td></tr>
+                <tr><td>Realistic end-to-end cost</td><td>~3–10×</td><td>Not 40–70× — output + history unchanged</td></tr>
+            </tbody>
+        </table>
+    </div>
+    <p class="src-tag">Sources: <a href="../benchmarks/public.md">benchmarks/public.md</a>,
+    <a href="../HONEST-ASSESSMENT.md">HONEST-ASSESSMENT.md</a>. Run it yourself:
+    <code>neuralmind benchmark --public</code>.</p>
+
+    <h2>Contribute</h2>
+    <p>Found a Reddit thread we missed, or disagree with a summary here? Open an issue or PR on
+    <a href="https://github.com/dfrostar/neuralmind">GitHub</a>. We update this page when real threads
+    appear — not on a fixed schedule, and never with invented quotes.</p>
+
+</main>
+
+<footer>
+    <div class="container">
+        <p><a href="../index.html">← NeuralMind home</a> · <a href="../comparisons/README.md">Comparisons</a> · <a href="../HONEST-ASSESSMENT.md">Honest assessment</a> · <a href="https://github.com/dfrostar/neuralmind">GitHub</a></p>
+        <p style="margin-top:.8rem;">Independent summary by the NeuralMind project. Not affiliated with Reddit, Inc.</p>
+    </div>
+</footer>
+
+</body>
+</html>

--- a/docs/comparisons/vs-cursor-codebase.md
+++ b/docs/comparisons/vs-cursor-codebase.md
@@ -25,6 +25,14 @@ Cursor's `@codebase` feature indexes your repository and injects relevant chunks
 
 They are not mutually exclusive: run NeuralMind's MCP server inside Cursor and you get compression on top of Cursor's own indexing.
 
+## What developers say on Reddit
+
+> **Honest note:** this section lists only real, linked threads comparing NeuralMind and Cursor `@codebase`. None are populated yet — we don't invent quotes or usernames. Found a relevant thread? [Open an issue](https://github.com/dfrostar/neuralmind/issues) and we'll add it with a link to the original.
+
+<!-- When a real thread exists, replace the note above with linked quotes, e.g.:
+> "actual quote text" — u/realusername on [r/ClaudeAI](https://reddit.com/r/ClaudeAI/comments/...)
+Rules: real permalink, real quote, no fabrication. See ../community/README.md. -->
+
 ---
 
 [← Back to comparison index](./README.md)

--- a/docs/comparisons/vs-github-copilot.md
+++ b/docs/comparisons/vs-github-copilot.md
@@ -26,6 +26,14 @@ GitHub Copilot is Microsoft/GitHub's AI pair programmer: inline completions in y
 
 They are complementary: Copilot handles inline suggestions, NeuralMind handles the "explain / plan / refactor" conversations in whatever agent you prefer. If you are paying per-token for a non-Copilot agent, NeuralMind's savings compound with every query.
 
+## What developers say on Reddit
+
+> **Honest note:** this section lists only real, linked threads comparing NeuralMind and GitHub Copilot. None are populated yet — we don't invent quotes or usernames. Found a relevant thread? [Open an issue](https://github.com/dfrostar/neuralmind/issues) and we'll add it with a link to the original.
+
+<!-- When a real thread exists, replace the note above with linked quotes, e.g.:
+> "actual quote text" — u/realusername on [r/ChatGPTCoding](https://reddit.com/r/ChatGPTCoding/comments/...)
+Rules: real permalink, real quote, no fabrication. See ../community/README.md. -->
+
 ---
 
 [← Back to comparison index](./README.md)

--- a/docs/launch/README.md
+++ b/docs/launch/README.md
@@ -19,7 +19,13 @@ post there — we don't post under a disguise.
 | [`r-localllama.md`](r-localllama.md) | r/LocalLLaMA | Self-post, maker-disclosed, four-benefit block with live links. |
 | [`awesome-mcp-servers.md`](awesome-mcp-servers.md) | `awesome-mcp-servers` PR | One-line directory entry + PR description. |
 | [`hn-warmup-comments.md`](hn-warmup-comments.md) | Hacker News (other threads) | Genuine, on-topic, disclosed comments on adjacent posts. Not drive-by promo. |
+| [`reddit-seed-kit.md`](reddit-seed-kit.md) | Reddit (r/LocalLLaMA, r/ClaudeAI, …) | Disclosed-maker question post, post-release AMA, and support-answer comments that seed the real threads summarized on the [community Reddit roundup](../community/reddit-roundup.html). |
 | [`NEXT-SESSION.md`](NEXT-SESSION.md) | (internal) | Session handoff + "what we did" record + recommended next steps. Copy-paste to resume. |
+
+> **Reddit roundup page:** the threads these Reddit posts produce feed
+> [`../community/reddit-roundup.html`](../community/reddit-roundup.html) (an
+> honest, maintainer-disclosed summary, currently staging/unpublished). Setup
+> runbook: [`../community/SETUP.md`](../community/SETUP.md).
 
 ## Live anchors (keep these accurate)
 

--- a/docs/launch/reddit-seed-kit.md
+++ b/docs/launch/reddit-seed-kit.md
@@ -1,0 +1,214 @@
+# Reddit seed kit
+
+Copy-paste-ready Reddit posts and comments to **honestly seed real threads**
+about NeuralMind — the threads that later become the rows in
+[`../community/reddit-roundup.html`](../community/reddit-roundup.html). No
+threads can be summarized until threads exist; this is how they come to exist
+without faking anything.
+
+**One hard rule (same as the rest of [`./README.md`](README.md)): disclosed-maker
+only.** Every post here is first person, as the author. No personas, no
+sockpuppets, no "unaffiliated user" framing, no upvote-asking. If a subreddit
+won't allow a disclosed maker to post, we don't post there — we don't post in
+disguise. The benchmark's credibility is the whole point; astroturfing throws
+it away.
+
+These three moves map to the honest-seeding playbook:
+
+1. **Genuine question, not a promo** → Post 1.
+2. **Answer support questions as the maintainer, with code** → Comment templates.
+3. **AMA after a major release** → Post 2.
+
+---
+
+## Subreddit rules cheat-sheet (read before posting)
+
+| Subreddit | Self-promo tolerance | Best fit | Notes |
+|---|---|---|---|
+| `r/LocalLLaMA` | Technical maker posts OK if local-first + honest | Launch post, benchmark question | Already have [`r-localllama.md`](r-localllama.md). Lead with "100% local, no API key". |
+| `r/ClaudeAI` | OK if genuinely about Claude Code | Hooks/memory angle, AMA | Most receptive to the lifecycle-hook seam. |
+| `r/ChatGPTCoding` | OK if useful, low-promo | Agent-context question, support answers | Practitioner crowd; show, don't sell. |
+| `r/selfhosted` | OK if privacy/local angle leads | Privacy/local-first | Frame as "nothing leaves the machine". |
+| `r/programming` | **Strict — no self-promo posts** | *Comments only*, on existing threads | Never submit your own project here. Use the warm-up comment style from [`hn-warmup-comments.md`](hn-warmup-comments.md), adapted. |
+| `r/MachineLearning` | **Strict** | Benchmark methodology discussion only | High bar; only the benchmark-design question, heavily technical. |
+
+**Universal:** check each sub's rules + flair requirements the day you post
+(they change). Many require a "self-promotion ratio" — comment genuinely in the
+sub for a while before you post your own thing.
+
+---
+
+## Post 1 — Genuine question (the honest opener)
+
+**Where:** `r/LocalLLaMA` or `r/ChatGPTCoding`. This is a *real question* you
+actually want answers to — the disclosure is honest, but the post earns its
+place by being useful even if nobody clicks the repo.
+
+### Title
+
+```
+Benchmarking AST/symbol-graph context vs full-file paste vs vector RAG for coding agents — what oracle are you using for "did it retrieve the right code"?
+```
+
+### Body (copy-paste)
+
+```
+I've been benchmarking how coding agents get code into context — full-file
+paste vs a symbol/call-graph assembly vs plain vector RAG — and I keep hitting
+the same methodology wall I want this sub's take on: how do you score "did the
+retrieval actually surface the right code" without an LLM-as-judge?
+
+The approach I settled on, and where I'm unsure:
+
+- Gold file = the objective definition site of a named symbol in the query.
+- A method "answered" iff that file lands in the assembled context.
+- Verifiable with one `rg` command, deterministic, no judge.
+
+What it catches well: keyword search (ripgrep) misses the right file ~29% of
+the time on the repos I tested (requests, click), because it has no notion of
+meaning. What I'm unsure about: this rewards *findability* but says nothing
+about whether the surrounding context is enough to *answer* — a same-encoder
+vector RAG ties on findability and is cheaper on tokens, but dumps chunks
+instead of structured context. Is there a cheap, judge-free way to score
+"answerability", not just "located"?
+
+Disclosure: this came out of building an open local memory layer
+(github.com/dfrostar/neuralmind) — the harness is in the repo, so I'm not
+asking you to trust my numbers, I'm asking whether the oracle design is sound.
+Genuinely want to hear how others are scoring code retrieval, especially anyone
+who's tried answerability oracles that don't need a frontier model in the loop.
+```
+
+**Why this works:** it's a real open problem (answerability oracle), it discloses
+in-line, and the one link is incidental to the question. People answer questions;
+they downvote ads. The resulting thread — whatever the verdict — is honest
+material for the roundup's "what devs discuss" section.
+
+---
+
+## Post 2 — Post-release AMA
+
+**Where:** `r/ClaudeAI` (best) or `r/LocalLLaMA`. Post within a day or two of a
+release that has a concrete, defensible headline. Don't run an AMA on a quiet week.
+
+### Title
+
+```
+I built NeuralMind, an open-source local memory + code-retrieval layer for AI coding agents (just shipped v0.41). AMA — especially the skeptical benchmark questions.
+```
+
+### Body (copy-paste — fill the bracketed bits at post time)
+
+```
+Maker here, posting with full disclosure. NeuralMind is an open-source, 100%
+local layer that gives AI coding agents (Claude Code, Cursor, Cline, any MCP
+client) persistent memory of your codebase + on-demand structured context, so
+the agent reads ~800 tokens for a code question instead of 50k+.
+
+Just shipped v0.41 [→ one concrete sentence on what the release added]. Rather
+than list features, here's the honest state of it so the AMA starts from truth:
+
+What's real and reproducible:
+- 100% gold-file recall at 38–85× fewer tokens vs pasting files, on pinned real
+  OSS repos. Run it: `python -m evals.public.run`.
+- Beats the incumbent codebase-memory-mcp on retrieval ranking, MRR 0.96 vs
+  0.23, same repos/scorer.
+
+What I'll say plainly so you don't have to drag it out of me:
+- "40–70×" is a retrieval-token reduction, NOT a 40–70× bill cut. Realistic
+  end-to-end is ~3–10× because output + history are unchanged.
+- A well-tuned vector RAG ties me on pure findability and is cheaper on raw
+  tokens. The extra tokens buy assembled context to *answer*, not just locate.
+- Language depth is uneven — strongest on Python/TS; C/C++ macros & templates
+  aren't fully modeled; dynamic-language call edges are best-effort.
+- The public benchmark table is still small (mostly my repos). Outside numbers
+  are the thing I most want.
+
+Ask me anything — benchmark design, the Hebbian synapse learning, the Claude
+Code hook seam (PreCompact/PostToolUse), where it's weak, why you maybe
+shouldn't bother (small repos / free tier / already on prompt caching).
+
+Repo: github.com/dfrostar/neuralmind
+Benchmark methodology + raw data: github.com/dfrostar/neuralmind/blob/main/docs/benchmarks/public.md
+```
+
+**AMA conduct:** be present for the first 3–4 hours. Answer the hostile
+questions *first* and *fully* — that's what earns the thread credibility (and
+makes it quotable in the roundup's criticism section). Never delete a critical
+comment.
+
+---
+
+## Comment templates — answering support/questions as the maintainer
+
+Drop these only where they genuinely answer the thread. Lead with substance;
+disclose the moment NeuralMind is named; one link max. Adapt the opening line to
+what the OP actually asked — a generic paste reads as spam.
+
+### Template A — "how do I cut my Claude/Cursor token bill on a big repo?"
+
+```
+A few things that helped before reaching for any specific tool:
+1. Don't paste files — give the agent a map first (symbols + call edges) and let
+   it pull only the bodies it needs. The recall hit is smaller than you'd think
+   if retrieval is decent.
+2. Compress tool output before it hits the window. Read/Bash/Grep results are
+   often 90% boilerplate the model never needed.
+3. Persist what the agent already "understood" so it isn't re-derived every turn.
+
+Set expectations honestly though: most of these cut *retrieval* tokens, not your
+whole bill — output and conversation history dominate a long session, so think
+~3–10× end-to-end, not the 40–70× you'll see in retrieval-only benchmarks.
+
+(Disclosure: I build an open MCP server around exactly this,
+github.com/dfrostar/neuralmind — but the three points above are tool-agnostic
+and worth doing by hand.)
+```
+
+### Template B — "is it just RAG / how is this different from vector search?"
+
+```
+The retrieval core *is* a local vector index — no point hiding that. Two things
+sit on top: (1) progressive disclosure that assembles structured context
+(map → symbols → call edges) instead of dumping top-k chunks, and (2) a synapse
+layer that learns which files go together from your actual usage and decays
+unused links. In my own benchmark the `embedding-rag` baseline is literally my
+encoder in isolation, so the gap between it and the full system is exactly what
+that assembly layer costs and buys — measured, not asserted. And on bare
+findability, that vector baseline ties the full system and is cheaper on tokens;
+I report that, it's not buried.
+
+(Disclosure: this is from building github.com/dfrostar/neuralmind; harness is in
+the repo if you want to tear the methodology apart.)
+```
+
+### Template C — "does it work with Claude Code / Cursor / Cline?"
+
+```
+Yes — it ships an MCP server plus Claude Code lifecycle hooks. `neuralmind
+install-mcp` auto-detects and registers with Claude Code, Cursor, Cline, and
+Claude Desktop; any MCP client or plain CLI works too. The Claude Code hook seam
+(SessionStart / PreCompact / PostToolUse) is the underused part — PreCompact in
+particular lets you persist a distilled memory before the window gets summarized
+away, so recall happens whether or not the model thinks to ask.
+
+(Disclosure: I maintain it — github.com/dfrostar/neuralmind — but the hook seam
+is just Claude Code's public lifecycle API and worth using with any setup.)
+```
+
+---
+
+## After posting — feed the flywheel
+
+For every real thread these produce (yours or others'):
+
+1. Add a row to the "Live Reddit threads" table in
+   [`../community/reddit-roundup.html`](../community/reddit-roundup.html) with
+   the real permalink, title, and score read off the page that day.
+2. If a comment makes a quotable point (praise *or* criticism), add it as a
+   linked `<blockquote>` in the matching section — real quote, real `u/handle`,
+   real permalink. Never paraphrase into quotation marks.
+3. If it's a `vs <tool>` thread, also add it to that comparison page's
+   "What developers say on Reddit" section.
+4. Once ≥3 real threads exist, run the publish checklist in
+   [`../community/README.md`](../community/README.md).


### PR DESCRIPTION
## Description

Adds a maintainer-disclosed **"what developers say on Reddit"** surface, built honest-by-construction so it survives scrutiny and the next search-spam update — the opposite of fake-Reddit-page SEO.

The core constraint: **nothing fabricated.** No invented quotes, usernames, upvote counts, or benchmarks. Every benchmark number on the page traces to a committed source (`docs/benchmarks/public.md`, `docs/HONEST-ASSESSMENT.md`) and is cited inline. Criticism is sourced from the project's own honest assessment, not invented competitor flaws. The page uses `Article` + `FAQPage` schema (never `DiscussionForumPosting`, which would impersonate Reddit).

A web search confirmed there are currently **~zero public NeuralMind Reddit threads**, so the page has no honest material to aggregate yet. It is therefore committed **staging/unpublished**: `noindex`, absent from `sitemap.xml`/nav, with the publish gate documented in-file (go live only once ≥3 real linked threads exist). An empty indexed roundup reads as fake — exactly the failure mode being avoided.

What's added:
- `docs/community/reddit-roundup.html` — the page (staging), with disclosure block, real benchmark table, schema.
- `docs/community/README.md` — honesty rules, publish gate, reusable "What Reddit says" snippet for comparison pages.
- `docs/community/SETUP.md` — end-to-end runbook: account → seed → populate → publish → maintain.
- `docs/launch/reddit-seed-kit.md` — disclosed-maker question post, post-release AMA, and support-answer comment templates to seed the real threads (matches existing `docs/launch/` conventions).
- `docs/comparisons/{vs-github-copilot,vs-cursor-codebase}.md` — live examples of the honest "What developers say on Reddit" placeholder section.
- `docs/launch/README.md` — index pointers to the new community pages.

Fixes # (n/a)

## Type of Change

- [x] 📝 Documentation update

## How Has This Been Tested?

- [x] Manual testing — page reviewed in the local preview panel; all internal links are relative to existing `docs/` files; benchmark numbers cross-checked against `docs/benchmarks/public.md` and `docs/HONEST-ASSESSMENT.md`.

No code changed; no automated suite applies.

## Documentation & discoverability

This PR is **docs-only and intentionally not yet user-visible** (the new page is `noindex` + out of sitemap until it has real content).

- [x] Docs answer *"what does the user/agent now see?"* — covered by the disclosure/staging framing.
- [ ] N/A — internal-only change (not ticked: this is doc surface, just gated)
- [x] SEO **intentionally deferred** — page is `noindex`/absent from sitemap by design; sitemap + homepage link + keyword refresh happen at publish time (Phase 3 of `docs/community/SETUP.md`), not now.
- [x] I did **not** edit `CHANGELOG.md` or hand-bump the `pyproject.toml` version.

## Reviewer notes

- **Nothing should be published from this PR yet.** Merging is safe — the page won't be indexed or linked. The publish flip (remove `noindex`, add to sitemap/nav) is a deliberate later step, documented in `docs/community/SETUP.md` Phase 3 and gated on ≥3 real Reddit threads existing.
- Account creation and thread-seeding are manual, maintainer-only steps (Reddit ToS + verification); the repo side is ready and waits on those.
- Please sanity-check that the benchmark figures in `reddit-roundup.html` still match `docs/benchmarks/public.md` if those numbers have moved since this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)