### PR TITLE
docs: fix audit-log path drift (documented path doesn't exist)

### DIFF
--- a/docs/COMPLIANCE-SUMMARY.md
+++ b/docs/COMPLIANCE-SUMMARY.md
@@ -13,7 +13,7 @@
 | Data leaves your machine | **Never** — fully local, no telemetry, no remote logging, no update checks |
 | Code uploaded to a cloud provider | **No** — all embeddings generated and stored locally via ChromaDB |
 | Outbound network at runtime | **None** — install-time only; see [air-gapped walkthrough](use-cases/air-gapped.md) |
-| Audit trail | **Built-in** — `.neuralmind/audit/` access log + query provenance |
+| Audit trail | **Built-in** — `.neuralmind/audit_events.jsonl` append-only log + query provenance |
 | Software Bill of Materials | **Auto-generated** — CycloneDX JSON attached to every tagged release |
 | License | **MIT** — full source review, no vendor lock-in |
 | Source available | **Yes** — entire codebase on GitHub, every claim verifiable |
@@ -27,7 +27,7 @@ The four NIST AI RMF functions and the evidence NeuralMind provides for each:
 ### GOVERN — oversight, accountability, policies
 
 - **Role-based access control (RBAC)** with documented user/permission model — see `SECURITY-GUIDE.md` §Access Control
-- **Access audit trail** at `.neuralmind/audit/access.log` — every read, query, and export logged with timestamp + actor + result
+- **Access audit trail** at `.neuralmind/audit_events.jsonl` — every query, search, build, and MCP call logged with timestamp, action, status, and details (the RBAC actor is captured at the MCP boundary)
 - **Query provenance** — every retrieval result is traceable to the specific code nodes that produced it (no black-box "trust us")
 - **Auto-generated NIST AI RMF report:** `neuralmind audit-report . --compliance nist-ai-rmf --output report.md`
 
@@ -57,7 +57,7 @@ The five Trust Service Criteria categories and where NeuralMind provides evidenc
 
 | SOC 2 Criterion | NeuralMind evidence |
 |---|---|
-| **CC6.1 Access Control** | RBAC implementation, `.neuralmind/audit/access.log` |
+| **CC6.1 Access Control** | RBAC implementation, `.neuralmind/audit_events.jsonl` |
 | **CC7.1 Monitoring** | Query logging, performance metrics, live activity feed |
 | **CC7.2 System Monitoring** | `/healthz` endpoint (v0.8+), error tracking, structured logging |
 | **A1.1 Processing Integrity** | Index validation on every build, audit trail of state changes |
@@ -78,7 +78,7 @@ NeuralMind processes code. Code can contain comments referencing names, emails, 
 - **Storage limitation** — the synapse store decays unused edges automatically (configurable via `NEURALMIND_SYNAPSE_DECAY_HALF_LIFE`)
 - **Right to erasure** — synapse store and audit log are local files; `rm -rf .neuralmind/` is a complete erasure path
 - **Data residency** — entirely under operator control; no cross-border transfers initiated by NeuralMind
-- **Pseudonymisation** — audit log actor field is operator-provided; can be a hashed token rather than a username
+- **Pseudonymisation** — audit log actor field is system-level on local queries and operator-supplied at the MCP boundary; can be a hashed token rather than a username
 - **Breach notification** — local files, no external surface area, no third-party processor
 
 NeuralMind does **not** act as a data processor in the GDPR sense — there is no external entity to which data is transferred. The operator is the sole controller.
@@ -129,7 +129,7 @@ Choose the strictest your operational needs allow — all four use the same Neur
 | Claim | How to verify yourself |
 |---|---|
 | "No outbound network at runtime" | `ss -tnp \| grep python` while running `neuralmind query` — no connections |
-| "Audit trail captures every query" | `cat .neuralmind/audit/access.log` after a session |
+| "Audit trail captures every query" | `cat .neuralmind/audit_events.jsonl` after a session |
 | "SBOM covers the full dep tree" | Run `syft .` on a local install, diff against the released SBOM |
 | "100% local processing" | Pull internet, `neuralmind build && neuralmind query .` still works |
 | "MIT licensed, full source" | `https://github.com/dfrostar/neuralmind` — every file readable |

--- a/docs/DEPLOYMENT-GUIDE.md
+++ b/docs/DEPLOYMENT-GUIDE.md
@@ -489,7 +489,7 @@ mkdir -p "$BACKUP_DIR"
 pg_dump -U neuralmind neuralmind > "$BACKUP_DIR/index.sql.gz"
 
 # Backup audit logs
-cp -r .neuralmind/audit "$BACKUP_DIR/audit"
+cp .neuralmind/audit_events.jsonl "$BACKUP_DIR/"
 
 # Backup code graph
 cp graphify-out/graph.json "$BACKUP_DIR/"

--- a/docs/SECURITY-GUIDE.md
+++ b/docs/SECURITY-GUIDE.md
@@ -94,7 +94,7 @@ class AuthenticatedMCPServer:
         self.security = MCPSecurityMiddleware(
             project_path=project_path,
             enforce_rbac=True,
-            audit_log_path=".neuralmind/audit/access.log"
+            audit_log_path=".neuralmind/audit_events.jsonl"
         )
     
     async def query(self, question: str, user: User) -> str:


### PR DESCRIPTION
## The problem

The compliance/security docs told auditors the audit trail lives at **`.neuralmind/audit/access.log`**, but the code (`neuralmind/audit.py`, `AUDIT_FILE_NAME`) actually writes **`.neuralmind/audit_events.jsonl`**. `COMPLIANCE-SUMMARY.md` even instructs a reviewer to run `cat .neuralmind/audit/access.log` — which returns nothing, because that file doesn't exist.

This is a credibility landmine on the exact page CISOs/compliance leads read: follow our documented verify step, find an empty/missing path, lose trust.

## Verified against the code first

The core claim we make across the site/posts — **"every query logged with provenance"** — is **accurate**: `core.py` `query()` and `search()` both call `_emit_audit` on every call, logging the question, search hits, and token budget (plus build, backend-switch, and the MCP security boundary). Only the **path** and the **per-actor** wording were wrong.

## Fixes

- **`COMPLIANCE-SUMMARY.md`** — correct the path in 4 places (at-a-glance table, GOVERN bullet, CC6.1 row, verify-yourself table); reword the GOVERN line to describe what's actually logged (system-level actor on local queries; RBAC actor at the MCP boundary); soften the GDPR pseudonymisation actor claim to match.
- **`SECURITY-GUIDE.md`** — fix `audit_log_path` in the example snippet.
- **`DEPLOYMENT-GUIDE.md`** — fix the backup command to copy the real file (`.neuralmind/audit_events.jsonl`), not a nonexistent `.neuralmind/audit/` directory.

No behavior change; docs-only, bringing the compliance surface in line with the code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01M99GJxqKdKB2e7tafZ73H2)_