### PR TITLE
docs: purge forbidden absolute privacy claims (+CI guard) & document git-worktree workflow (#316)

### DIFF
--- a/PROJECT_LINKEDIN_NEURALMIND.md
+++ b/PROJECT_LINKEDIN_NEURALMIND.md
@@ -54,7 +54,7 @@ Establish NeuralMind's commercial presence and CFO consulting motion — from Li
 | Day | Post # | Angle | Hook |
 |-----|--------|-------|------|
 | MON | 1 | CFO Thought Leadership | Benchmarks are in — here's what they mean |
-| TUE | 2 | Zero Egress / Security | Your code never leaves your machine |
+| TUE | 2 | Minimal Egress / Security | NeuralMind makes zero network calls of its own — local audit trail as SOC 2 evidence |
 | WED | 3 | Consulting Pattern | "We approved $200K for AI — is it making us faster?" |
 | THU | 4 | Building in Public | Obsessed with context quality over quantity |
 | FRI | 5 | Soft CTA + Value | 40-70x reduction + defensible AI bill |
@@ -66,7 +66,7 @@ Establish NeuralMind's commercial presence and CFO consulting motion — from Li
 | Step | What | Priority | ETA |
 |------|------|----------|-----|
 | **1** | Generate logo via Gemini (prompt ready) | **High** | Today |
-| **2** | Post #2 (zero egress / security) | **High** | Tomorrow |
+| **2** | Post #2 (minimal egress / security) | **High** | Tomorrow |
 | **3** | Register `neuralmind.dev` domain + wire to GitHub Pages | **Medium** | This week |
 | **4** | Replace GitHub Pages "NeuralMind" text with logo | **Medium** | After logo gen |
 | **5** | Cold outreach to 10 VP Eng at mid-market startups | **Medium** | This week |

--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 [![Self-benchmark](https://github.com/dfrostar/neuralmind/actions/workflows/ci-benchmark.yml/badge.svg?branch=main)](https://github.com/dfrostar/neuralmind/actions/workflows/ci-benchmark.yml)
-[![Local-First](https://img.shields.io/badge/Local--First-No%20Exfiltration-brightgreen.svg)](#-security--compliance)
+[![Local-First](https://img.shields.io/badge/Local--First-No%20Telemetry-brightgreen.svg)](#-security--compliance)
 [![Offline](https://img.shields.io/badge/Offline-100%25-blue.svg)](#-security--compliance)
 
 **Persistent memory and context compression for AI coding agents.**
 
 > Your AI coding agent learns your codebase the way a senior engineer would — what files go together, what you usually edit next, what patterns matter — and NeuralMind **compresses tool output before the model reads it**, so the agent spends tokens only on what matters. The memory persists across sessions and surfaces automatically. No MCP tool call required: NeuralMind writes a `SYNAPSE_MEMORY.md` file that Claude Code loads on every session start, so the agent boots with what it's learned about your code already in context.
 
-> Works with Claude Code (including Claude Fable 5), Cursor, Cline, Continue, and any MCP-compatible agent. 100% local — your code never leaves your machine. The more capable the model, the more every saved token is worth, so context compression and persistent memory pay off more on a frontier model like Fable 5. (Side effect: ~5–10× cheaper agent sessions because the agent stops re-loading context it already understood. [Benchmarks below ↓](#-benchmarks).)
+> Works with Claude Code (including Claude Fable 5), Cursor, Cline, Continue, and any MCP-compatible agent. NeuralMind itself runs 100% locally — zero network calls of its own, no telemetry. The more capable the model, the more every saved token is worth, so context compression and persistent memory pay off more on a frontier model like Fable 5. (Side effect: ~5–10× cheaper agent sessions because the agent stops re-loading context it already understood. [Benchmarks below ↓](#-benchmarks).)
 
 ## Why NeuralMind — four benefits, each backed by an eval you can run
 
@@ -194,8 +194,8 @@ The headline you can stand on: **retrieval reduction is measured in CI on every 
 
 **For enterprises and regulated industries:**
 
-- **100% Local Processing** – Your code never leaves your machine. All embeddings are generated and stored locally (the default turbovec/ONNX backend; ChromaDB optional).
-- **No External APIs** – NeuralMind runs completely offline. No cloud services, no telemetry, no data exfiltration.
+- **100% Local Processing** – NeuralMind makes zero network calls of its own and sends no telemetry; all embeddings are generated and stored locally (the default turbovec/ONNX backend; ChromaDB optional).
+- **No External APIs** – NeuralMind runs completely offline: no cloud services, no telemetry, no calls home. (It's a local context layer that feeds your agent — your agent still sends its chosen slice to its model, so NeuralMind minimizes egress, it doesn't eliminate it.)
 - **Explainable AI** – Every context decision is auditable. Know exactly which code was retrieved (Extracted) vs. inferred by the model.
 - **Open-Source & MIT Licensed** – Full transparency. No hidden clauses, no vendor lock-in. Audit the code yourself.
 - **GDPR/HIPAA-Friendly** – Process sensitive code without compliance concerns. All data stays under your control.
@@ -1811,7 +1811,7 @@ NeuralMind benchmarks itself on every pull request. A hermetic fixture (`tests/f
 
 ### Community benchmarks
 
-Real-world numbers submitted by users. Your code never leaves your machine — you submit a PR (or an issue, which a maintainer converts to a PR) with only the numbers. CI validates every entry against the schema and re-renders this table automatically.
+Real-world numbers submitted by users. You submit only the numbers, not your code — a PR (or an issue a maintainer converts to a PR) carrying just the metrics. CI validates every entry against the schema and re-renders this table automatically.
 
 <!-- COMMUNITY-BENCHMARKS:START -->
 | Project | Lang | Nodes | Wakeup | Avg Query | Reduction | Model | Submitted |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,7 +5,7 @@
 NeuralMind is designed with **enterprise security as a first-class concern**:
 
 - **No external API calls** – all processing happens locally on your machines
-- **No data exfiltration** – your code never leaves your development environment
+- **No calls home** – NeuralMind makes no external network calls and sends no telemetry; it adds nothing to what your agent transmits
 - **Fully auditable** – open-source code, MIT license, complete transparency
 - **Zero telemetry** – no usage tracking, no analytics, no hidden data collection
 - **Compliance-ready** – works with GDPR, HIPAA, and other regulatory frameworks
@@ -18,7 +18,7 @@ NeuralMind is designed with **enterprise security as a first-class concern**:
 Security fixes target the latest released minor version. Older 0.x
 minors are unsupported once a newer minor ships — the practical
 guidance is "stay on latest." Because NeuralMind is local-first with
-no exfiltration surface, the patch urgency for older versions is
+no network surface of its own, the patch urgency for older versions is
 typically low.
 
 | Version  | Status              | Notes                                        |
@@ -261,9 +261,9 @@ NeuralMind is **designed to support** standard enterprise compliance requirement
 - **Business Associate Agreements**: No BAA needed (no external vendors processing your data)
 
 ### ✅ SOC 2 Type II
-- **Security**: Local processing, no exfiltration, encrypted at rest (your choice)
+- **Security**: Local processing, no network calls of its own, encrypted at rest (your choice)
 - **Availability**: No dependencies on external services for core functionality
-- **Confidentiality**: No data leaves your organization
+- **Confidentiality**: NeuralMind stores and processes locally and makes no external calls of its own
 - **Integrity**: Deterministic, reproducible indexing from your source code
 - **Privacy**: No collection, no analytics, no tracking
 

--- a/docs/BUSINESS-CASE.md
+++ b/docs/BUSINESS-CASE.md
@@ -322,7 +322,7 @@ Skeptical? Each row of this table is a single command:
 | The retrieval reduction claim | `bash scripts/demo.sh` | 5.5× on the fixture |
 | The CI claim | View any PR's [self-benchmark comment](https://github.com/dfrostar/neuralmind/pulls?q=is%3Apr) | 6.1× on the same fixture |
 | The "works on my code" claim | `neuralmind benchmark . --contribute` | YOUR ratio, YOUR tokens, YOUR dollar estimate |
-| The "no data leaves your machine" claim | Read [`SECURITY.md`](../SECURITY.md), audit dependencies (chromadb, mcp, pyyaml — all local-only), and run with network disabled (`unshare -n bash scripts/demo.sh` on Linux, or block on a firewall) — the demo completes after the first-run model download | local-only at runtime, not just at install |
+| The "NeuralMind makes no network calls of its own" claim | Read [`SECURITY.md`](../SECURITY.md), audit dependencies (chromadb, mcp, pyyaml — all local-only), and run with network disabled (`unshare -n bash scripts/demo.sh` on Linux, or block on a firewall) — the demo completes after the first-run model download | local-only at runtime, not just at install |
 | The "incremental updates work" claim | `neuralmind build . --force` then `neuralmind build .` | second run reports ~all skipped |
 | The "composes with prompt caching" claim | Run any agent with NeuralMind's compressed Read output through your normal cached prompt — observe lower input tokens at cache reads | Math holds |
 

--- a/docs/ENTERPRISE.md
+++ b/docs/ENTERPRISE.md
@@ -13,7 +13,7 @@ for internal conversations; the actual numbers come from running
 
 **What NeuralMind offers:**
 - Every recommendation is traceable to extracted code (auditable, not guessed at).
-- Runs 100% on-premise — no cloud, no data transfer, zero exfiltration risk.
+- Runs 100% on-premise — no cloud, no telemetry, no network calls of its own.
 - Compatible with GDPR, HIPAA, SOC 2, and ISO 27001 deployment patterns. (NeuralMind itself isn't certified; the architecture supports certification of the deployment.)
 - Explainability by design — you can see which code fed each decision.
 

--- a/docs/NEXT-RELEASE-PLAN.md
+++ b/docs/NEXT-RELEASE-PLAN.md
@@ -238,7 +238,7 @@ portable-format design (§4, v0.16) and the enterprise sequencing (§5).
   they're per-user. That's a durable niche.
 - **It stays local-first.** A git-committed, human-reviewable `SYNAPSE_MEMORY.md` /
   synapse export means the team's learned map of the codebase travels in the repo,
-  reviewed in PRs — **no SaaS, no server, no exfiltration.** Consistent with the
+  reviewed in PRs — **no SaaS, no server, no calls home.** Consistent with the
   headline promise.
 - **It compounds onboarding value.** "New hire's agent boots with the team's
   accumulated map of what-goes-with-what" is a concrete, searchable workflow and a

--- a/docs/SECURITY-GUIDE.md
+++ b/docs/SECURITY-GUIDE.md
@@ -20,7 +20,7 @@
 
 ### Core Principles
 
-1. **Zero Data Exfiltration** — Your code never leaves your infrastructure
+1. **No Calls Home** — NeuralMind makes no external network calls; it adds nothing to what your agent sends its model
 2. **Local-First Processing** — All embeddings computed locally
 3. **Explainability** — Every decision is auditable
 4. **Least Privilege** — Users get minimum permissions needed

--- a/docs/about.html
+++ b/docs/about.html
@@ -136,7 +136,7 @@
                 <li><strong>v0.16 — Anticipate.</strong> Promote directional "what you edit next" recall to a first-class agent surface, and ship a portable memory format so one learned map serves Claude Code, Cursor, Cline, and Continue.</li>
             </ul>
             <h3>A decision we've made for the team story</h3>
-            <p>Committable, opt-in <strong>team/shared memory</strong> is approved in principle: a reviewed team baseline that travels in your git repo (no SaaS, no exfiltration), overlaid by each developer's private personal layer. Its day-one onboarding lift will be <em>measured</em> by the v0.13 harness before the design is locked — we sign off on data, not assertion.</p>
+            <p>Committable, opt-in <strong>team/shared memory</strong> is approved in principle: a reviewed team baseline that travels in your git repo (no SaaS, no calls home), overlaid by each developer's private personal layer. Its day-one onboarding lift will be <em>measured</em> by the v0.13 harness before the design is locked — we sign off on data, not assertion.</p>
             <p><a href="https://github.com/dfrostar/neuralmind/blob/main/docs/NEXT-RELEASE-PLAN.md">Read the full next-release plan &amp; feature map →</a> · <a href="https://github.com/dfrostar/neuralmind/blob/main/ROADMAP.md">Roadmap →</a></p>
         </div>
     </section>
@@ -889,7 +889,7 @@
 
             <h3>Enterprise Ready</h3>
             <ul>
-                <li>✅ <strong>100% local & offline</strong> — No cloud, no telemetry, zero data exfiltration</li>
+                <li>✅ <strong>100% local & offline</strong> — No cloud, no telemetry, no calls home</li>
                 <li>✅ <strong>NIST AI RMF audit trail</strong> — Full query provenance, compliance reporting</li>
                 <li>✅ <strong>Open source & MIT licensed</strong> — No vendor lock-in, full transparency</li>
                 <li>✅ <strong>Works everywhere</strong> — Claude Code, Cursor, ChatGPT, Gemini, local LLMs</li>
@@ -990,7 +990,7 @@
             <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); gap: 2rem; margin: 2rem 0;">
                 <div style="padding: 1.5rem; border-left: 4px solid #667eea; background: #f9f9f9;">
                     <strong>Privacy First</strong>
-                    <p>Your code stays local. Zero cloud calls, zero telemetry, zero data exfiltration.</p>
+                    <p>NeuralMind runs entirely local. Zero cloud calls, zero telemetry, no calls home.</p>
                 </div>
                 <div style="padding: 1.5rem; border-left: 4px solid #667eea; background: #f9f9f9;">
                     <strong>Transparency</strong>

--- a/docs/comparisons/context-engineering-stack.md
+++ b/docs/comparisons/context-engineering-stack.md
@@ -25,7 +25,7 @@ NeuralMind functions as a local-first semantic memory engine designed to model a
 
 ### Core Mechanism: AST Parsing and the Hebbian Synapse Layer
 
-NeuralMind employs Abstract Syntax Tree (AST) parsing natively for **Python, TypeScript, and Go** via its built-in tree-sitter backend. Additional language support is available through the optional [graphify](https://github.com/safishamsi/graphify) backend — any language graphify supports feeds the same retrieval pipeline. Relationships are stored in an offline ChromaDB instance (or the dependency-free turbovec backend), providing a secure, local-first boundary that ensures proprietary logic never leaves the developer's environment.
+NeuralMind employs Abstract Syntax Tree (AST) parsing natively for **Python, TypeScript, and Go** via its built-in tree-sitter backend. Additional language support is available through the optional [graphify](https://github.com/safishamsi/graphify) backend — any language graphify supports feeds the same retrieval pipeline. Relationships are stored in an offline ChromaDB instance (or the dependency-free turbovec backend), providing a secure, local-first processing boundary: NeuralMind itself makes no external calls, so it adds no network calls of its own to your agent's workflow.
 
 The system's primary learning signal is the **Hebbian Synapse Layer**. This layer continuously records user queries and file edits, allowing active associations to strengthen while unused connections naturally decay. In the v0.25.0 release, the previous co-occurrence reranker was deprecated and removed; internal benchmarks confirmed it was "runtime-inert on the warm path," adding 0.0 points to accuracy while increasing complexity.
 

--- a/docs/comparisons/vs-cursor-codebase.md
+++ b/docs/comparisons/vs-cursor-codebase.md
@@ -13,7 +13,7 @@ Cursor's `@codebase` feature indexes your repository and injects relevant chunks
 | Retrieval | Chunk similarity | 4-layer progressive disclosure (identity → summary → clusters → search) |
 | Output | Raw chunks into prompt | Structured, token-budgeted context with reduction metrics |
 | Tool-output compression | None | PostToolUse hooks compress Read/Bash/Grep results |
-| Offline | No (Cursor cloud) | Yes — nothing leaves your machine |
+| Offline | No (Cursor cloud) | Yes — NeuralMind makes no network calls of its own |
 | Cost | Bundled in Cursor subscription | Free, local |
 | Install methods | Paid Mac/Windows/Linux IDE installer | `pip` / `pipx` / `uv` / Docker / source — runs anywhere Python does |
 | Adapts to you | No | Yes — a Hebbian synapse layer learns associations from your usage automatically (co-activation with decay), no manual step |

--- a/docs/comparisons/vs-github-copilot.md
+++ b/docs/comparisons/vs-github-copilot.md
@@ -15,7 +15,7 @@ GitHub Copilot is Microsoft/GitHub's AI pair programmer: inline completions in y
 | Model choice | GitHub-provided models | Model-agnostic (Claude, GPT, Gemini, local) |
 | Tool-output compression | No | Yes (PostToolUse hooks) |
 | License | Proprietary, per-seat | MIT, free |
-| Data flow | Code snippets sent to GitHub/OpenAI | Nothing leaves your machine |
+| Data flow | Code snippets sent to GitHub/OpenAI | NeuralMind makes no calls of its own; you pick the agent's model (incl. local) |
 | Cost scaling | Flat subscription | Flat local cost; API costs drop 40–70× |
 | Install methods | Editor extension + GitHub sign-in required | `pip` / `pipx` / `uv` / Docker / source — no sign-in, no account |
 

--- a/docs/launch/r-localllama.md
+++ b/docs/launch/r-localllama.md
@@ -19,7 +19,8 @@ I built a local semantic-memory layer for coding agents — and an honest benchm
 I'm the author of NeuralMind, an open-source local memory layer for AI coding
 agents (Claude Code, Cursor, Cline, any MCP client). Posting it here because it's
 exactly the kind of thing this sub cares about: it runs 100% on-device, the index
-needs no API key, and your code never leaves the machine. The more capable your
+needs no API key, and NeuralMind itself makes zero network calls — no telemetry, no
+calls home. (Pair it with a local model and nothing leaves your box.) The more capable your
 local model, the more each saved token is worth — context compression pays off
 more, not less, as models get better.
 

--- a/docs/use-cases/any-llm.md
+++ b/docs/use-cases/any-llm.md
@@ -82,7 +82,7 @@ Paste, ask, done. Usually ~800–1,100 tokens instead of tens of thousands.
 - The same 4-layer progressive disclosure
 - The same skeleton views (`neuralmind skeleton <file>`)
 - The same semantic search (`neuralmind search . "term"`)
-- Fully local, no data leaves your machine
+- Fully local — NeuralMind makes no network calls of its own
 - Works with any model — OpenAI, Google, Anthropic, Ollama, vLLM, anything
 
 ## Graph view works with any LLM (v0.6.0+)

--- a/docs/use-cases/branch-isolated-memory.md
+++ b/docs/use-cases/branch-isolated-memory.md
@@ -100,6 +100,67 @@ lands in `personal` with identical weights and counts. The single-namespace
 behavior you had *is* the `personal` namespace — that's the compatibility
 contract, and a dedicated no-data-loss test enforces it.
 
+## Git worktrees — share the memory, rebuild the index
+
+`git worktree` gives you several working directories off one repo, each on
+its own branch. NeuralMind's state splits into two kinds that want opposite
+treatment:
+
+| State | Path | Derived from | Worktree strategy |
+|---|---|---|---|
+| **The index** | `graphify-out/` + `.neuralmind/` embeddings | your source | **rebuild per worktree** — cheap, disposable |
+| **The learned memory** | `.neuralmind/synapses.db` | how you work | **share one store** — that's the moat |
+
+Both live under the working directory you point NeuralMind at, and both are
+gitignored (`graphify-out/`, `.neuralmind/synapses.db`). So copying them
+into a new worktree is exactly the trap [#316](https://github.com/dfrostar/neuralmind/issues/316)
+hit: you fork the memory, each copy learns in isolation, and
+`git worktree remove` deletes it. **Don't copy** — do this instead:
+
+**Rebuild the index in each worktree (always).** It's derived from source
+and fast:
+
+```bash
+cd ../my-feature-worktree
+neuralmind build .
+```
+
+**For the memory, pick one:**
+
+*Simplest — centralize on your primary checkout.* Run NeuralMind's hooks /
+daemon / `serve` from your main working tree. Short-lived worktrees get a
+fresh local index; long-term associations keep accruing in the one place
+that isn't going away.
+
+*Shared — symlink the store, let branch namespaces isolate.* Point every
+worktree's synapse store at your main checkout's:
+
+```bash
+cd ../my-feature-worktree
+mkdir -p .neuralmind
+ln -sf /path/to/main-checkout/.neuralmind/synapses.db .neuralmind/synapses.db
+```
+
+This is safe: the store is SQLite in WAL mode, so concurrent worktrees read
+and write it without stepping on each other. And because memory is keyed by
+**namespace** — each worktree is on its own branch, so it writes to
+`branch:<name>` — the shared store keeps every branch's associations
+separate while still blending your `personal` long-term layer underneath
+(the same merged view described above). When you `git worktree remove`, the
+symlink dies; the real store in your main checkout is untouched.
+
+> **Why a symlink and not a path setting?** The store location is fixed at
+> `<project>/.neuralmind/synapses.db` (there's no relocation env var today),
+> and NeuralMind resolves artifact paths by string only — it doesn't follow
+> symlinks when confirming they stay inside the project — so a symlinked
+> `.neuralmind/synapses.db` is the supported way to redirect the store while
+> keeping the path inside the tree.
+
+*Seeded but independent — export/import.* To have a worktree (or a fresh dev
+container) *start* from what your main checkout knows and then learn on its
+own, export a baseline and import it under `shared` — see **Walkthrough 2**
+above. Nothing shared live, nothing to clean up.
+
 ## Related
 
 - [Release Notes v0.24.0](../../RELEASE_NOTES_v0.24.0.md) — full PRD 4 details

--- a/docs/wiki/FAQ.md
+++ b/docs/wiki/FAQ.md
@@ -162,6 +162,33 @@ neuralmind build . --optimize
 
 ---
 
+### "Should I run NeuralMind on one codebase, a monorepo, or across several repos?"
+
+**One codebase is the unit — and where NeuralMind is strongest.** Everything
+is anchored to a single project root: the index in `graphify-out/`, and the
+embeddings plus the learned synapse memory in `.neuralmind/`. One root = one
+index + one namespaced memory.
+
+- **A monorepo counts as one codebase** and is fully supported. Retrieval is
+  community/cluster-aware, and builds are incremental — `neuralmind build .`
+  re-embeds only changed nodes, so build time scales with churn, not repo
+  size. (See the Growing Monorepo use case.)
+- **Several *separate* repos → run one NeuralMind per repo.** There's no
+  cross-repo "workspace" store today; each repo is its own independent brain
+  with its own `.neuralmind/`. Nothing stops you running it on ten repos —
+  they're just ten separate stores, not one unified one.
+- **The memory compounds per codebase.** The synapse layer learns
+  associations from how you actually work *in that repo*, so sustained use on
+  one codebase sharpens recall over time. Splitting attention across many
+  repos means each accumulates less learning signal.
+
+Within a single codebase it's still flexible: memory namespaces isolate
+`branch:<name>` / `personal` / `shared`, multiple agents (Claude Code,
+Cursor, Cline) share the one store, and even multiple git worktrees can share
+it with per-branch isolation.
+
+---
+
 ## Features & Capabilities
 
 ### "Does NeuralMind support my language?"
@@ -215,7 +242,7 @@ exclude_patterns = [
 # 2. Local node_modules / site-packages (yes)
 # 3. External PyPI/npm packages (no, stays private)
 
-# Nothing leaves your machine
+# NeuralMind indexes only local code and makes no calls of its own
 ```
 
 ---

--- a/docs/wiki/FAQ.md
+++ b/docs/wiki/FAQ.md
@@ -265,7 +265,7 @@ neuralmind-mcp . --rbac-enabled \
 - ✅ 100% local processing
 - ✅ No cloud APIs
 - ✅ No telemetry
-- ✅ Zero data exfiltration
+- ✅ No network calls of its own
 
 ---
 
@@ -293,7 +293,7 @@ neuralmind search . "password"  # Should return no results
 - ✅ NIST AI RMF audit trail
 - ✅ SOC 2 compliance mapping
 - ✅ GDPR-compliant (local processing)
-- ✅ HIPAA-friendly (no data exfiltration)
+- ✅ HIPAA-friendly (local processing, no calls home)
 
 ---
 

--- a/tests/test_docs_claims.py
+++ b/tests/test_docs_claims.py
@@ -1,0 +1,130 @@
+"""Guard the published surfaces against forbidden absolute claims.
+
+NeuralMind is a *local context layer that feeds an AI coding agent*. The
+agent still sends its selected slice to its model, so NeuralMind minimizes
+egress — it does not eliminate it. Absolute privacy/compliance claims
+("your code never leaves your machine", "zero exfiltration", "SOC 2
+certified") are therefore inaccurate and repeatedly leaked back into the
+docs during release passes (they get copied from one surface to the next).
+
+This test is the backstop: it scans the *published* claim surfaces (the
+live docs site + README + security/compliance guides) and fails if any
+forbidden absolute reappears. It is intentionally stdlib-only and keyed to
+whole phrases, not bare words, so accurate copy — "no telemetry", "no
+network calls of its own", "air-gap installable", "SOC 2-ready posture" —
+keeps passing.
+
+If you are adding a legitimate use of one of these words, phrase it as what
+NeuralMind *itself* does (no calls of its own / no telemetry) rather than as
+an absolute about the whole agent workflow.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+# Explicit list of files + globs that are actually published to users: the
+# live docs site, the README, and the security/compliance guides CISOs read.
+# Internal planning notes and unpublished drafts (docs/launch, docs/plans,
+# docs/prd, docs/market-research, docs/notebooklm, PROJECT_LINKEDIN…) are
+# deliberately excluded — they are working material, not live claims.
+PUBLISHED_FILES = (
+    "README.md",
+    "SECURITY.md",
+    "docs/index.html",
+    "docs/about.html",
+    "docs/COMPLIANCE-SUMMARY.md",
+    "docs/SECURITY-GUIDE.md",
+    "docs/DEPLOYMENT-GUIDE.md",
+    "docs/ENTERPRISE.md",
+    "docs/BUSINESS-CASE.md",
+)
+PUBLISHED_GLOBS = (
+    "docs/comparisons/*.md",
+    "docs/use-cases/*.md",
+    "docs/wiki/*.md",
+)
+
+# Each entry: (compiled pattern, why it's forbidden / what to say instead).
+# Patterns target whole misleading phrases, case-insensitive.
+FORBIDDEN = [
+    (
+        re.compile(r"\b(code|logic|data)\s+never\s+leaves?\b", re.IGNORECASE),
+        "Absolute privacy claim — the agent still egresses its chosen slice. "
+        "Say what NeuralMind itself does: 'makes no network calls of its own'.",
+    ),
+    (
+        re.compile(r"\bnever\s+leaves?\s+(your|the)\s+(machine|infrastructure|environment|network|organi[sz]ation)\b", re.IGNORECASE),
+        "Absolute privacy claim about the whole workflow — inaccurate. "
+        "Scope the claim to NeuralMind's own behavior.",
+    ),
+    (
+        re.compile(r"\bno\s+data\s+leaves?\s+your\b", re.IGNORECASE),
+        "Absolute claim — reword to NeuralMind's own local processing.",
+    ),
+    (
+        re.compile(r"\b(zero|no)\s+(data\s+)?exfiltration\b", re.IGNORECASE),
+        "Absolute exfiltration claim. Use 'no telemetry / no calls home'.",
+    ),
+    (
+        re.compile(r"\bexfiltration\s+risk\b", re.IGNORECASE),
+        "Implies the workflow can't exfiltrate — it can (the agent egresses). "
+        "Describe NeuralMind's own zero network surface instead.",
+    ),
+    (
+        re.compile(r"\b(zero|no)\s+(data\s+)?egress\b", re.IGNORECASE),
+        "Absolute egress claim. NeuralMind minimizes egress, doesn't eliminate it.",
+    ),
+    (
+        re.compile(r"\bfully\s+air[-\s]?gapped\b", re.IGNORECASE),
+        "Overclaim. 'air-gap installable' is the accurate phrasing.",
+    ),
+    (
+        re.compile(r"\bsoc[-\s]?2[-\s]*(compliant|certified)\b", re.IGNORECASE),
+        "NeuralMind is not certified. Use 'SOC 2-ready posture / evidence for your review'.",
+    ),
+    (
+        re.compile(r"\bzero\s+compliance\s+risk\b", re.IGNORECASE),
+        "Overclaim. Say the architecture supports certification of the deployment.",
+    ),
+]
+
+
+def _published_paths() -> list[Path]:
+    paths: list[Path] = []
+    for rel in PUBLISHED_FILES:
+        p = REPO_ROOT / rel
+        if p.exists():
+            paths.append(p)
+    for pattern in PUBLISHED_GLOBS:
+        paths.extend(sorted(REPO_ROOT.glob(pattern)))
+    return paths
+
+
+def test_published_surfaces_have_no_forbidden_absolute_claims() -> None:
+    violations: list[str] = []
+    for path in _published_paths():
+        text = path.read_text(encoding="utf-8", errors="replace")
+        for lineno, line in enumerate(text.splitlines(), start=1):
+            for pattern, reason in FORBIDDEN:
+                m = pattern.search(line)
+                if m:
+                    rel = path.relative_to(REPO_ROOT)
+                    violations.append(
+                        f"{rel}:{lineno}: forbidden claim {m.group(0)!r} — {reason}"
+                    )
+    assert not violations, (
+        "Forbidden absolute claim(s) found on published surfaces "
+        "(NeuralMind minimizes egress, it does not eliminate it):\n  "
+        + "\n  ".join(violations)
+    )
+
+
+def test_guard_actually_matches_a_known_bad_phrase() -> None:
+    # Sanity: the guard must trip on the canonical bad phrase, so a future
+    # refactor can't neuter it into a silent no-op.
+    bad = "100% local — your code never leaves your machine."
+    assert any(p.search(bad) for p, _ in FORBIDDEN)

--- a/tests/test_docs_claims.py
+++ b/tests/test_docs_claims.py
@@ -69,6 +69,11 @@ FORBIDDEN = [
         "Absolute claim — reword to NeuralMind's own local processing.",
     ),
     (
+        re.compile(r"\bnothing\s+leaves?\s+your\b", re.IGNORECASE),
+        "Absolute privacy claim about the whole workflow — inaccurate. "
+        "Scope the claim to NeuralMind's own behavior.",
+    ),
+    (
         re.compile(r"\b(zero|no)\s+(data\s+)?exfiltration\b", re.IGNORECASE),
         "Absolute exfiltration claim. Use 'no telemetry / no calls home'.",
     ),

--- a/tests/test_docs_claims.py
+++ b/tests/test_docs_claims.py
@@ -57,7 +57,10 @@ FORBIDDEN = [
         "Say what NeuralMind itself does: 'makes no network calls of its own'.",
     ),
     (
-        re.compile(r"\bnever\s+leaves?\s+(your|the)\s+(machine|infrastructure|environment|network|organi[sz]ation)\b", re.IGNORECASE),
+        re.compile(
+            r"\bnever\s+leaves?\s+(your|the)\s+(machine|infrastructure|environment|network|organi[sz]ation)\b",
+            re.IGNORECASE,
+        ),
         "Absolute privacy claim about the whole workflow — inaccurate. "
         "Scope the claim to NeuralMind's own behavior.",
     ),
@@ -113,13 +116,10 @@ def test_published_surfaces_have_no_forbidden_absolute_claims() -> None:
                 m = pattern.search(line)
                 if m:
                     rel = path.relative_to(REPO_ROOT)
-                    violations.append(
-                        f"{rel}:{lineno}: forbidden claim {m.group(0)!r} — {reason}"
-                    )
+                    violations.append(f"{rel}:{lineno}: forbidden claim {m.group(0)!r} — {reason}")
     assert not violations, (
         "Forbidden absolute claim(s) found on published surfaces "
-        "(NeuralMind minimizes egress, it does not eliminate it):\n  "
-        + "\n  ".join(violations)
+        "(NeuralMind minimizes egress, it does not eliminate it):\n  " + "\n  ".join(violations)
     )
 
 


### PR DESCRIPTION
## Description

Two claim-accuracy / docs fixes bundled on the web-maintenance branch.

**1. Purge forbidden absolute privacy/compliance claims + add a CI guard.**
NeuralMind is a *local context layer that feeds an AI coding agent* — the agent still sends its selected slice to its model, so NeuralMind **minimizes egress, it does not eliminate it**. Absolute claims ("your code never leaves your machine", "zero/no data exfiltration", "no data leaves your organization", "zero exfiltration risk") were live across the README and the security/compliance surfaces CISOs read, and kept getting re-copied on release passes. Every live occurrence is rewritten to scope the claim to what NeuralMind *itself* does (no network calls of its own, no telemetry, no calls home). New `tests/test_docs_claims.py` scans the published surfaces and fails CI if any forbidden absolute reappears — automating the "audit index.html + about.html after every release" checklist item. It caught 5 pre-existing violations my manual grep missed.

**2. Document the correct git-worktree workflow.**
Answers #316. Per-project state splits into two kinds that want opposite treatment across worktrees: the **index** (`graphify-out/` + `.neuralmind/` embeddings, derived from source) should be *rebuilt* per worktree, and the **learned memory** (`.neuralmind/synapses.db`) should be *shared*. Because memory is keyed by branch namespace (`branch:<name>`) and the store is SQLite in WAL mode, worktrees can share one symlinked `synapses.db` with per-branch isolation intact and no concurrent-access risk. Both dirs are gitignored, so copying them into worktrees (what the reporter did) fragments memory that then dies on `git worktree remove`. Added a "Git worktrees" section to `docs/use-cases/branch-isolated-memory.md`.

Fixes #316

## Type of Change

- [x] 📝 Documentation update
- [x] 🧪 Test update (new CI guard)
- [x] 🐛 Bug fix (visible: inaccurate claims on published surfaces)

## How Has This Been Tested?

- [x] Unit tests — `pytest tests/test_docs_claims.py` passes; the guard trips on the canonical bad phrase (self-test) and is clean across all published surfaces after the rewrites.

### Test Configuration

* **Test command**: `pytest tests/test_docs_claims.py -v`

## Documentation & discoverability

- [x] Docs answer *"what does the user/agent now see?"* — worktree section is workflow-first; claim rewrites are user-facing accuracy fixes
- [x] `README.md` updated (badge + hero + security section)
- [x] `docs/about.html` updated (claim rewrites)
- [x] `docs/wiki/*.md` updated (`FAQ.md` claim rewrites — syncs to live wiki)
- [x] Use-case walkthrough updated (`branch-isolated-memory.md` gains the worktree section)
- [x] I did **not** edit `CHANGELOG.md` or hand-bump `pyproject.toml`

## Additional Notes

The claim guard is intentionally scoped to *published* surfaces (README, SECURITY.md, docs site, security/compliance guides, comparisons, use-cases, wiki) and keyed to whole phrases, so accurate copy ("no telemetry", "air-gap installable", "SOC 2-ready posture") keeps passing. Internal planning drafts (e.g. `PROJECT_LINKEDIN_NEURALMIND.md`, `docs/launch/*`) still contain the old phrasing and are deliberately **not** scanned — flagging separately for a decision on whether to clean those too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SaXsRDpi9agGnpAuuasD2z)_