### PR TITLE
refactor: split core.py, remove deprecated enable_reranking, fix IR aliasing

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -13,28 +13,82 @@ nine-initiative durability arc beyond that (versioned IR, retrieval quality
 harness, daemon-first architecture, and more), see
 [`docs/plans/2026-06-10-future-proofing-prd-pack.md`](docs/plans/2026-06-10-future-proofing-prd-pack.md).
 
-## Next — v0.13 → v0.16 (the eval-first arc)
+## Now — v0.41.0 (shipped & published)
 
-The spine is *measure, then change, then measure again.* Full detail,
-epics, and acceptance criteria in
-[`docs/NEXT-RELEASE-PLAN.md`](docs/NEXT-RELEASE-PLAN.md); tracked in
-issues [#171](https://github.com/dfrostar/neuralmind/issues/171)–[#175](https://github.com/dfrostar/neuralmind/issues/175).
+Latest release **v0.41.0** is live on
+[PyPI](https://pypi.org/project/neuralmind/) and GHCR. The
+v0.13 → v0.16 "eval-first" arc that used to sit here is **fully shipped**
+and the project has carried well past it — see
+[Shipped v0.13 → v0.41](#shipped-v013--v041) below. Full per-release
+detail lives in `RELEASE_NOTES_v*.md` at the repo root and in
+[`CHANGELOG.md`](CHANGELOG.md).
 
-| Release | Theme | What it does |
-|---|---|---|
-| **v0.13** | **Measure** | CI-gated faithfulness + retrieval-quality eval harness (100%-local offline judge; opt-in API judge). Polyglot TS/Go fixtures. The fitness function everything else depends on. |
-| **v0.14** | **Decouple** | A `GraphSource` adapter so tree-sitter / LSP / SCIP can feed the pipeline, proven at parity by the v0.13 harness. Reduces the single-graph-backend dependency, widens language coverage. |
-| **v0.15** | **Endure** | Host-capabilities adapter + integration-contract tests pinning Claude Code hook / MCP behaviour, so upstream drift is a one-adapter swap. |
-| **v0.16** | **Anticipate** | Promote directional "what you edit next" recall to first-class; ship a portable cross-agent memory format. |
+**Remaining work for the current arc is execution, not engineering:**
 
-**Team/shared memory — approved in principle, gated on measurement.**
-An opt-in, git-committed team baseline (reviewed in PRs, no SaaS) overlaid
-by each developer's private personal layer. Its day-one onboarding lift is
-*measured* by the v0.13 harness before the design is locked — see
-[#175](https://github.com/dfrostar/neuralmind/issues/175). This is what
-un-gates an honest enterprise lane: the compliance surface (RBAC, audit
-of the shared layer) sequences *after* a real multi-writer surface exists,
-not in anticipation of one.
+- **Answerability proof.** The opt-in `--judge` harness shipped in
+  v0.34.0, but `bench/public/judge/` is still empty. Run
+  `neuralmind benchmark --public --judge` with `ANTHROPIC_API_KEY` set
+  and commit the transcripts, so the launch materials show a concrete
+  answerability table instead of "run it yourself." Pre-empts the
+  "recall ≠ answering" critique.
+- **Launch — disclosed-maker only.** Copy is ready in
+  [`docs/launch/`](docs/launch/) (Show HN, r/LocalLLaMA, awesome-mcp
+  PR). Standing rule: outreach is disclosed-maker only — no
+  unaffiliated-user posts, no personas.
+- **Two GitHub-UI edits** the maker does by hand: repo About / Topics
+  (comparison terms for search weighting) and the v0.37.0 Release body
+  (umbrella notes + honest comparison footer).
+
+## Next — forward candidates
+
+Post-launch engineering candidates that are *not* yet shipped:
+
+- **`neuralmind impact` blast-radius tool.** Reverse-edge traversal —
+  "what depends on this?" The forward graph is built at index time;
+  materialise the reverse index during `build` and expose it as an MCP
+  tool + CLI command. The one structural capability gap vs.
+  dependency-graph peers.
+- **Broader `install-mcp` targets.** Add Windsurf, Continue.dev, and
+  Zed — same MCP JSON config, only the destination path differs. Takes
+  supported agents from 4 → 7 with no logic changes.
+- **Cross-agent portable memory format.** Promote the directional
+  "what you edit next" recall into a portable memory format that
+  survives across agent runtimes.
+
+## Shipped v0.13 → v0.41
+
+The eval-first arc and everything after it. Full notes per release in
+`RELEASE_NOTES_v*.md`; highlights:
+
+- **Eval-first foundation (v0.13–v0.16).** CI-gated faithfulness +
+  retrieval-quality harness, `GraphSource` decoupling behind a
+  tree-sitter seam, host-capabilities resilience, and first-class
+  directional recall.
+- **Backend independence (v0.21–v0.29).** Owned MiniLM embedder and the
+  experimental TurboVec (TurboQuant) backend, culminating in a
+  **ChromaDB-free default install** (turbovec/ONNX) in v0.29.
+- **Durability PRDs (v0.23–v0.24).** Versioned IR, quality harness,
+  debug traces, a local daemon, and memory namespaces + git-branch
+  isolation for the synapse layer.
+- **One learning signal (v0.25–v0.26).** Retired the `learned_patterns`
+  reranker so the synapse layer is the single learning signal, then
+  added selector auto-tuning that learns from it.
+- **Ten languages (v0.27–v0.37).** Rust, Java, C/C++, C#, Ruby, and PHP
+  added behind the tree-sitter seam — ten languages total.
+- **Honest public benchmark (v0.31–v0.34).** `neuralmind benchmark
+  --public`, a live `codebase-memory-mcp` head-to-head, an opt-in
+  LLM-judged answerability arm, and the four-data-backed-benefits
+  positioning + disclosed-maker launch kit.
+- **Team memory (v0.30/v0.31).** Commit the learned synapse signal;
+  teammates' agents inherit it (`.neuralmind-team-memory.json`,
+  content-hash idempotent, fail-open).
+- **Agent-facing surface (v0.38–v0.41).** VS Code extension, hybrid
+  BM25 + dense search, explicit-feedback MCP tool, CI auto-index,
+  `neuralmind probe` (label-free retrieval self-test), the
+  trust/transparency six (`--dry-run`, `--explain`, `review`,
+  `savings`, rationale probe, instant deletion decay), schema-artifact
+  indexing (OpenAPI / SQL DDL / Protobuf), and the reuse-vs-rewrite
+  feedback loop + structured relevance sidecar.
 
 ## Shipped since v0.9.0
 

--- a/neuralmind/core.py
+++ b/neuralmind/core.py
@@ -171,7 +171,6 @@ class NeuralMind:
         self,
         project_path: str,
         db_path: str = None,
-        enable_reranking: bool = True,
         backend_type: str | None = None,
         hybrid_context: bool | None = None,
         enable_synapses: bool = True,
@@ -183,10 +182,6 @@ class NeuralMind:
         Args:
             project_path: Path to project root (where graphify-out/ lives)
             db_path: Optional custom path for ChromaDB storage
-            enable_reranking: Deprecated and ignored. The learned_patterns
-                reranker was removed; the synapse layer supersedes it. Kept in
-                the signature for backward compatibility (callers passing it
-                won't break), but it no longer has any effect.
             enable_synapses: If True, run the associative synapse layer that
                 learns co-activation patterns across queries and tool calls.
             memory_namespace: Explicit synapse-memory namespace (PRD 4). When
@@ -195,10 +190,6 @@ class NeuralMind:
         """
         self.project_path = Path(project_path)
         self.db_path = db_path
-        # Deprecated and ignored (see __init__ docstring): retained only so the
-        # attribute keeps existing for any code that reads it. The reranker it
-        # used to gate has been removed; the synapse layer supersedes it.
-        self.enable_reranking = enable_reranking
         self.backend_manager = BackendManager(
             project_path=str(self.project_path), db_path=db_path, backend=backend_type
         )

--- a/neuralmind/core.py
+++ b/neuralmind/core.py
@@ -24,13 +24,14 @@ Usage:
 
 import json
 import os
-import re
 import threading
-from datetime import datetime, timezone
+from datetime import datetime
 from pathlib import Path
 
 from . import ir as ir_mod
 from . import namespaces as ns_mod
+from . import querying, synapse_feedback
+from . import recent_queries as recent_queries_log
 from .audit import get_audit_trail
 from .backend_manager import BackendManager
 from .context_selector import ContextResult, ContextSelector
@@ -38,51 +39,6 @@ from .memory import is_memory_logging_enabled, log_query_event, log_wakeup_event
 from .synapses import SynapseStore, default_db_path
 
 DEFAULT_HYBRID_HIGHLIGHT_COUNT = 3
-
-# Serializes recent-queries appends within this process. POSIX O_APPEND
-# already makes single-line appends atomic, but Windows' CRT implements
-# append mode as a separate seek-to-end + write, so two handles writing
-# concurrently can interleave and lose lines.
-_RECENT_QUERIES_APPEND_LOCK = threading.Lock()
-
-try:
-    import msvcrt  # Windows-only: cross-process advisory lock below.
-except ImportError:  # pragma: no cover - POSIX
-    msvcrt = None  # type: ignore[assignment]
-
-
-def _lock_byte0(fd: int) -> bool:
-    """Best-effort cross-process mutex on byte 0 of *fd* (Windows only).
-
-    POSIX writers don't need it (O_APPEND is atomic) and use flock for
-    compaction instead; on Windows both the appender and the compactor
-    take this same region so a compaction's read-truncate-rewrite can't
-    drop a concurrent process's append. Non-blocking with a short retry
-    so a stuck holder can never stall a query.
-    """
-    if msvcrt is None:
-        return False
-    import time as _time
-
-    for _ in range(50):  # ~50ms worst case
-        try:
-            os.lseek(fd, 0, os.SEEK_SET)
-            msvcrt.locking(fd, msvcrt.LK_NBLCK, 1)
-            return True
-        except OSError:
-            _time.sleep(0.001)
-    return False
-
-
-def _unlock_byte0(fd: int) -> None:
-    if msvcrt is None:
-        return
-    try:
-        os.lseek(fd, 0, os.SEEK_SET)
-        msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
-    except OSError:
-        pass
-
 
 # Canonical IR artifacts (PRD 1), under <project>/.neuralmind/.
 IR_FILENAME = "index_ir.json"
@@ -304,199 +260,31 @@ class NeuralMind:
             return 0
 
     def activate_files(self, file_paths: list[str], strength: float = 1.0) -> int:
-        """Resolve file paths to graph node ids and feed them as one batch.
+        """Co-activate every node in the touched files as one batch.
 
-        Used by the file watcher: when a cluster of files is edited together,
-        we treat them as having co-fired and let the synapse store strengthen
-        the edges between every node living in those files.
-
-        Two parallel updates run from one call:
-
-        - Undirected co-activation across every node inside the touched
-          files (the existing Hebbian signal).
-        - Directional file-level transitions (``A -> B``) for each
-          consecutive pair in ``file_paths``, so callers can ask
-          ``next_likely(file)`` for what typically follows. *(v0.11.0+)*
+        See :func:`neuralmind.synapse_feedback.activate_files`.
         """
-        if not file_paths:
-            return 0
-        self._ensure_built()
-
-        store = self.synapses
-        if store is not None and len(file_paths) >= 2:
-            try:
-                store.record_sequence(file_paths, strength=strength)
-            except Exception:
-                pass
-
-        node_ids: list[str] = []
-        for path in file_paths:
-            try:
-                for node in self.embedder.get_file_nodes(path):
-                    nid = node.get("id")
-                    if nid:
-                        node_ids.append(str(nid))
-            except Exception:
-                continue
-        if len(node_ids) < 2:
-            return 0
-        return self.activate(node_ids, strength=strength)
-
-    # Language-agnostic identifier tokenizer for reuse detection: we never
-    # parse source syntax, only match bare identifiers against graph labels,
-    # so this works uniformly across every tree-sitter extractor.
-    _REUSE_IDENT_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
-
-    # Graph node file_types that are prose, not symbols — their labels are
-    # docstrings/file paths, never identifiers, so they're excluded from the
-    # reuse index.
-    _NON_SYMBOL_FILE_TYPES = frozenset({"rationale", "document"})
+        return synapse_feedback.activate_files(self, file_paths, strength=strength)
 
     @classmethod
     def _symbol_name(cls, label: str) -> str:
-        """Bare identifier for a graph label ("login_endpoint()" -> "login_endpoint").
-
-        Generated graphs label functions with signature punctuation; the code we
-        tokenize yields bare identifiers, so we key the reuse index on the
-        leading identifier of each label to make the two comparable.
-        """
-        m = cls._REUSE_IDENT_RE.search(str(label or ""))
-        return m.group(0) if m else ""
-
-    def _external_symbol_index(self) -> dict[str, list[str]]:
-        """Map normalized symbol name -> node ids that define it, across the graph.
-
-        Cached on the instance and invalidated when the node count changes
-        (build/reindex), so repeated Edit/Write feedback calls don't re-scan the
-        whole graph each time — per-edit work is then ~O(#tokens), not O(#nodes).
-        Edited-file ownership is filtered at match time, not here.
-        """
-        nodes = getattr(self.embedder, "nodes", None) or []
-        sig = len(nodes)
-        cached = getattr(self, "_symbol_index_cache", None)
-        if cached is not None and getattr(self, "_symbol_index_sig", None) == sig:
-            return cached
-        index: dict[str, list[str]] = {}
-        for n in nodes:
-            if n.get("file_type") in self._NON_SYMBOL_FILE_TYPES:
-                continue
-            nid = str(n.get("id", ""))
-            if not nid:
-                continue
-            name = self._symbol_name(n.get("label", ""))
-            if name:
-                index.setdefault(name, []).append(nid)
-        self._symbol_index_cache = index
-        self._symbol_index_sig = sig
-        return index
+        """Bare identifier for a graph label. See
+        :func:`neuralmind.synapse_feedback.symbol_name`."""
+        return synapse_feedback.symbol_name(label)
 
     def record_edit_activity(self, file_path: str, new_code: str) -> dict:
-        """Learn from an Edit/Write: did the new code reuse existing symbols?
+        """Learn from an Edit/Write reuse signal.
 
-        When an agent edits ``file_path``, identifiers in ``new_code`` that
-        already name a symbol defined *elsewhere* in the graph are treated as
-        a **reuse** signal — the edited file and the reused definitions fired
-        together in one thought, so we reinforce their synapse edges. The
-        existing L2/L3 synapse boost then surfaces those reused nodes more
-        readily on future queries, closing the loop between what got reused
-        and what is worth remembering.
-
-        Symbols ``new_code`` *defines* whose name also exists in another file
-        are reported as possible duplication, but in this MVP that is surfaced
-        only in the return value — not acted on.
-
-        Operates on graph nodes + identifier tokens, never on source syntax,
-        so it is language-agnostic. A **pure side effect**: it never triggers a
-        build (only the cheap graph load via ``get_file_nodes``), and fails open
-        — if the graph isn't available it returns empty rather than pay build
-        cost in a hook. Writes land in the project's active namespace (same as
-        ``activate``). Returns a summary dict for the hook to log and tests to
-        assert on.
+        See :func:`neuralmind.synapse_feedback.record_edit_activity`.
         """
-        empty = {"reused": [], "possible_dupes": [], "pairs": 0}
-        if self.synapses is None or not file_path or not new_code:
-            return empty
-
-        # Nodes already defined in the edited file. get_file_nodes lazily loads
-        # graph.json (cheap) but never embeds — so no build is forced here.
-        try:
-            file_nodes = self.embedder.get_file_nodes(file_path)
-        except Exception:
-            file_nodes = []
-        file_node_ids = {str(n.get("id")) for n in file_nodes if n.get("id")}
-
-        index = self._external_symbol_index()
-        if not index:
-            return empty
-
-        tokens = set(self._REUSE_IDENT_RE.findall(new_code))
-
-        reused_ids: list[str] = []
-        reused_labels: list[str] = []
-        for name in tokens & index.keys():
-            ext_ids = [i for i in index[name] if i not in file_node_ids]
-            if ext_ids:
-                reused_ids.extend(ext_ids)
-                reused_labels.append(name)
-
-        # Possible duplication: a symbol defined in this file whose name also
-        # exists in another file. Reported only (MVP does not penalize).
-        possible_dupes = sorted(
-            {
-                name
-                for n in file_nodes
-                if n.get("file_type") not in self._NON_SYMBOL_FILE_TYPES
-                and (name := self._symbol_name(n.get("label", ""))) in index
-                and any(i not in file_node_ids for i in index[name])
-            }
-        )
-
-        pairs = 0
-        coactivate = list(file_node_ids) + reused_ids
-        if reused_ids and len(coactivate) >= 2:
-            pairs = self.activate(coactivate, strength=self.REUSE_FEEDBACK_STRENGTH)
-
-        return {
-            "reused": sorted(set(reused_labels)),
-            "possible_dupes": possible_dupes,
-            "pairs": pairs,
-        }
+        return synapse_feedback.record_edit_activity(self, file_path, new_code)
 
     def deactivate_files(self, file_paths: list[str]) -> int:
-        """Accelerate synapse decay for nodes belonging to deleted files.
+        """Accelerate synapse decay for nodes in deleted files.
 
-        When a file is removed from the project (rename, refactor, deletion),
-        its graph nodes should lose influence quickly so they stop surfacing in
-        context and spreading activation. Calls ``decay_node`` once per node
-        found in the deleted files — one targeted tick is enough to sink
-        non-LTP edges below the prune threshold within a few normal decay
-        cycles, while LTP-protected edges (heavily-used, long-established)
-        survive and fade gracefully.
-
-        Returns the number of nodes targeted.
+        See :func:`neuralmind.synapse_feedback.deactivate_files`.
         """
-        if not file_paths:
-            return 0
-        store = self.synapses
-        if store is None:
-            return 0
-        if not self._built:
-            return 0
-
-        targeted = 0
-        for path in file_paths:
-            try:
-                for node in self.embedder.get_file_nodes(path):
-                    nid = node.get("id")
-                    if nid:
-                        try:
-                            store.decay_node(str(nid))
-                            targeted += 1
-                        except Exception:
-                            pass
-            except Exception:
-                continue
-        return targeted
+        return synapse_feedback.deactivate_files(self, file_paths)
 
     def _emit_audit(
         self,
@@ -1035,338 +823,44 @@ class NeuralMind:
         return self.project_path / ".neuralmind" / self.RECENT_QUERIES_FILENAME
 
     def _record_recent_query(self, question: str, result: ContextResult) -> None:
-        """Append the last query's retrieval state to the recent-queries log.
-
-        Powers the graph-view UI's 'Replay last query' panel: a human can
-        see which nodes the agent actually received, including ids the
-        UI can highlight on the canvas. Always on (local-only data,
-        readable only through the auth-gated server).
-
-        The hot path is a single-line O_APPEND write. On POSIX that is
-        atomic across processes by itself (writes < PIPE_BUF don't
-        tear); Windows' CRT implements append as seek-to-end + write,
-        so writes are additionally serialized by a process-local lock
-        and a best-effort cross-process byte-range lock. Trimming back
-        to RECENT_QUERIES_MAX is a lazy compaction step gated by file
-        size and protected by the same locks — see
-        ``_compact_recent_queries``.
+        """Append the query's retrieval state to the replay log.
 
         Gated on the same consent flag as the learning log
         (`NEURALMIND_MEMORY`): if the user opted out of persisting
         query text, we don't create a parallel persistence path here.
+        See :func:`neuralmind.recent_queries.append_query_record`.
         """
         if not is_memory_logging_enabled():
             return
-        try:
-            hits = []
-            for hit in (getattr(result, "top_search_hits", []) or [])[:12]:
-                meta = hit.get("metadata") or {}
-                hits.append(
-                    {
-                        "id": str(hit.get("id", "")),
-                        "label": meta.get("label", hit.get("id", "")),
-                        "source_file": meta.get("source_file", ""),
-                        "score": round(float(hit.get("score", 0.0)), 3),
-                    }
-                )
-            record = {
-                "ts": datetime.now(timezone.utc).isoformat(),
-                "question": question,
-                "tokens": int(getattr(getattr(result, "budget", None), "total", 0)),
-                "reduction_ratio": round(float(getattr(result, "reduction_ratio", 0.0)), 2),
-                "layers_used": list(getattr(result, "layers_used", [])),
-                "communities_loaded": list(getattr(result, "communities_loaded", [])),
-                "top_hits": hits,
-            }
-            log_path = self._recent_queries_path()
-            log_path.parent.mkdir(parents=True, exist_ok=True)
-            encoded = (json.dumps(record, sort_keys=True) + "\n").encode("utf-8")
-            with _RECENT_QUERIES_APPEND_LOCK:
-                fd = os.open(str(log_path), os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o644)
-                locked = False
-                try:
-                    locked = _lock_byte0(fd)
-                    os.write(fd, encoded)
-                finally:
-                    if locked:
-                        _unlock_byte0(fd)
-                    os.close(fd)
-        except Exception:
-            # Recording must never block the actual query.
-            return
-        try:
-            self._compact_recent_queries(log_path)
-        except Exception:
-            pass
-
-    def _compact_recent_queries(self, log_path: Path) -> None:
-        """Trim the recent-queries log back to RECENT_QUERIES_MAX entries.
-
-        Only runs when the file has grown past the size threshold, so the
-        hot path stays append-only. The read-truncate-rewrite is guarded
-        against another process's append by flock on POSIX and by the
-        byte-0 region lock shared with ``_record_recent_query`` on
-        Windows; both are best-effort — worst case is a slightly
-        oversized log file (no data loss).
-        """
-        try:
-            size = log_path.stat().st_size
-        except OSError:
-            return
-        if size <= self.RECENT_QUERIES_COMPACT_BYTES:
-            return
-        try:
-            import fcntl
-        except ImportError:
-            fcntl = None  # type: ignore[assignment]
-        with _RECENT_QUERIES_APPEND_LOCK, log_path.open("r+", encoding="utf-8") as f:
-            if fcntl is not None:
-                try:
-                    fcntl.flock(f.fileno(), fcntl.LOCK_EX)
-                except OSError:
-                    pass
-            locked = _lock_byte0(f.fileno())
-            try:
-                lines = [ln for ln in f if ln.strip()]
-                if len(lines) <= self.RECENT_QUERIES_MAX:
-                    return
-                f.seek(0)
-                f.truncate()
-                f.writelines(lines[-self.RECENT_QUERIES_MAX :])
-                f.flush()
-            finally:
-                if locked:
-                    _unlock_byte0(f.fileno())
-                if fcntl is not None:
-                    try:
-                        fcntl.flock(f.fileno(), fcntl.LOCK_UN)
-                    except OSError:
-                        pass
+        recent_queries_log.append_query_record(
+            self._recent_queries_path(),
+            question,
+            result,
+            max_entries=self.RECENT_QUERIES_MAX,
+            compact_bytes=self.RECENT_QUERIES_COMPACT_BYTES,
+        )
 
     def recent_queries(self, n: int = 20) -> list[dict]:
         """Return the N most-recent recorded queries, newest first."""
-        log_path = self._recent_queries_path()
-        if not log_path.exists():
-            return []
-        try:
-            with log_path.open(encoding="utf-8") as f:
-                lines = [line for line in f if line.strip()]
-        except OSError:
-            return []
-        out: list[dict] = []
-        for line in lines[-max(1, n) :]:
-            try:
-                out.append(json.loads(line))
-            except json.JSONDecodeError:
-                continue
-        out.reverse()
-        return out
+        return recent_queries_log.read_recent(self._recent_queries_path(), n)
 
     def _reinforce_from_query(self, question: str, result: ContextResult) -> None:
         """Hebbian update: nodes co-activated by a query wire together.
 
-        Reuses the search hits the selector already fetched for L2/L3 so
-        we don't pay for a third round trip to the embedder. Falls back
-        to a fresh search only if the result didn't surface any hits
-        (e.g. an L0/L1-only call).
+        See :func:`neuralmind.synapse_feedback.reinforce_from_query`.
         """
-        store = self.synapses
-        if store is None:
-            return
-        hits = result.top_search_hits
-        if not hits:
-            try:
-                hits = self.embedder.search(question, n=6)
-            except Exception:
-                return
-        node_ids: list[str] = []
-        for hit in hits[:6]:
-            nid = hit.get("id")
-            if nid:
-                node_ids.append(str(nid))
-        for comm_id in result.communities_loaded or []:
-            node_ids.append(f"community_{comm_id}")
-        if len(node_ids) >= 2:
-            try:
-                store.reinforce(node_ids)
-            except Exception:
-                pass
+        synapse_feedback.reinforce_from_query(self, question, result)
 
     def _build_hybrid_highlights(self, question: str, cached_hits: list[dict] | None = None) -> str:
-        if cached_hits:
-            results = cached_hits[: self.MAX_HYBRID_HIGHLIGHT_RESULTS]
-        else:
-            results = self.embedder.search(question, n=self.MAX_HYBRID_HIGHLIGHT_RESULTS)
-        if not results:
-            return ""
-        lines = ["## Hybrid Highlights"]
-        for item in results:
-            metadata = item.get("metadata", {})
-            label = metadata.get("label", item.get("id", "unknown"))
-            source = metadata.get("source_file", "")
-            score = item.get("score", 0.0)
-            source_suffix = f" ({source})" if source else ""
-            lines.append(f"- {label}{source_suffix} — score {score:.2f}")
-        return "\n".join(lines)
+        return querying.build_hybrid_highlights(self, question, cached_hits)
 
     def skeleton(self, file_path: str) -> str:
         """Return a compact skeleton view of a file using graph data.
 
-        The skeleton contains:
-        - File header (community, function count)
-        - Function list with line numbers and one-line rationale from the graph
-        - Internal call graph (within the file)
-        - Cross-file relationships (shares_data_with, imports_from edges)
-        - Pointer to bypass for full source
-
-        Args:
-            file_path: Path to the source file (absolute or project-relative)
-
-        Returns:
-            Formatted skeleton text, or empty string if file is not indexed
+        See :func:`neuralmind.querying.skeleton`.
         """
         self._ensure_built()
-
-        nodes = self.embedder.get_file_nodes(file_path)
-        if not nodes:
-            return ""
-
-        node_ids = {n["id"] for n in nodes}
-        edges = self.embedder.get_file_edges(file_path, node_ids=node_ids)
-
-        # Partition nodes
-        code_nodes = [n for n in nodes if n.get("file_type") == "code"]
-        rationale_nodes = [n for n in nodes if n.get("file_type") == "rationale"]
-
-        # Map code node id → rationale text (via rationale_for edges)
-        # Edge shape: {relation: "rationale_for", _src: rationale_id, _tgt: code_id, ...}
-        rationale_map: dict[str, str] = {}
-        for e in edges:
-            if e.get("relation") != "rationale_for":
-                continue
-            src = e.get("_src") or e.get("source")
-            tgt = e.get("_tgt") or e.get("target")
-            # Find the rationale node
-            rationale_node = next(
-                (rn for rn in rationale_nodes if rn["id"] in (src, tgt)),
-                None,
-            )
-            code_node = next(
-                (cn for cn in code_nodes if cn["id"] in (src, tgt)),
-                None,
-            )
-            if rationale_node and code_node:
-                label = rationale_node.get("label", "").strip()
-                # Rationale labels are sometimes truncated docstrings; strip trailing ellipsis
-                if label:
-                    rationale_map[code_node["id"]] = label[:120]
-
-        # Separate the file-level node (source_location "L1" or label matching filename)
-        file_node = next(
-            (
-                n
-                for n in code_nodes
-                if n.get("source_location") == "L1"
-                or n.get("label", "").endswith((".py", ".ts", ".js", ".go", ".rs"))
-            ),
-            None,
-        )
-        function_nodes = [n for n in code_nodes if n is not file_node]
-
-        # Sort functions by line number
-        def _line_no(node: dict) -> int:
-            loc = node.get("source_location", "L0")
-            try:
-                return int(loc.lstrip("L"))
-            except ValueError:
-                return 0
-
-        function_nodes.sort(key=_line_no)
-
-        # Build call graph (within-file calls)
-        calls_map: dict[str, list[str]] = {}
-        for e in edges:
-            if e.get("relation") != "calls":
-                continue
-            # Graph stores calls as target calls source (reversed semantics per exploration)
-            src = e.get("_src") or e.get("source")
-            tgt = e.get("_tgt") or e.get("target")
-            if src in node_ids and tgt in node_ids:
-                # Display direction: caller → callee
-                # Per graphify convention, _src is caller, _tgt is callee
-                caller_id = src
-                callee_id = tgt
-                callee_node = next((n for n in function_nodes if n["id"] == callee_id), None)
-                caller_node = next((n for n in function_nodes if n["id"] == caller_id), None)
-                if caller_node and callee_node:
-                    calls_map.setdefault(caller_node.get("label", caller_id), []).append(
-                        callee_node.get("label", callee_id)
-                    )
-
-        # Cross-file edges
-        cross_edges = [
-            e
-            for e in edges
-            if e.get("relation") in ("shares_data_with", "imports_from", "implements", "uses")
-            and (
-                (e.get("_src") in node_ids) != (e.get("_tgt") in node_ids)
-            )  # exactly one endpoint inside
-        ]
-
-        # Format output
-        lines: list[str] = []
-        community = nodes[0].get("community", "?")
-        lines.append(f"# {file_path}  (community {community}, {len(function_nodes)} functions)")
-        lines.append("")
-        lines.append("## Functions")
-
-        # Compute padding for nice alignment
-        max_label = max((len(n.get("label", "")) for n in function_nodes), default=12)
-        for n in function_nodes:
-            loc = n.get("source_location", "L?")
-            label = n.get("label", "?")
-            rat = rationale_map.get(n["id"])
-            if rat:
-                lines.append(f"{loc:<5} {label:<{max_label}}  — {rat}")
-            else:
-                lines.append(f"{loc:<5} {label}")
-
-        if calls_map:
-            lines.append("")
-            lines.append("## Call graph (within this file)")
-            for caller, callees in calls_map.items():
-                unique = sorted(set(callees))
-                lines.append(f"{caller} → {', '.join(unique)}")
-
-        if cross_edges:
-            lines.append("")
-            lines.append("## Cross-file")
-            seen_pairs: set[tuple[str, str, str]] = set()
-            for e in cross_edges[:10]:  # cap to avoid bloat
-                rel = e.get("relation", "?")
-                src = e.get("_src") or e.get("source")
-                tgt = e.get("_tgt") or e.get("target")
-                conf = e.get("confidence", "")
-                score = e.get("confidence_score", "")
-                pair = (src, tgt, rel)
-                if pair in seen_pairs:
-                    continue
-                seen_pairs.add(pair)
-                # Name the out-of-file endpoint
-                our_ids = node_ids
-                inside_id = src if src in our_ids else tgt
-                outside_id = tgt if src in our_ids else src
-                inside_label = next(
-                    (n.get("label", inside_id) for n in nodes if n["id"] == inside_id),
-                    inside_id,
-                )
-                score_str = f" {score}" if score else ""
-                lines.append(f"{inside_label} {rel} → {outside_id} ({conf}{score_str})")
-
-        lines.append("")
-        lines.append("[Full source available: Read this file with NEURALMIND_BYPASS=1]")
-
-        return "\n".join(lines)
+        return querying.skeleton(self, file_path)
 
     def search(self, query: str, n: int = 10, **filters) -> list[dict]:
         """
@@ -1448,82 +942,12 @@ class NeuralMind:
     def graph_data(self, synapse_min_weight: float = 0.05, synapse_limit: int = 2000) -> dict:
         """Return the full code graph for the ``serve`` graph-view UI.
 
-        Combines structural edges (calls/imports from graph.json) with the
-        learned synapse overlay. Node ids are the embedder's graph ids so
-        the overlay lines up with the structural nodes. Read-only — never
-        mutates the index or the synapse store.
+        See :func:`neuralmind.querying.graph_data`.
         """
         self._ensure_built()
-        raw_nodes = list(getattr(self.embedder, "nodes", []) or [])
-        raw_edges = list(getattr(self.embedder, "edges", []) or [])
-
-        nodes = []
-        for n in raw_nodes:
-            nid = str(n.get("id", n.get("label", "")))
-            if not nid:
-                continue
-            nodes.append(
-                {
-                    "id": nid,
-                    "label": n.get("label", nid),
-                    "file_type": n.get("file_type", "unknown"),
-                    "source_file": n.get("source_file", ""),
-                    "source_location": n.get("source_location", ""),
-                    "community": int(n.get("community", -1)),
-                }
-            )
-        node_ids = {n["id"] for n in nodes}
-
-        edges = []
-        for e in raw_edges:
-            src = e.get("_src") or e.get("source")
-            tgt = e.get("_tgt") or e.get("target")
-            if src not in node_ids or tgt not in node_ids:
-                continue
-            edges.append(
-                {
-                    "source": src,
-                    "target": tgt,
-                    "relation": e.get("relation", "related"),
-                }
-            )
-
-        synapses = []
-        store = self.synapses
-        if store is not None:
-            try:
-                for a, b, weight, count in store.edges(
-                    min_weight=synapse_min_weight, limit=synapse_limit
-                ):
-                    # Synapse ids can include community_* pseudo-nodes that
-                    # aren't real graph nodes — keep only edges we can draw.
-                    if a in node_ids and b in node_ids:
-                        synapses.append(
-                            {
-                                "source": a,
-                                "target": b,
-                                "weight": round(weight, 4),
-                                "activation_count": count,
-                            }
-                        )
-            except Exception:
-                pass
-
-        return {
-            "project": self.project_path.name,
-            # Full absolute path so the UI can key per-project state (e.g.
-            # saved canvas layouts) without collisions between two repos
-            # that happen to share a basename.
-            "project_path": str(self.project_path.resolve()),
-            "nodes": nodes,
-            "edges": edges,
-            "synapses": synapses,
-            "stats": {
-                "nodes": len(nodes),
-                "edges": len(edges),
-                "synapses": len(synapses),
-            },
-        }
+        return querying.graph_data(
+            self, synapse_min_weight=synapse_min_weight, synapse_limit=synapse_limit
+        )
 
     def _recall_for_selection(
         self, seed_ids: list[str], depth: int = 2, top_k: int = 8

--- a/neuralmind/core.py
+++ b/neuralmind/core.py
@@ -167,12 +167,6 @@ class NeuralMind:
     # the synapse weight gently and let decay wash out false positives.
     REUSE_FEEDBACK_STRENGTH = 0.5
 
-    # Canonical IR artifacts (PRD 1). The IR is materialized from graph.json at
-    # build time and validated; the embedder still reads graph.json directly
-    # (legacy default), so the IR is a hidden, parity-checked internal contract.
-    IR_FILENAME = IR_FILENAME
-    IR_META_FILENAME = IR_META_FILENAME
-
     def __init__(
         self,
         project_path: str,
@@ -670,11 +664,11 @@ class NeuralMind:
     # ----------------------------------------------------------------- #
     @property
     def ir_path(self) -> Path:
-        return ir_mod.project_artifact(self.project_path, ".neuralmind", self.IR_FILENAME)
+        return ir_mod.project_artifact(self.project_path, ".neuralmind", IR_FILENAME)
 
     @property
     def ir_meta_path(self) -> Path:
-        return ir_mod.project_artifact(self.project_path, ".neuralmind", self.IR_META_FILENAME)
+        return ir_mod.project_artifact(self.project_path, ".neuralmind", IR_META_FILENAME)
 
     def _materialize_ir(self) -> dict | None:
         """Adapt the loaded graph into the canonical IR, validate, and persist.

--- a/neuralmind/querying.py
+++ b/neuralmind/querying.py
@@ -1,0 +1,280 @@
+"""
+querying.py — read-side query/search formatting
+================================================
+
+Presentation helpers over an already-built index: hybrid-highlight
+prefixes for query results, the compact file skeleton view, and the
+graph payload for the ``serve`` graph-view UI. Extracted from
+``core.py``; each function takes the :class:`~neuralmind.core.NeuralMind`
+instance and is read-only over its embedder/synapse state. Callers are
+responsible for ``_ensure_built()`` — these functions assume a built
+index.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .core import NeuralMind
+
+
+def build_hybrid_highlights(
+    mind: NeuralMind, question: str, cached_hits: list[dict] | None = None
+) -> str:
+    if cached_hits:
+        results = cached_hits[: mind.MAX_HYBRID_HIGHLIGHT_RESULTS]
+    else:
+        results = mind.embedder.search(question, n=mind.MAX_HYBRID_HIGHLIGHT_RESULTS)
+    if not results:
+        return ""
+    lines = ["## Hybrid Highlights"]
+    for item in results:
+        metadata = item.get("metadata", {})
+        label = metadata.get("label", item.get("id", "unknown"))
+        source = metadata.get("source_file", "")
+        score = item.get("score", 0.0)
+        source_suffix = f" ({source})" if source else ""
+        lines.append(f"- {label}{source_suffix} — score {score:.2f}")
+    return "\n".join(lines)
+
+
+def skeleton(mind: NeuralMind, file_path: str) -> str:
+    """Return a compact skeleton view of a file using graph data.
+
+    The skeleton contains:
+    - File header (community, function count)
+    - Function list with line numbers and one-line rationale from the graph
+    - Internal call graph (within the file)
+    - Cross-file relationships (shares_data_with, imports_from edges)
+    - Pointer to bypass for full source
+
+    Args:
+        mind: A built NeuralMind instance
+        file_path: Path to the source file (absolute or project-relative)
+
+    Returns:
+        Formatted skeleton text, or empty string if file is not indexed
+    """
+    nodes = mind.embedder.get_file_nodes(file_path)
+    if not nodes:
+        return ""
+
+    node_ids = {n["id"] for n in nodes}
+    edges = mind.embedder.get_file_edges(file_path, node_ids=node_ids)
+
+    # Partition nodes
+    code_nodes = [n for n in nodes if n.get("file_type") == "code"]
+    rationale_nodes = [n for n in nodes if n.get("file_type") == "rationale"]
+
+    # Map code node id → rationale text (via rationale_for edges)
+    # Edge shape: {relation: "rationale_for", _src: rationale_id, _tgt: code_id, ...}
+    rationale_map: dict[str, str] = {}
+    for e in edges:
+        if e.get("relation") != "rationale_for":
+            continue
+        src = e.get("_src") or e.get("source")
+        tgt = e.get("_tgt") or e.get("target")
+        # Find the rationale node
+        rationale_node = next(
+            (rn for rn in rationale_nodes if rn["id"] in (src, tgt)),
+            None,
+        )
+        code_node = next(
+            (cn for cn in code_nodes if cn["id"] in (src, tgt)),
+            None,
+        )
+        if rationale_node and code_node:
+            label = rationale_node.get("label", "").strip()
+            # Rationale labels are sometimes truncated docstrings; strip trailing ellipsis
+            if label:
+                rationale_map[code_node["id"]] = label[:120]
+
+    # Separate the file-level node (source_location "L1" or label matching filename)
+    file_node = next(
+        (
+            n
+            for n in code_nodes
+            if n.get("source_location") == "L1"
+            or n.get("label", "").endswith((".py", ".ts", ".js", ".go", ".rs"))
+        ),
+        None,
+    )
+    function_nodes = [n for n in code_nodes if n is not file_node]
+
+    # Sort functions by line number
+    def _line_no(node: dict) -> int:
+        loc = node.get("source_location", "L0")
+        try:
+            return int(loc.lstrip("L"))
+        except ValueError:
+            return 0
+
+    function_nodes.sort(key=_line_no)
+
+    # Build call graph (within-file calls)
+    calls_map: dict[str, list[str]] = {}
+    for e in edges:
+        if e.get("relation") != "calls":
+            continue
+        # Graph stores calls as target calls source (reversed semantics per exploration)
+        src = e.get("_src") or e.get("source")
+        tgt = e.get("_tgt") or e.get("target")
+        if src in node_ids and tgt in node_ids:
+            # Display direction: caller → callee
+            # Per graphify convention, _src is caller, _tgt is callee
+            caller_id = src
+            callee_id = tgt
+            callee_node = next((n for n in function_nodes if n["id"] == callee_id), None)
+            caller_node = next((n for n in function_nodes if n["id"] == caller_id), None)
+            if caller_node and callee_node:
+                calls_map.setdefault(caller_node.get("label", caller_id), []).append(
+                    callee_node.get("label", callee_id)
+                )
+
+    # Cross-file edges
+    cross_edges = [
+        e
+        for e in edges
+        if e.get("relation") in ("shares_data_with", "imports_from", "implements", "uses")
+        and (
+            (e.get("_src") in node_ids) != (e.get("_tgt") in node_ids)
+        )  # exactly one endpoint inside
+    ]
+
+    # Format output
+    lines: list[str] = []
+    community = nodes[0].get("community", "?")
+    lines.append(f"# {file_path}  (community {community}, {len(function_nodes)} functions)")
+    lines.append("")
+    lines.append("## Functions")
+
+    # Compute padding for nice alignment
+    max_label = max((len(n.get("label", "")) for n in function_nodes), default=12)
+    for n in function_nodes:
+        loc = n.get("source_location", "L?")
+        label = n.get("label", "?")
+        rat = rationale_map.get(n["id"])
+        if rat:
+            lines.append(f"{loc:<5} {label:<{max_label}}  — {rat}")
+        else:
+            lines.append(f"{loc:<5} {label}")
+
+    if calls_map:
+        lines.append("")
+        lines.append("## Call graph (within this file)")
+        for caller, callees in calls_map.items():
+            unique = sorted(set(callees))
+            lines.append(f"{caller} → {', '.join(unique)}")
+
+    if cross_edges:
+        lines.append("")
+        lines.append("## Cross-file")
+        seen_pairs: set[tuple[str, str, str]] = set()
+        for e in cross_edges[:10]:  # cap to avoid bloat
+            rel = e.get("relation", "?")
+            src = e.get("_src") or e.get("source")
+            tgt = e.get("_tgt") or e.get("target")
+            conf = e.get("confidence", "")
+            score = e.get("confidence_score", "")
+            pair = (src, tgt, rel)
+            if pair in seen_pairs:
+                continue
+            seen_pairs.add(pair)
+            # Name the out-of-file endpoint
+            our_ids = node_ids
+            inside_id = src if src in our_ids else tgt
+            outside_id = tgt if src in our_ids else src
+            inside_label = next(
+                (n.get("label", inside_id) for n in nodes if n["id"] == inside_id),
+                inside_id,
+            )
+            score_str = f" {score}" if score else ""
+            lines.append(f"{inside_label} {rel} → {outside_id} ({conf}{score_str})")
+
+    lines.append("")
+    lines.append("[Full source available: Read this file with NEURALMIND_BYPASS=1]")
+
+    return "\n".join(lines)
+
+
+def graph_data(
+    mind: NeuralMind, synapse_min_weight: float = 0.05, synapse_limit: int = 2000
+) -> dict:
+    """Return the full code graph for the ``serve`` graph-view UI.
+
+    Combines structural edges (calls/imports from graph.json) with the
+    learned synapse overlay. Node ids are the embedder's graph ids so
+    the overlay lines up with the structural nodes. Read-only — never
+    mutates the index or the synapse store.
+    """
+    raw_nodes = list(getattr(mind.embedder, "nodes", []) or [])
+    raw_edges = list(getattr(mind.embedder, "edges", []) or [])
+
+    nodes = []
+    for n in raw_nodes:
+        nid = str(n.get("id", n.get("label", "")))
+        if not nid:
+            continue
+        nodes.append(
+            {
+                "id": nid,
+                "label": n.get("label", nid),
+                "file_type": n.get("file_type", "unknown"),
+                "source_file": n.get("source_file", ""),
+                "source_location": n.get("source_location", ""),
+                "community": int(n.get("community", -1)),
+            }
+        )
+    node_ids = {n["id"] for n in nodes}
+
+    edges = []
+    for e in raw_edges:
+        src = e.get("_src") or e.get("source")
+        tgt = e.get("_tgt") or e.get("target")
+        if src not in node_ids or tgt not in node_ids:
+            continue
+        edges.append(
+            {
+                "source": src,
+                "target": tgt,
+                "relation": e.get("relation", "related"),
+            }
+        )
+
+    synapses = []
+    store = mind.synapses
+    if store is not None:
+        try:
+            for a, b, weight, count in store.edges(
+                min_weight=synapse_min_weight, limit=synapse_limit
+            ):
+                # Synapse ids can include community_* pseudo-nodes that
+                # aren't real graph nodes — keep only edges we can draw.
+                if a in node_ids and b in node_ids:
+                    synapses.append(
+                        {
+                            "source": a,
+                            "target": b,
+                            "weight": round(weight, 4),
+                            "activation_count": count,
+                        }
+                    )
+        except Exception:
+            pass
+
+    return {
+        "project": mind.project_path.name,
+        # Full absolute path so the UI can key per-project state (e.g.
+        # saved canvas layouts) without collisions between two repos
+        # that happen to share a basename.
+        "project_path": str(mind.project_path.resolve()),
+        "nodes": nodes,
+        "edges": edges,
+        "synapses": synapses,
+        "stats": {
+            "nodes": len(nodes),
+            "edges": len(edges),
+            "synapses": len(synapses),
+        },
+    }

--- a/neuralmind/recent_queries.py
+++ b/neuralmind/recent_queries.py
@@ -1,0 +1,198 @@
+"""
+recent_queries.py — the recent-queries JSONL replay log
+========================================================
+
+Persistence for the graph-view UI's 'Replay last query' panel: each
+query appends one JSON line describing the retrieval state the agent
+actually received. Extracted from ``core.py``; the consent gate
+(``NEURALMIND_MEMORY``) stays with the caller in
+:meth:`neuralmind.core.NeuralMind._record_recent_query`, so this module
+only ever sees writes the user has opted into.
+
+Stdlib-only, like the rest of the synapse layer's support modules.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .context_selector import ContextResult
+
+# Serializes recent-queries appends within this process. POSIX O_APPEND
+# already makes single-line appends atomic, but Windows' CRT implements
+# append mode as a separate seek-to-end + write, so two handles writing
+# concurrently can interleave and lose lines.
+_APPEND_LOCK = threading.Lock()
+
+try:
+    import msvcrt  # Windows-only: cross-process advisory lock below.
+except ImportError:  # pragma: no cover - POSIX
+    msvcrt = None  # type: ignore[assignment]
+
+
+def _lock_byte0(fd: int) -> bool:
+    """Best-effort cross-process mutex on byte 0 of *fd* (Windows only).
+
+    POSIX writers don't need it (O_APPEND is atomic) and use flock for
+    compaction instead; on Windows both the appender and the compactor
+    take this same region so a compaction's read-truncate-rewrite can't
+    drop a concurrent process's append. Non-blocking with a short retry
+    so a stuck holder can never stall a query.
+    """
+    if msvcrt is None:
+        return False
+    import time as _time
+
+    for _ in range(50):  # ~50ms worst case
+        try:
+            os.lseek(fd, 0, os.SEEK_SET)
+            msvcrt.locking(fd, msvcrt.LK_NBLCK, 1)
+            return True
+        except OSError:
+            _time.sleep(0.001)
+    return False
+
+
+def _unlock_byte0(fd: int) -> None:
+    if msvcrt is None:
+        return
+    try:
+        os.lseek(fd, 0, os.SEEK_SET)
+        msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
+    except OSError:
+        pass
+
+
+def append_query_record(
+    log_path: Path,
+    question: str,
+    result: ContextResult,
+    *,
+    max_entries: int,
+    compact_bytes: int,
+) -> None:
+    """Append the last query's retrieval state to the recent-queries log.
+
+    Powers the graph-view UI's 'Replay last query' panel: a human can
+    see which nodes the agent actually received, including ids the
+    UI can highlight on the canvas. Always on (local-only data,
+    readable only through the auth-gated server).
+
+    The hot path is a single-line O_APPEND write. On POSIX that is
+    atomic across processes by itself (writes < PIPE_BUF don't
+    tear); Windows' CRT implements append as seek-to-end + write,
+    so writes are additionally serialized by a process-local lock
+    and a best-effort cross-process byte-range lock. Trimming back
+    to ``max_entries`` is a lazy compaction step gated by file
+    size and protected by the same locks — see :func:`compact_log`.
+    """
+    try:
+        hits = []
+        for hit in (getattr(result, "top_search_hits", []) or [])[:12]:
+            meta = hit.get("metadata") or {}
+            hits.append(
+                {
+                    "id": str(hit.get("id", "")),
+                    "label": meta.get("label", hit.get("id", "")),
+                    "source_file": meta.get("source_file", ""),
+                    "score": round(float(hit.get("score", 0.0)), 3),
+                }
+            )
+        record = {
+            "ts": datetime.now(timezone.utc).isoformat(),
+            "question": question,
+            "tokens": int(getattr(getattr(result, "budget", None), "total", 0)),
+            "reduction_ratio": round(float(getattr(result, "reduction_ratio", 0.0)), 2),
+            "layers_used": list(getattr(result, "layers_used", [])),
+            "communities_loaded": list(getattr(result, "communities_loaded", [])),
+            "top_hits": hits,
+        }
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        encoded = (json.dumps(record, sort_keys=True) + "\n").encode("utf-8")
+        with _APPEND_LOCK:
+            fd = os.open(str(log_path), os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o644)
+            locked = False
+            try:
+                locked = _lock_byte0(fd)
+                os.write(fd, encoded)
+            finally:
+                if locked:
+                    _unlock_byte0(fd)
+                os.close(fd)
+    except Exception:
+        # Recording must never block the actual query.
+        return
+    try:
+        compact_log(log_path, max_entries=max_entries, compact_bytes=compact_bytes)
+    except Exception:
+        pass
+
+
+def compact_log(log_path: Path, *, max_entries: int, compact_bytes: int) -> None:
+    """Trim the recent-queries log back to ``max_entries`` entries.
+
+    Only runs when the file has grown past ``compact_bytes``, so the
+    hot path stays append-only. The read-truncate-rewrite is guarded
+    against another process's append by flock on POSIX and by the
+    byte-0 region lock shared with :func:`append_query_record` on
+    Windows; both are best-effort — worst case is a slightly
+    oversized log file (no data loss).
+    """
+    try:
+        size = log_path.stat().st_size
+    except OSError:
+        return
+    if size <= compact_bytes:
+        return
+    try:
+        import fcntl
+    except ImportError:
+        fcntl = None  # type: ignore[assignment]
+    with _APPEND_LOCK, log_path.open("r+", encoding="utf-8") as f:
+        if fcntl is not None:
+            try:
+                fcntl.flock(f.fileno(), fcntl.LOCK_EX)
+            except OSError:
+                pass
+        locked = _lock_byte0(f.fileno())
+        try:
+            lines = [ln for ln in f if ln.strip()]
+            if len(lines) <= max_entries:
+                return
+            f.seek(0)
+            f.truncate()
+            f.writelines(lines[-max_entries:])
+            f.flush()
+        finally:
+            if locked:
+                _unlock_byte0(f.fileno())
+            if fcntl is not None:
+                try:
+                    fcntl.flock(f.fileno(), fcntl.LOCK_UN)
+                except OSError:
+                    pass
+
+
+def read_recent(log_path: Path, n: int = 20) -> list[dict]:
+    """Return the N most-recent recorded queries, newest first."""
+    if not log_path.exists():
+        return []
+    try:
+        with log_path.open(encoding="utf-8") as f:
+            lines = [line for line in f if line.strip()]
+    except OSError:
+        return []
+    out: list[dict] = []
+    for line in lines[-max(1, n) :]:
+        try:
+            out.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+    out.reverse()
+    return out

--- a/neuralmind/synapse_feedback.py
+++ b/neuralmind/synapse_feedback.py
@@ -1,0 +1,254 @@
+"""
+synapse_feedback.py — the synapse write-path
+=============================================
+
+Feedback signals that feed the associative synapse layer: file-level
+co-activation from the watcher, reuse detection from Edit/Write hooks,
+decay acceleration for deleted files, and Hebbian reinforcement from
+queries. Extracted from ``core.py``; each function takes the
+:class:`~neuralmind.core.NeuralMind` instance and operates through its
+public surface (``mind.synapses``, ``mind.embedder``, ``mind.activate``),
+mirroring the free-function pattern in :mod:`neuralmind.server` and
+:mod:`neuralmind.self_improve`.
+
+Stdlib-only, like the rest of the synapse layer.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .context_selector import ContextResult
+    from .core import NeuralMind
+
+# Language-agnostic identifier tokenizer for reuse detection: we never
+# parse source syntax, only match bare identifiers against graph labels,
+# so this works uniformly across every tree-sitter extractor.
+REUSE_IDENT_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+
+# Graph node file_types that are prose, not symbols — their labels are
+# docstrings/file paths, never identifiers, so they're excluded from the
+# reuse index.
+NON_SYMBOL_FILE_TYPES = frozenset({"rationale", "document"})
+
+
+def symbol_name(label: str) -> str:
+    """Bare identifier for a graph label ("login_endpoint()" -> "login_endpoint").
+
+    Generated graphs label functions with signature punctuation; the code we
+    tokenize yields bare identifiers, so we key the reuse index on the
+    leading identifier of each label to make the two comparable.
+    """
+    m = REUSE_IDENT_RE.search(str(label or ""))
+    return m.group(0) if m else ""
+
+
+def external_symbol_index(mind: NeuralMind) -> dict[str, list[str]]:
+    """Map normalized symbol name -> node ids that define it, across the graph.
+
+    Cached on the mind instance and invalidated when the node count changes
+    (build/reindex), so repeated Edit/Write feedback calls don't re-scan the
+    whole graph each time — per-edit work is then ~O(#tokens), not O(#nodes).
+    Edited-file ownership is filtered at match time, not here.
+    """
+    nodes = getattr(mind.embedder, "nodes", None) or []
+    sig = len(nodes)
+    cached = getattr(mind, "_symbol_index_cache", None)
+    if cached is not None and getattr(mind, "_symbol_index_sig", None) == sig:
+        return cached
+    index: dict[str, list[str]] = {}
+    for n in nodes:
+        if n.get("file_type") in NON_SYMBOL_FILE_TYPES:
+            continue
+        nid = str(n.get("id", ""))
+        if not nid:
+            continue
+        name = symbol_name(n.get("label", ""))
+        if name:
+            index.setdefault(name, []).append(nid)
+    mind._symbol_index_cache = index
+    mind._symbol_index_sig = sig
+    return index
+
+
+def activate_files(mind: NeuralMind, file_paths: list[str], strength: float = 1.0) -> int:
+    """Resolve file paths to graph node ids and feed them as one batch.
+
+    Used by the file watcher: when a cluster of files is edited together,
+    we treat them as having co-fired and let the synapse store strengthen
+    the edges between every node living in those files.
+
+    Two parallel updates run from one call:
+
+    - Undirected co-activation across every node inside the touched
+      files (the existing Hebbian signal).
+    - Directional file-level transitions (``A -> B``) for each
+      consecutive pair in ``file_paths``, so callers can ask
+      ``next_likely(file)`` for what typically follows. *(v0.11.0+)*
+    """
+    if not file_paths:
+        return 0
+    mind._ensure_built()
+
+    store = mind.synapses
+    if store is not None and len(file_paths) >= 2:
+        try:
+            store.record_sequence(file_paths, strength=strength)
+        except Exception:
+            pass
+
+    node_ids: list[str] = []
+    for path in file_paths:
+        try:
+            for node in mind.embedder.get_file_nodes(path):
+                nid = node.get("id")
+                if nid:
+                    node_ids.append(str(nid))
+        except Exception:
+            continue
+    if len(node_ids) < 2:
+        return 0
+    return mind.activate(node_ids, strength=strength)
+
+
+def record_edit_activity(mind: NeuralMind, file_path: str, new_code: str) -> dict:
+    """Learn from an Edit/Write: did the new code reuse existing symbols?
+
+    When an agent edits ``file_path``, identifiers in ``new_code`` that
+    already name a symbol defined *elsewhere* in the graph are treated as
+    a **reuse** signal — the edited file and the reused definitions fired
+    together in one thought, so we reinforce their synapse edges. The
+    existing L2/L3 synapse boost then surfaces those reused nodes more
+    readily on future queries, closing the loop between what got reused
+    and what is worth remembering.
+
+    Symbols ``new_code`` *defines* whose name also exists in another file
+    are reported as possible duplication, but in this MVP that is surfaced
+    only in the return value — not acted on.
+
+    Operates on graph nodes + identifier tokens, never on source syntax,
+    so it is language-agnostic. A **pure side effect**: it never triggers a
+    build (only the cheap graph load via ``get_file_nodes``), and fails open
+    — if the graph isn't available it returns empty rather than pay build
+    cost in a hook. Writes land in the project's active namespace (same as
+    ``activate``). Returns a summary dict for the hook to log and tests to
+    assert on.
+    """
+    empty = {"reused": [], "possible_dupes": [], "pairs": 0}
+    if mind.synapses is None or not file_path or not new_code:
+        return empty
+
+    # Nodes already defined in the edited file. get_file_nodes lazily loads
+    # graph.json (cheap) but never embeds — so no build is forced here.
+    try:
+        file_nodes = mind.embedder.get_file_nodes(file_path)
+    except Exception:
+        file_nodes = []
+    file_node_ids = {str(n.get("id")) for n in file_nodes if n.get("id")}
+
+    index = external_symbol_index(mind)
+    if not index:
+        return empty
+
+    tokens = set(REUSE_IDENT_RE.findall(new_code))
+
+    reused_ids: list[str] = []
+    reused_labels: list[str] = []
+    for name in tokens & index.keys():
+        ext_ids = [i for i in index[name] if i not in file_node_ids]
+        if ext_ids:
+            reused_ids.extend(ext_ids)
+            reused_labels.append(name)
+
+    # Possible duplication: a symbol defined in this file whose name also
+    # exists in another file. Reported only (MVP does not penalize).
+    possible_dupes = sorted(
+        {
+            name
+            for n in file_nodes
+            if n.get("file_type") not in NON_SYMBOL_FILE_TYPES
+            and (name := symbol_name(n.get("label", ""))) in index
+            and any(i not in file_node_ids for i in index[name])
+        }
+    )
+
+    pairs = 0
+    coactivate = list(file_node_ids) + reused_ids
+    if reused_ids and len(coactivate) >= 2:
+        pairs = mind.activate(coactivate, strength=mind.REUSE_FEEDBACK_STRENGTH)
+
+    return {
+        "reused": sorted(set(reused_labels)),
+        "possible_dupes": possible_dupes,
+        "pairs": pairs,
+    }
+
+
+def deactivate_files(mind: NeuralMind, file_paths: list[str]) -> int:
+    """Accelerate synapse decay for nodes belonging to deleted files.
+
+    When a file is removed from the project (rename, refactor, deletion),
+    its graph nodes should lose influence quickly so they stop surfacing in
+    context and spreading activation. Calls ``decay_node`` once per node
+    found in the deleted files — one targeted tick is enough to sink
+    non-LTP edges below the prune threshold within a few normal decay
+    cycles, while LTP-protected edges (heavily-used, long-established)
+    survive and fade gracefully.
+
+    Returns the number of nodes targeted.
+    """
+    if not file_paths:
+        return 0
+    store = mind.synapses
+    if store is None:
+        return 0
+    if not mind._built:
+        return 0
+
+    targeted = 0
+    for path in file_paths:
+        try:
+            for node in mind.embedder.get_file_nodes(path):
+                nid = node.get("id")
+                if nid:
+                    try:
+                        store.decay_node(str(nid))
+                        targeted += 1
+                    except Exception:
+                        pass
+        except Exception:
+            continue
+    return targeted
+
+
+def reinforce_from_query(mind: NeuralMind, question: str, result: ContextResult) -> None:
+    """Hebbian update: nodes co-activated by a query wire together.
+
+    Reuses the search hits the selector already fetched for L2/L3 so
+    we don't pay for a third round trip to the embedder. Falls back
+    to a fresh search only if the result didn't surface any hits
+    (e.g. an L0/L1-only call).
+    """
+    store = mind.synapses
+    if store is None:
+        return
+    hits = result.top_search_hits
+    if not hits:
+        try:
+            hits = mind.embedder.search(question, n=6)
+        except Exception:
+            return
+    node_ids: list[str] = []
+    for hit in hits[:6]:
+        nid = hit.get("id")
+        if nid:
+            node_ids.append(str(nid))
+    for comm_id in result.communities_loaded or []:
+        node_ids.append(f"community_{comm_id}")
+    if len(node_ids) >= 2:
+        try:
+            store.reinforce(node_ids)
+        except Exception:
+            pass

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -47,20 +47,6 @@ class TestNeuralMindInit:
         mind = NeuralMind(str(temp_project))
         assert isinstance(mind.embedder, EmbeddingBackend)
 
-    def test_init_accepts_deprecated_enable_reranking(self, temp_project):
-        """The deprecated enable_reranking kwarg is accepted (no TypeError).
-
-        The learned_patterns reranker was removed in favor of the synapse
-        layer; the kwarg is ignored but still part of the public signature so
-        existing callers don't break.
-        """
-        from neuralmind import NeuralMind
-
-        mind = NeuralMind(str(temp_project), enable_reranking=False)
-        # Stored for backward compat, but it no longer gates any behavior.
-        assert mind.enable_reranking is False
-
-
 class TestNeuralMindBuild:
     """Tests for NeuralMind build functionality."""
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -47,6 +47,7 @@ class TestNeuralMindInit:
         mind = NeuralMind(str(temp_project))
         assert isinstance(mind.embedder, EmbeddingBackend)
 
+
 class TestNeuralMindBuild:
     """Tests for NeuralMind build functionality."""
 


### PR DESCRIPTION
## Summary

Acts on external code-review feedback that flagged `core.py` (1811 lines) as the highest-risk file in the package. Three commits:

1. **`refactor: drop IR_FILENAME class-attribute aliasing`** — deletes the confusing `IR_FILENAME = IR_FILENAME` / `IR_META_FILENAME = IR_META_FILENAME` class attributes; the `ir_path`/`ir_meta_path` properties read the module constants directly. Nothing outside `core.py` referenced them.

2. **`refactor!: remove deprecated enable_reranking parameter`** ⚠️ **BREAKING** — the parameter had been accepted-and-ignored since v0.25.0 and the attribute it set was never read. Callers passing `enable_reranking` now get a `TypeError`. No call site in the repo passes it; every caller passes only the project path positionally, so no positional shift. The backward-compat pin test is deleted with it.

3. **`refactor: extract synapse feedback, querying, and recent-queries modules from core`** — `core.py` goes 1811 → 1220 lines. Three new stdlib-only modules of free functions taking the `NeuralMind` instance (the established pattern from `server.py`/`self_improve.py`/`memory.py`):
   - `neuralmind/synapse_feedback.py` — the synapse write-path: file co-activation, Edit/Write reuse detection, deleted-file decay, query-time Hebbian reinforcement
   - `neuralmind/recent_queries.py` — the JSONL replay log incl. the Windows msvcrt byte-0 / POSIX flock locking, moved wholesale and unchanged
   - `neuralmind/querying.py` — read-side formatting: hybrid highlights, file skeleton view, graph-view payload

   `NeuralMind` keeps thin delegating methods, so the public API and every `neuralmind.core.*` patch point (`is_memory_logging_enabled`, `log_query_event`, `SynapseStore`, `NeuralMind`) are unchanged. The consent gate and `_ensure_built()` plumbing stay in core; `RECENT_QUERIES_*` stay class attrs and flow into the moved functions as parameters so monkeypatched values still apply.

## Notes for reviewers

- This branch also carries `74ebe45` (`docs: refresh ROADMAP.md to v0.41`), which predates it and isn't on `origin/main` yet — it rides along until whichever branch carrying it merges first.
- `docs/wiki/Learning-Guide.md:311` and `docs/about.html:493` now describe removed behavior (`enable_reranking`); a follow-up docs pass is queued rather than bundled here. Historical release notes are intentionally untouched.
- `CHANGELOG.md` untouched — release-please writes it from the commit messages (the `BREAKING CHANGE:` footer on commit 2 carries the break).
- Follow-up from the same review, next branch: split `server.py` into handlers/auth/sse/routes.

## Test plan

- Full suite passes except `test_hooks_check_warn_when_none` and `test_detect_clients_with_fake_home`, which fail identically **without** these changes (local-machine Claude config leaks into their fake-home setup) — pre-existing, not regressions.
- `ruff check` / `black --check` clean on every touched file.
- Import-contract smoke: `NeuralMind`, `create_mind`, `GraphNotBuiltError`, `validate_project` all importable from `neuralmind.core`; `neuralmind.NeuralMind` identity preserved.
- End-to-end against the sample fixture: build → query (72x reduction) → replay log written (`recent_queries.py`) → 10 synapse edges reinforced (`synapse_feedback.py`) → skeleton renders (`querying.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)