### PR TITLE
docs: services page + Fable-pricing LinkedIn draft

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "docs",
+      "runtimeExecutable": "python",
+      "runtimeArgs": ["-m", "http.server", "8890", "--directory", "docs"],
+      "port": 8890
+    }
+  ]
+}

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -13,28 +13,82 @@ nine-initiative durability arc beyond that (versioned IR, retrieval quality
 harness, daemon-first architecture, and more), see
 [`docs/plans/2026-06-10-future-proofing-prd-pack.md`](docs/plans/2026-06-10-future-proofing-prd-pack.md).
 
-## Next — v0.13 → v0.16 (the eval-first arc)
+## Now — v0.41.0 (shipped & published)
 
-The spine is *measure, then change, then measure again.* Full detail,
-epics, and acceptance criteria in
-[`docs/NEXT-RELEASE-PLAN.md`](docs/NEXT-RELEASE-PLAN.md); tracked in
-issues [#171](https://github.com/dfrostar/neuralmind/issues/171)–[#175](https://github.com/dfrostar/neuralmind/issues/175).
+Latest release **v0.41.0** is live on
+[PyPI](https://pypi.org/project/neuralmind/) and GHCR. The
+v0.13 → v0.16 "eval-first" arc that used to sit here is **fully shipped**
+and the project has carried well past it — see
+[Shipped v0.13 → v0.41](#shipped-v013--v041) below. Full per-release
+detail lives in `RELEASE_NOTES_v*.md` at the repo root and in
+[`CHANGELOG.md`](CHANGELOG.md).
 
-| Release | Theme | What it does |
-|---|---|---|
-| **v0.13** | **Measure** | CI-gated faithfulness + retrieval-quality eval harness (100%-local offline judge; opt-in API judge). Polyglot TS/Go fixtures. The fitness function everything else depends on. |
-| **v0.14** | **Decouple** | A `GraphSource` adapter so tree-sitter / LSP / SCIP can feed the pipeline, proven at parity by the v0.13 harness. Reduces the single-graph-backend dependency, widens language coverage. |
-| **v0.15** | **Endure** | Host-capabilities adapter + integration-contract tests pinning Claude Code hook / MCP behaviour, so upstream drift is a one-adapter swap. |
-| **v0.16** | **Anticipate** | Promote directional "what you edit next" recall to first-class; ship a portable cross-agent memory format. |
+**Remaining work for the current arc is execution, not engineering:**
 
-**Team/shared memory — approved in principle, gated on measurement.**
-An opt-in, git-committed team baseline (reviewed in PRs, no SaaS) overlaid
-by each developer's private personal layer. Its day-one onboarding lift is
-*measured* by the v0.13 harness before the design is locked — see
-[#175](https://github.com/dfrostar/neuralmind/issues/175). This is what
-un-gates an honest enterprise lane: the compliance surface (RBAC, audit
-of the shared layer) sequences *after* a real multi-writer surface exists,
-not in anticipation of one.
+- **Answerability proof.** The opt-in `--judge` harness shipped in
+  v0.34.0, but `bench/public/judge/` is still empty. Run
+  `neuralmind benchmark --public --judge` with `ANTHROPIC_API_KEY` set
+  and commit the transcripts, so the launch materials show a concrete
+  answerability table instead of "run it yourself." Pre-empts the
+  "recall ≠ answering" critique.
+- **Launch — disclosed-maker only.** Copy is ready in
+  [`docs/launch/`](docs/launch/) (Show HN, r/LocalLLaMA, awesome-mcp
+  PR). Standing rule: outreach is disclosed-maker only — no
+  unaffiliated-user posts, no personas.
+- **Two GitHub-UI edits** the maker does by hand: repo About / Topics
+  (comparison terms for search weighting) and the v0.37.0 Release body
+  (umbrella notes + honest comparison footer).
+
+## Next — forward candidates
+
+Post-launch engineering candidates that are *not* yet shipped:
+
+- **`neuralmind impact` blast-radius tool.** Reverse-edge traversal —
+  "what depends on this?" The forward graph is built at index time;
+  materialise the reverse index during `build` and expose it as an MCP
+  tool + CLI command. The one structural capability gap vs.
+  dependency-graph peers.
+- **Broader `install-mcp` targets.** Add Windsurf, Continue.dev, and
+  Zed — same MCP JSON config, only the destination path differs. Takes
+  supported agents from 4 → 7 with no logic changes.
+- **Cross-agent portable memory format.** Promote the directional
+  "what you edit next" recall into a portable memory format that
+  survives across agent runtimes.
+
+## Shipped v0.13 → v0.41
+
+The eval-first arc and everything after it. Full notes per release in
+`RELEASE_NOTES_v*.md`; highlights:
+
+- **Eval-first foundation (v0.13–v0.16).** CI-gated faithfulness +
+  retrieval-quality harness, `GraphSource` decoupling behind a
+  tree-sitter seam, host-capabilities resilience, and first-class
+  directional recall.
+- **Backend independence (v0.21–v0.29).** Owned MiniLM embedder and the
+  experimental TurboVec (TurboQuant) backend, culminating in a
+  **ChromaDB-free default install** (turbovec/ONNX) in v0.29.
+- **Durability PRDs (v0.23–v0.24).** Versioned IR, quality harness,
+  debug traces, a local daemon, and memory namespaces + git-branch
+  isolation for the synapse layer.
+- **One learning signal (v0.25–v0.26).** Retired the `learned_patterns`
+  reranker so the synapse layer is the single learning signal, then
+  added selector auto-tuning that learns from it.
+- **Ten languages (v0.27–v0.37).** Rust, Java, C/C++, C#, Ruby, and PHP
+  added behind the tree-sitter seam — ten languages total.
+- **Honest public benchmark (v0.31–v0.34).** `neuralmind benchmark
+  --public`, a live `codebase-memory-mcp` head-to-head, an opt-in
+  LLM-judged answerability arm, and the four-data-backed-benefits
+  positioning + disclosed-maker launch kit.
+- **Team memory (v0.30/v0.31).** Commit the learned synapse signal;
+  teammates' agents inherit it (`.neuralmind-team-memory.json`,
+  content-hash idempotent, fail-open).
+- **Agent-facing surface (v0.38–v0.41).** VS Code extension, hybrid
+  BM25 + dense search, explicit-feedback MCP tool, CI auto-index,
+  `neuralmind probe` (label-free retrieval self-test), the
+  trust/transparency six (`--dry-run`, `--explain`, `review`,
+  `savings`, rationale probe, instant deletion decay), schema-artifact
+  indexing (OpenAPI / SQL DDL / Protobuf), and the reuse-vs-rewrite
+  feedback loop + structured relevance sidecar.
 
 ## Shipped since v0.9.0
 

--- a/docs/LINKEDIN-POST-FABLE-PRICING.md
+++ b/docs/LINKEDIN-POST-FABLE-PRICING.md
@@ -1,0 +1,98 @@
+# LinkedIn post draft — Fable pricing / context-quantity levers
+
+Genre-matched to the Headroom owner's 2026-07-09 Fable-pricing post:
+news hook → concrete levers for enterprises running Claude Code → soft
+CTA. His levers tune the **price** of context; this post owns the
+**quantity** lever. Written partner-to-partner — it compliments the
+price-tuning advice without naming or countering him.
+
+## ⚠️ Before posting — verify these two things
+
+1. **Pricing.** Verified against Anthropic's published models table on
+   2026-07-09: **Claude Fable 5 = $10 / 1M input, $50 / 1M output**
+   (Opus 4.8 = $5/$25, Sonnet 5 = $3/$15). **The Headroom owner's post
+   said $30/1M output — that figure is wrong per Anthropic's docs.**
+   This post uses the correct $50. The held reply comment to his post
+   was checked against the 2026-07-09 session transcript: it cites only
+   the $10/1M input figure, so it's safe to post as-is.
+2. **v0.42.0 status.** PR #315 is still DRAFT/unmerged (latest tag:
+   v0.41.0). Do **not** include the optional v0.42.0 paragraph below
+   until release-please has tagged v0.42.0. Post works fine without it.
+
+---
+
+## The post
+
+> Anthropic put Claude Fable 5 on standard API pricing: **$10 per 1M
+> input tokens, $50 per 1M output.** That's 2× Opus 4.8 on both meters
+> — for the most capable model they ship.
+>
+> If your team runs Claude Code, most of that spend is one thing:
+> **context.** A single "how does our auth flow work?" that loads whole
+> files into the window is ~50K input tokens. On Fable that's $0.50 —
+> per question, per session, per engineer. Nobody notices $0.50.
+> Everybody notices it multiplied by questions/day × engineers ×
+> workdays, re-paid every session for code the agent already read
+> yesterday.
+>
+> There's good advice going around on tuning the *price* of those
+> tokens — model pinning, compaction thresholds, longer cache TTLs. Do
+> all of it. Then pull the other lever family: shrink the *quantity*.
+> Four things that work today:
+>
+> 1️⃣ **Answer code questions from a graph, not from pasted files.**
+> Graph-backed retrieval answers the same question in ~800 tokens
+> instead of 50K+. On our public benchmark (real pinned OSS repos, no
+> LLM judge): 100% gold-file recall at **38–85× fewer tokens** than
+> pasting files.
+>
+> 2️⃣ **Compress tool output before the model reads it.** A test run
+> dumps 800 lines; the model needs the errors, the repeated-failure
+> patterns, and the last 3 lines. Hook-level compression makes
+> Read/Bash/Grep output **88–91% smaller**, with the raw output cached
+> for recovery — no re-running commands.
+>
+> 3️⃣ **Stop paying the cold-start tax.** Every fresh session re-reads
+> the same context. A learned memory file loaded at session start means
+> the agent boots already knowing your code's shape — and committing
+> team memory to the repo gives every teammate's agent that head start
+> (**+6.5 pts** measured onboarding lift).
+>
+> 4️⃣ **Measure on your repo, not our benchmark.** `neuralmind
+> benchmark .` runs the methodology on your own code; `neuralmind
+> savings` reads your real usage log and shows cumulative tokens saved.
+> Run your own multiplication.
+>
+> Honest scope: 40–70× is the *retrieval* line item. A full agent
+> workload nets out **~5–10× cheaper end-to-end**, because retrieval is
+> one slice of spend. Both numbers scale with whatever per-token price
+> you're paying — price levers and quantity levers multiply.
+>
+> If you tuned your rates last month, tune your volume this month.
+>
+> Free, MIT, 100% local — your code never leaves your machine.
+> Reproduce the numbers in 30 seconds on a fresh clone:
+> github.com/dfrostar/neuralmind
+>
+> #ClaudeCode #AIEngineering #LLMOptimization
+
+---
+
+## Optional v0.42.0 paragraph — insert after lever 3️⃣ ONLY once v0.42.0 tags
+
+> (New this week in v0.42.0: `neuralmind mine-history` pre-warms that
+> learned layer from your git history — directional "what gets edited
+> after what" transitions mined from actual commits — so the map starts
+> warm on day one. And the index stops going stale: watch re-indexes by
+> default, plus an incremental git hook.)
+
+## Posting notes
+
+- Genre-match is deliberate: his format is news hook → 3–4 levers →
+  soft pitch. Numbered-emoji levers, numbers first, no fluff.
+- Don't cite his post or correct his $30 figure publicly — partner
+  courtesy. The correct number stands on its own.
+- Tuesday/Wednesday morning posting window, per prior drafts.
+- Best-effort visual: the token-bar graphic from the landing page
+  (50,000 vs ~800, drawn to scale) or a `neuralmind savings` terminal
+  screenshot. Post works without one.

--- a/docs/launch/SERVICES-CROSSLINKS.md
+++ b/docs/launch/SERVICES-CROSSLINKS.md
@@ -1,0 +1,60 @@
+# services.html cross-links — apply AFTER PR #315 merges
+
+`docs/services.html` ships on the marketing branch, but the pages it
+should be linked *from* (`index.html`, `about.html`, `sitemap.xml`) are
+rewritten wholesale by PR #315's redesign. Editing them on this branch
+would guarantee merge conflicts, so the link-through edits live here as
+exact paste-ready snippets. After #315 merges, rebase this branch onto
+main and apply the five edits below (then delete this file).
+
+## 1. index.html — nav link
+
+In the `#navlinks` div, insert after the Quickstart link:
+
+```html
+            <a href="services.html">Services</a>
+```
+
+Resulting order: How it works · Proof · Compare · Quickstart ·
+**Services** · Docs · About · GitHub.
+
+## 2. index.html — #enterprise link-through card
+
+Append as the fifth card inside `#enterprise .cards` (the `doc-card`
+class gives the green heading + ↗ suffix used for outbound cards):
+
+```html
+            <a class="card doc-card" href="services.html">
+                <h3>Hands-on help</h3>
+                <p>Guided rollouts, team-memory onboarding, benchmark-your-repo reports, and compliance review — engagements from the maintainer, scoped individually.</p>
+            </a>
+```
+
+## 3. index.html — footer link
+
+In `.foot-links`, insert after the Benchmarks link:
+
+```html
+            <a href="services.html">Services</a>
+```
+
+## 4. about.html — nav link
+
+Same nav treatment as index.html: insert
+`<a href="services.html">Services</a>` immediately before the
+`<a href="about.html">About</a>` entry (line ~77 on the #315 version).
+
+## 5. sitemap.xml — new URL
+
+Insert after the `about.html` entry:
+
+```xml
+  <url>
+    <loc>https://dfrostar.github.io/neuralmind/services.html</loc>
+    <lastmod>2026-07-09</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+```
+
+(Bump `lastmod` to the actual apply date.)

--- a/docs/services.html
+++ b/docs/services.html
@@ -1,0 +1,584 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>NeuralMind Services — Install, Team Memory, Benchmarks &amp; Compliance Help</title>
+    <meta name="description" content="Hands-on engagements from the NeuralMind maintainer: guided install and rollout audits, team-memory onboarding, benchmark-your-repo reports, and compliance review for regulated environments. Scoped individually — get in touch.">
+    <meta name="keywords" content="NeuralMind services, AI coding agent consulting, Claude Code cost optimization, MCP server setup, team memory onboarding, code retrieval benchmark, LLM token cost audit, air-gapped AI install, NIST AI RMF review, enterprise AI coding agents">
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://dfrostar.github.io/neuralmind/services.html">
+    <meta property="og:title" content="NeuralMind Services — hands-on help from the maintainer">
+    <meta property="og:description" content="Guided rollouts, team-memory onboarding, benchmark-your-repo engagements, and compliance review. Scoped individually — no rate card, just a concrete proposal.">
+    <meta property="og:image" content="https://dfrostar.github.io/neuralmind/assets/social-preview.png">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="NeuralMind Services — hands-on help from the maintainer">
+    <meta name="twitter:description" content="Guided rollouts, team-memory onboarding, benchmark-your-repo engagements, and compliance review for teams running AI coding agents.">
+    <link rel="canonical" href="https://dfrostar.github.io/neuralmind/services.html">
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Service",
+      "@id": "https://dfrostar.github.io/neuralmind/services.html#services",
+      "serviceType": "AI coding agent infrastructure consulting",
+      "name": "NeuralMind Services",
+      "description": "Hands-on engagements around the open-source NeuralMind project: guided install and rollout audits, team-memory onboarding, benchmark-your-repo reports, and compliance review for regulated environments.",
+      "provider": { "@type": "Person", "name": "Darren Frost" },
+      "url": "https://dfrostar.github.io/neuralmind/services.html",
+      "areaServed": "Worldwide (remote)",
+      "hasOfferCatalog": {
+        "@type": "OfferCatalog",
+        "name": "Engagements",
+        "itemListElement": [
+          { "@type": "Offer", "itemOffered": { "@type": "Service", "name": "Install & rollout audit" } },
+          { "@type": "Offer", "itemOffered": { "@type": "Service", "name": "Team-memory onboarding" } },
+          { "@type": "Offer", "itemOffered": { "@type": "Service", "name": "Benchmark your repo" } },
+          { "@type": "Offer", "itemOffered": { "@type": "Service", "name": "Compliance review" } }
+        ]
+      }
+    }
+    </script>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,400;0,6..72,500;0,6..72,600;1,6..72,400;1,6..72,500&family=IBM+Plex+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+    <style>
+        :root {
+            --ink: #070b09;
+            --ink-2: #0a100d;
+            --panel: #0d1410;
+            --panel-2: #101813;
+            --hairline: #1d2b23;
+            --hairline-bright: #2b4234;
+            --text: #c8d5cb;
+            --text-dim: #8fa396;
+            --text-faint: #5c6f63;
+            --head: #eef5ef;
+            --green: #3ee08f;
+            --green-dim: #2aa96c;
+            --green-ghost: rgba(62, 224, 143, 0.08);
+            --teal: #5eead4;
+            --amber: #ffb454;
+            --red: #f0876f;
+            --font-serif: 'Newsreader', 'Iowan Old Style', Georgia, serif;
+            --font-mono: 'IBM Plex Mono', ui-monospace, 'Cascadia Code', Menlo, monospace;
+        }
+
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+
+        html { scroll-behavior: smooth; scroll-padding-top: 90px; }
+
+        body {
+            font-family: var(--font-serif);
+            font-size: 17px;
+            line-height: 1.65;
+            background: var(--ink);
+            color: var(--text);
+            counter-reset: fig;
+            -webkit-font-smoothing: antialiased;
+        }
+
+        /* film grain over everything — the instrument has texture */
+        body::after {
+            content: "";
+            position: fixed;
+            inset: 0;
+            z-index: 999;
+            pointer-events: none;
+            opacity: 0.055;
+            background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='140' height='140'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2'/%3E%3C/filter%3E%3Crect width='140' height='140' filter='url(%23n)'/%3E%3C/svg%3E");
+        }
+
+        ::selection { background: var(--green); color: var(--ink); }
+
+        a { color: var(--teal); text-decoration: none; }
+        a:hover { text-decoration: underline; text-underline-offset: 3px; }
+
+        code {
+            font-family: var(--font-mono);
+            font-size: 0.82em;
+            background: var(--green-ghost);
+            border: 1px solid var(--hairline);
+            border-radius: 4px;
+            padding: 0.08em 0.35em;
+            color: var(--teal);
+        }
+
+        .container { max-width: 1120px; margin: 0 auto; padding: 0 24px; }
+
+        /* ---------------- nav ---------------- */
+        nav {
+            position: sticky;
+            top: 0;
+            z-index: 100;
+            background: rgba(7, 11, 9, 0.82);
+            backdrop-filter: blur(12px);
+            border-bottom: 1px solid var(--hairline);
+        }
+        .nav-inner {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            height: 62px;
+        }
+        .nav-logo {
+            display: inline-flex;
+            align-items: center;
+            gap: 10px;
+            font-family: var(--font-mono);
+            font-weight: 600;
+            font-size: 15px;
+            letter-spacing: 0.02em;
+            color: var(--head);
+        }
+        .nav-logo:hover { text-decoration: none; color: var(--green); }
+        .nav-logo svg { width: 26px; height: 26px; }
+        .nav-links {
+            display: flex;
+            align-items: center;
+            gap: 26px;
+            font-family: var(--font-mono);
+            font-size: 12.5px;
+            text-transform: uppercase;
+            letter-spacing: 0.08em;
+        }
+        .nav-links a { color: var(--text-dim); }
+        .nav-links a:hover { color: var(--green); text-decoration: none; }
+        .nav-links a.active { color: var(--green); }
+        .nav-gh {
+            border: 1px solid var(--hairline-bright);
+            border-radius: 4px;
+            padding: 6px 12px;
+            color: var(--head) !important;
+            transition: border-color 0.2s, box-shadow 0.2s;
+        }
+        .nav-gh:hover {
+            border-color: var(--green);
+            box-shadow: 0 0 18px rgba(62, 224, 143, 0.25);
+        }
+        .nav-toggle {
+            display: none;
+            background: none;
+            border: 1px solid var(--hairline-bright);
+            border-radius: 4px;
+            color: var(--text);
+            font-size: 18px;
+            padding: 4px 10px;
+            cursor: pointer;
+        }
+
+        /* ---------------- hero ---------------- */
+        .hero {
+            position: relative;
+            overflow: hidden;
+            padding: 96px 0 72px;
+            border-bottom: 1px solid var(--hairline);
+            background:
+                radial-gradient(ellipse 700px 420px at 12% -8%, rgba(62, 224, 143, 0.09), transparent 60%),
+                radial-gradient(ellipse 600px 400px at 95% 30%, rgba(94, 234, 212, 0.06), transparent 65%),
+                var(--ink);
+        }
+        .hero > .container > * { animation: fadeUp 0.7s cubic-bezier(0.2, 0.7, 0.2, 1) both; }
+        .hero > .container > *:nth-child(1) { animation-delay: 0.05s; }
+        .hero > .container > *:nth-child(2) { animation-delay: 0.14s; }
+        .hero > .container > *:nth-child(3) { animation-delay: 0.23s; }
+        .hero > .container > *:nth-child(4) { animation-delay: 0.32s; }
+        @keyframes fadeUp {
+            from { opacity: 0; transform: translateY(18px); }
+            to   { opacity: 1; transform: translateY(0); }
+        }
+
+        .badge {
+            display: inline-flex;
+            align-items: center;
+            gap: 8px;
+            font-family: var(--font-mono);
+            font-size: 12px;
+            letter-spacing: 0.05em;
+            color: var(--text-dim);
+            border: 1px solid var(--hairline-bright);
+            border-radius: 999px;
+            padding: 6px 14px;
+            background: rgba(13, 20, 16, 0.6);
+        }
+        .dot {
+            width: 7px;
+            height: 7px;
+            border-radius: 50%;
+            background: var(--green);
+            box-shadow: 0 0 10px var(--green);
+            animation: firePulse 2.2s ease-in-out infinite;
+        }
+        @keyframes firePulse {
+            0%, 100% { transform: scale(1); opacity: 1; }
+            50% { transform: scale(1.35); opacity: 0.65; }
+        }
+
+        h1 {
+            font-family: var(--font-serif);
+            font-weight: 500;
+            font-size: clamp(2.4rem, 5vw, 3.8rem);
+            line-height: 1.08;
+            letter-spacing: -0.015em;
+            color: var(--head);
+            margin: 22px 0 20px;
+            max-width: 22ch;
+        }
+        .grad {
+            font-style: italic;
+            font-weight: 400;
+            background: linear-gradient(100deg, var(--green) 10%, var(--teal) 90%);
+            -webkit-background-clip: text;
+            background-clip: text;
+            color: transparent;
+        }
+        .hero-sub {
+            font-size: 1.18rem;
+            line-height: 1.6;
+            color: var(--text);
+            max-width: 62ch;
+            margin-bottom: 30px;
+        }
+        .hero-sub strong { color: var(--head); font-weight: 600; }
+
+        .cta-row { display: flex; flex-wrap: wrap; gap: 14px; }
+        .btn {
+            display: inline-block;
+            font-family: var(--font-mono);
+            font-size: 13px;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.09em;
+            padding: 13px 22px;
+            border-radius: 5px;
+            transition: transform 0.18s, box-shadow 0.18s, border-color 0.18s, background 0.18s;
+        }
+        .btn:hover { text-decoration: none; transform: translateY(-2px); }
+        .btn-primary {
+            background: var(--green);
+            color: #06110b;
+            box-shadow: 0 0 0 rgba(62, 224, 143, 0);
+        }
+        .btn-primary:hover { box-shadow: 0 6px 28px rgba(62, 224, 143, 0.35); background: #4bea9c; }
+        .btn-ghost {
+            border: 1px solid var(--hairline-bright);
+            color: var(--head);
+            background: rgba(13, 20, 16, 0.5);
+        }
+        .btn-ghost:hover { border-color: var(--green); box-shadow: 0 4px 22px rgba(62, 224, 143, 0.18); }
+
+        /* ---------------- sections ---------------- */
+        section { padding: 96px 0; border-bottom: 1px solid var(--hairline); counter-increment: fig; }
+        section:nth-of-type(even) { background: var(--ink-2); }
+
+        .eyebrow {
+            font-family: var(--font-mono);
+            font-size: 12px;
+            font-weight: 500;
+            text-transform: uppercase;
+            letter-spacing: 0.2em;
+            color: var(--green);
+            margin-bottom: 14px;
+        }
+        .eyebrow::before {
+            content: "fig. " counter(fig, decimal-leading-zero) "  /  ";
+            color: var(--text-faint);
+        }
+        h2 {
+            font-family: var(--font-serif);
+            font-weight: 500;
+            font-size: clamp(1.9rem, 3.4vw, 2.7rem);
+            line-height: 1.15;
+            letter-spacing: -0.01em;
+            color: var(--head);
+            margin-bottom: 16px;
+            max-width: 30ch;
+        }
+        .lede {
+            font-size: 1.12rem;
+            color: var(--text-dim);
+            max-width: 68ch;
+            margin-bottom: 40px;
+        }
+        .lede strong { color: var(--text); }
+
+        /* ---------------- cards ---------------- */
+        .cards {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+            gap: 18px;
+            counter-reset: card;
+        }
+        .card {
+            position: relative;
+            counter-increment: card;
+            background: linear-gradient(180deg, var(--panel-2), var(--panel));
+            border: 1px solid var(--hairline);
+            border-radius: 8px;
+            padding: 26px 24px 22px;
+            transition: transform 0.22s, border-color 0.22s, box-shadow 0.22s;
+        }
+        .card::before {
+            content: counter(card, decimal-leading-zero);
+            position: absolute;
+            top: 14px;
+            right: 16px;
+            font-family: var(--font-mono);
+            font-size: 11px;
+            letter-spacing: 0.08em;
+            color: var(--text-faint);
+        }
+        .card:hover {
+            transform: translateY(-3px);
+            border-color: var(--hairline-bright);
+            box-shadow: 0 14px 44px rgba(0, 0, 0, 0.45), 0 0 30px rgba(62, 224, 143, 0.10);
+        }
+        .card:hover::before { color: var(--green); }
+        .card-icon { font-size: 22px; margin-bottom: 12px; filter: saturate(0.8); }
+        .card h3 {
+            font-family: var(--font-serif);
+            font-weight: 600;
+            font-size: 1.18rem;
+            color: var(--head);
+            margin-bottom: 10px;
+            line-height: 1.3;
+        }
+        .card p { font-size: 0.96rem; color: var(--text-dim); }
+        .card p + p { margin-top: 8px; }
+        .card p em { color: var(--text-faint); font-size: 0.88em; }
+        .card p strong, .card p b { color: var(--text); }
+
+        .bar-note {
+            font-size: 0.92rem;
+            color: var(--text-faint);
+            max-width: 78ch;
+            margin-top: 26px;
+            padding-left: 14px;
+            border-left: 2px solid var(--hairline-bright);
+        }
+
+        /* ---------------- process steps ---------------- */
+        .steps {
+            display: grid;
+            grid-template-columns: repeat(3, 1fr);
+            gap: 18px;
+            counter-reset: step;
+        }
+        .step {
+            counter-increment: step;
+            border: 1px solid var(--hairline);
+            border-radius: 8px;
+            background: linear-gradient(180deg, var(--panel-2), var(--panel));
+            padding: 26px 24px 22px;
+        }
+        .step::before {
+            content: "0" counter(step);
+            display: block;
+            font-family: var(--font-mono);
+            font-size: 13px;
+            font-weight: 600;
+            letter-spacing: 0.12em;
+            color: var(--green);
+            margin-bottom: 12px;
+        }
+        .step h3 {
+            font-family: var(--font-serif);
+            font-weight: 600;
+            font-size: 1.12rem;
+            color: var(--head);
+            margin-bottom: 8px;
+        }
+        .step p { font-size: 0.95rem; color: var(--text-dim); }
+
+        .center-cta { margin-top: 40px; text-align: center; }
+
+        /* ---------------- footer ---------------- */
+        footer { padding: 54px 0 64px; background: var(--ink-2); }
+        .foot-inner { display: grid; gap: 22px; }
+        .foot-links {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 22px;
+            font-family: var(--font-mono);
+            font-size: 12.5px;
+            text-transform: uppercase;
+            letter-spacing: 0.07em;
+        }
+        .foot-links a { color: var(--text-dim); }
+        .foot-links a:hover { color: var(--green); text-decoration: none; }
+        .foot-meta { font-size: 0.85rem; color: var(--text-faint); }
+
+        /* ---------------- responsive ---------------- */
+        @media (max-width: 960px) {
+            .steps { grid-template-columns: 1fr; }
+        }
+        @media (max-width: 860px) {
+            .nav-toggle { display: block; }
+            .nav-links {
+                display: none;
+                position: absolute;
+                top: 62px;
+                left: 0;
+                right: 0;
+                flex-direction: column;
+                align-items: flex-start;
+                gap: 0;
+                background: var(--ink-2);
+                border-bottom: 1px solid var(--hairline);
+                padding: 10px 24px 18px;
+            }
+            .nav-links.open { display: flex; }
+            .nav-links a { padding: 11px 0; }
+        }
+        @media (max-width: 640px) {
+            body { font-size: 16px; }
+            section { padding: 64px 0; }
+            .hero { padding: 64px 0 52px; }
+        }
+
+        @media (prefers-reduced-motion: reduce) {
+            *, *::before, *::after {
+                animation-duration: 0.01ms !important;
+                animation-iteration-count: 1 !important;
+                transition-duration: 0.01ms !important;
+            }
+            html { scroll-behavior: auto; }
+        }
+    </style>
+</head>
+<body>
+
+<nav>
+    <div class="container nav-inner">
+        <a class="nav-logo" href="https://dfrostar.github.io/neuralmind/">
+            <svg viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                <circle cx="6" cy="6" r="2.4" fill="#5eead4"/><circle cx="18" cy="5" r="1.9" fill="#5eead4"/>
+                <circle cx="12" cy="13" r="2.8" fill="#3ee08f"/><circle cx="5" cy="18" r="1.9" fill="#5eead4"/>
+                <circle cx="19" cy="17" r="2.2" fill="#5eead4"/>
+                <path d="M7.8 7.4 10.6 11M16.5 6.2 13.7 11M7 16.8l3-2.4M14.4 14.6l3 1.6" stroke="#2aa96c" stroke-width="1.3" stroke-linecap="round"/>
+            </svg>
+            NeuralMind
+        </a>
+        <button class="nav-toggle" aria-label="Toggle navigation" onclick="document.getElementById('navlinks').classList.toggle('open')">☰</button>
+        <div class="nav-links" id="navlinks">
+            <a href="./#how-it-works">How it works</a>
+            <a href="./#proof">Proof</a>
+            <a href="./#quickstart">Quickstart</a>
+            <a class="active" href="services.html">Services</a>
+            <a href="wiki/Home">Docs</a>
+            <a href="about.html">About</a>
+            <a class="nav-gh" href="https://github.com/dfrostar/neuralmind">GitHub ↗</a>
+        </div>
+    </div>
+</nav>
+
+<header class="hero">
+    <div class="container">
+        <p class="badge"><span class="dot"></span> services — from the maintainer, scoped individually</p>
+        <h1>The software is free. <span class="grad">The rollout doesn't have to be solo.</span></h1>
+        <p class="hero-sub">NeuralMind is MIT-licensed and always will be. For teams that want it working across every engineer's agent — <strong>verified, benchmarked on their own repos, and defensible in an audit</strong> — the maintainer takes on a small number of hands-on engagements.</p>
+        <div class="cta-row">
+            <a class="btn btn-primary" href="https://www.linkedin.com/in/darren-frost-a9021">Get in touch on LinkedIn</a>
+            <a class="btn btn-ghost" href="./">Back to the project</a>
+        </div>
+    </div>
+</header>
+
+<section id="engagements">
+    <div class="container">
+        <p class="eyebrow">Engagements</p>
+        <h2>Five ways to bring in help</h2>
+        <p class="lede">Every engagement is built on the same open-source project and the same committed evals — <strong>nothing proprietary is held back.</strong> What you're buying is time, experience, and a verified result.</p>
+        <div class="cards">
+            <div class="card">
+                <div class="card-icon">🛠</div>
+                <h3>Install &amp; rollout audit</h3>
+                <p>Guided rollout across your team: install, index build, MCP registration for every agent in use (Claude Code, Cursor, Cline, Continue), hooks configured, and the whole setup verified with <code>neuralmind doctor</code> — or an audit of an existing install that isn't pulling its weight.</p>
+                <p><em>For teams adopting, or teams who installed it and aren't sure it's working.</em></p>
+            </div>
+            <div class="card">
+                <div class="card-icon">🧠</div>
+                <h3>Team-memory onboarding</h3>
+                <p>Set up committed team memory and the CI auto-index workflow so every teammate's agent inherits the learned synapse layer on their next session — namespace strategy, publish cadence, and a working session with the team on how the memory behaves.</p>
+                <p><em>The measured onboarding lift (+6.5 pts) is the point: a fresh clone starts with the team's earned intuition.</em></p>
+            </div>
+            <div class="card">
+                <div class="card-icon">📊</div>
+                <h3>Benchmark your repo</h3>
+                <p>The public-benchmark methodology — objective gold-file recall, token cost vs. full-file paste, ripgrep, and vector-RAG baselines — run against <strong>your own repositories</strong>, with a written report of recall, reduction, and projected spend savings you can put in front of whoever owns the budget.</p>
+                <p><em>Same honest-scope framing as the public benchmark: where it wins, and where it doesn't.</em></p>
+            </div>
+            <div class="card">
+                <div class="card-icon">🔐</div>
+                <h3>Compliance review</h3>
+                <p>Air-gapped install support, SBOM and audit-trail walkthrough, and a mapping of NeuralMind's local-first posture onto your framework — NIST AI RMF, SOC 2, GDPR — working from the same <a href="COMPLIANCE-SUMMARY">compliance one-pager</a> your auditors will read.</p>
+                <p><em>For regulated environments where "your code never leaves the machine" has to be provable, not promised.</em></p>
+            </div>
+            <div class="card">
+                <div class="card-icon">✳️</div>
+                <h3>Something else</h3>
+                <p>Running an unusual stack, evaluating NeuralMind against an internal tool, or planning something none of the boxes above cover? Describe it — custom engagements are scoped the same way as everything else.</p>
+                <p><em>If it touches agent context, memory, or token spend, it's probably in scope.</em></p>
+            </div>
+        </div>
+        <p class="bar-note">No rate card on this page by design — engagements are scoped individually against your team size, repos, and constraints. You describe the situation; you get back a concrete written proposal with fixed scope and deliverables.</p>
+    </div>
+</section>
+
+<section id="how-engagements-work">
+    <div class="container">
+        <p class="eyebrow">Process</p>
+        <h2>How an engagement works</h2>
+        <div class="steps">
+            <div class="step">
+                <h3>Reach out</h3>
+                <p>A short message on LinkedIn: team size, repos and languages, which agents you run, and what outcome you're after. That's enough to start.</p>
+            </div>
+            <div class="step">
+                <h3>Scope</h3>
+                <p>A short call, then a written proposal — fixed scope, named deliverables, and exactly what "done" means. No open-ended retainers unless you ask for one.</p>
+            </div>
+            <div class="step">
+                <h3>Deliver &amp; verify</h3>
+                <p>Every deliverable is verified with the project's own tooling — <code>neuralmind doctor</code> for installs, the committed eval suite for benchmarks — so the result is checkable after the engagement ends.</p>
+            </div>
+        </div>
+        <p class="center-cta">
+            <a class="btn btn-primary" href="https://www.linkedin.com/in/darren-frost-a9021">Start the conversation</a>
+        </p>
+    </div>
+</section>
+
+<footer>
+    <div class="container foot-inner">
+        <a class="nav-logo" href="https://dfrostar.github.io/neuralmind/">
+            <svg viewBox="0 0 24 24" fill="none" aria-hidden="true" width="20" height="20">
+                <circle cx="6" cy="6" r="2.4" fill="#5eead4"/><circle cx="18" cy="5" r="1.9" fill="#5eead4"/>
+                <circle cx="12" cy="13" r="2.8" fill="#3ee08f"/><circle cx="5" cy="18" r="1.9" fill="#5eead4"/>
+                <circle cx="19" cy="17" r="2.2" fill="#5eead4"/>
+                <path d="M7.8 7.4 10.6 11M16.5 6.2 13.7 11M7 16.8l3-2.4M14.4 14.6l3 1.6" stroke="#2aa96c" stroke-width="1.3" stroke-linecap="round"/>
+            </svg>
+            NeuralMind
+        </a>
+        <div class="foot-links">
+            <a href="https://github.com/dfrostar/neuralmind">GitHub</a>
+            <a href="https://pypi.org/project/neuralmind/">PyPI</a>
+            <a href="wiki/Home">Docs</a>
+            <a href="benchmarks/">Benchmarks</a>
+            <a href="services.html">Services</a>
+            <a href="https://github.com/dfrostar/neuralmind/issues">Issues</a>
+            <a href="about.html">About</a>
+        </div>
+        <p class="foot-meta">MIT License. Open source, not affiliated with NeuralMind.ai. &nbsp;🔐 100% local · ⚡ 40–70× token reduction · ✅ NIST AI RMF · 🛠 Works with any MCP agent</p>
+    </div>
+</footer>
+
+<script>
+    document.querySelectorAll('#navlinks a').forEach(function (a) {
+        a.addEventListener('click', function () {
+            document.getElementById('navlinks').classList.remove('open');
+        });
+    });
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
## What's in here

Two marketing deliverables, both docs-only (no release trigger):

1. **`docs/services.html`** — a maintainer-services page (the counterpart to Headroom's). Five engagements: install & rollout audit, team-memory onboarding, benchmark-your-repo, compliance review, and a custom catch-all. Contact-only pricing by design; CTA goes to Darren's LinkedIn profile. Built to match the **#315 instrument-readout redesign** (Newsreader × IBM Plex Mono, green-black palette, film-grain, fig. counters) so it lands visually consistent once that merges.
2. **`docs/LINKEDIN-POST-FABLE-PRICING.md`** — post draft in the Headroom owner's genre (news hook → levers → soft CTA), using Anthropic's **verified** Fable 5 pricing ($10/1M input, $50/1M output — the $30 figure circulating is wrong per Anthropic's published models table). Includes an optional `mine-history` paragraph gated on v0.42.0 tagging.

Plus `docs/launch/SERVICES-CROSSLINKS.md` (paste-ready index/about/sitemap link-through edits, deferred so this branch doesn't conflict with #315's index.html rewrite) and a `.claude/launch.json` docs preview config.

## Merge order

**Merge #315 first**, then this. After both: apply the five snippets in SERVICES-CROSSLINKS.md and delete it.

## Verification

Previewed via local static server: hero/cards/process/footer render in the new aesthetic; mobile (375px) collapses nav to hamburger and steps to one column with no horizontal overflow; Service JSON-LD included; no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)