### PR TITLE
docs: add "US-based" trust signal to docs-site footers

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -269,7 +269,7 @@
             <a href="https://github.com/dfrostar/neuralmind/discussions">Discussions</a>
             <a href="/about.html">About</a>
         </div>
-        <p class="foot-meta">© 2026 NeuralMind · US-based. MIT-licensed open source, not affiliated with NeuralMind.ai. &nbsp;🔐 100% local · ⚡ 40–70× token reduction · ✅ NIST AI RMF · 🛠 Works with any MCP agent</p>
+        <p class="foot-meta">© {{ site.time | date: '%Y' }} NeuralMind · US-based. MIT-licensed open source, not affiliated with NeuralMind.ai. &nbsp;🔐 100% local · ⚡ 40–70× token reduction · ✅ NIST AI RMF · 🛠 Works with any MCP agent</p>
     </div>
 </footer>
 

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -269,7 +269,7 @@
             <a href="https://github.com/dfrostar/neuralmind/discussions">Discussions</a>
             <a href="/about.html">About</a>
         </div>
-        <p class="foot-meta">MIT License. Open source, not affiliated with NeuralMind.ai. &nbsp;🔐 100% local · ⚡ 40–70× token reduction · ✅ NIST AI RMF · 🛠 Works with any MCP agent</p>
+        <p class="foot-meta">© 2026 NeuralMind · US-based. MIT-licensed open source, not affiliated with NeuralMind.ai. &nbsp;🔐 100% local · ⚡ 40–70× token reduction · ✅ NIST AI RMF · 🛠 Works with any MCP agent</p>
     </div>
 </footer>
 

--- a/docs/about.html
+++ b/docs/about.html
@@ -1037,7 +1037,7 @@
                 <a href="about.html">About</a> •
                 <a href="https://github.com/dfrostar/neuralmind">GitHub</a>
             </p>
-            <p style="color: #999;">© 2026 NeuralMind Contributors. MIT License. Not affiliated with NeuralMind.ai.</p>
+            <p style="color: #999;">© 2026 NeuralMind · US-based. Open source under the MIT License. Not affiliated with NeuralMind.ai.</p>
         </div>
     </footer>
 </body>

--- a/docs/benchmarks/index.html
+++ b/docs/benchmarks/index.html
@@ -255,7 +255,7 @@ neuralmind benchmark . --contribute">Copy</button>
             <a href="https://github.com/dfrostar/neuralmind/discussions">Discussions</a>
             <a href="/about.html">About</a>
         </div>
-        <p class="foot-meta">MIT License. Dashboard reads <a href="https://github.com/dfrostar/neuralmind/blob/main/docs/community-benchmarks.json"><code>community-benchmarks.json</code></a> at page load — no server, no tracking, no data sent anywhere. View source: <a href="https://github.com/dfrostar/neuralmind/tree/main/docs/benchmarks">docs/benchmarks/</a>.</p>
+        <p class="foot-meta">© 2026 NeuralMind · US-based. MIT License. Dashboard reads <a href="https://github.com/dfrostar/neuralmind/blob/main/docs/community-benchmarks.json"><code>community-benchmarks.json</code></a> at page load — no server, no tracking, no data sent anywhere. View source: <a href="https://github.com/dfrostar/neuralmind/tree/main/docs/benchmarks">docs/benchmarks/</a>.</p>
     </div>
 </footer>
 


### PR DESCRIPTION
## Description

Adds a lightweight **US-based** trust signal to the docs-site footers, for US enterprise buyers evaluating the vendor. NeuralMind is operated by a US entity, so "US-based" is an accurate, honest signal that defuses the "foreign vendor / `.uk` domain" reflex a US CISO/procurement lead might have — without a costly domain migration.

Design decision (per maintainer): surface **"US-based" only** on public pages. The legal entity name is intentionally kept off marketing/docs pages and reserved for the transaction/verification layer (Terms, Privacy, contracts, invoices), where it actually belongs and where a diligent buyer verifies.

Footers updated (all preserve the existing MIT / open-source / not-affiliated-with-NeuralMind.ai signals):
- `docs/_layouts/default.html` — the Jekyll layout, so every wiki/docs page
- `docs/about.html`
- `docs/benchmarks/index.html`

`docs/index.html` is a redirect stub (the landing page lives at the apex `neuralmind.uk`), so it has no footer to change. `neuralmind.uk` stays as-is — the disclosure removes the need for a domain change.

## Type of Change

- [x] 📝 Documentation update

## How Has This Been Tested?

- [x] `pytest tests/test_docs_claims.py` — the published-surface claim guard stays green (no forbidden absolutes introduced).

## Documentation & discoverability

- [x] Docs answer *"what does the user see?"* — a US-based signal in the footer
- [x] `docs/about.html` + docs layout updated
- [x] I did **not** edit `CHANGELOG.md` or hand-bump `pyproject.toml`

## Additional Notes

Follow-up still recommended on the **apex marketing site** (`dfrostar/neuralmind-marketing`, separate repo): mirror the footer "US-based" signal there (it's the primary buyer-facing surface), and add the legal entity name to that site's Terms/Privacy imprint. Not in this repo/PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SaXsRDpi9agGnpAuuasD2z)_