### PR TITLE
[superseded] savings --dollars

### DIFF
--- a/docs/wiki/CLI-Reference.md
+++ b/docs/wiki/CLI-Reference.md
@@ -1671,7 +1671,9 @@ neuralmind savings [project_path] [OPTIONS]
 | Option | Default | Description |
 |--------|---------|-------------|
 | `--global` | False | Show savings across ALL projects (reads the global event log at `~/.neuralmind/memory/`) |
-| `--json`, `-j` | False | Emit structured JSON output |
+| `--dollars` | False | Also price the measured token savings in USD. Uses the model's **input** rate (NeuralMind trims input context), from a rate card current as of the date shown in the output. Every dollar figure derives from the logged token counts — no per-query numbers are invented. |
+| `--model` | `claude-3-5-sonnet` | Model to price against with `--dollars` (e.g. `gpt-4o`, `gpt-4o-mini`, `gemini-1.5-pro`, `claude-3-opus`). |
+| `--json`, `-j` | False | Emit structured JSON output (adds a `dollars` object when `--dollars` is set) |
 
 #### Examples
 
@@ -1685,11 +1687,18 @@ neuralmind savings .
 # →   Est. cost without NM : 2,350,000
 # →   Tokens saved         : 2,266,860
 
+# Put a dollar figure on it (CFO-ready), priced against a chosen model
+neuralmind savings . --dollars --model gpt-4o
+#     Priced with gpt-4o input rate ($2.50/1M, as of 2026-07-15):
+#       Cost without NM    : $        5.88
+#       Cost with NM       : $        0.21
+#       Dollars saved      : $        5.67
+
 # Global savings across all projects
 neuralmind savings --global
 
-# JSON for dashboards or scripting
-neuralmind savings . --json
+# JSON for dashboards or scripting (includes a "dollars" block with --dollars)
+neuralmind savings . --dollars --json
 ```
 
 Memory logging must be enabled (answer yes when first prompted, or set `NEURALMIND_MEMORY=1`).

--- a/neuralmind/cli.py
+++ b/neuralmind/cli.py
@@ -440,22 +440,38 @@ def cmd_savings(args):
     total_saved = total_full_cost - total_tokens_used
     avg_ratio = sum(e["ratio"] for e in queries) / len(queries) if queries else 0.0
 
+    # Optional dollar costing. NeuralMind trims the input context, so the
+    # measured token counts are priced at the model's INPUT rate — no per-event
+    # fields are invented; every figure derives from the tokens above.
+    dollars = None
+    if getattr(args, "dollars", False):
+        from . import rate_card
+
+        model = getattr(args, "model", None) or rate_card.DEFAULT_MODEL
+        rate = rate_card.resolve(model)
+        dollars = {
+            "model": rate.model_id,
+            "rates_as_of": rate_card.RATES_AS_OF,
+            "input_rate_per_million": rate.input_per_million,
+            "cost_without_neuralmind": round(rate_card.input_cost(total_full_cost, model), 2),
+            "cost_with_neuralmind": round(rate_card.input_cost(total_tokens_used, model), 2),
+            "dollars_saved": round(rate_card.input_cost(total_saved, model), 2),
+        }
+
     if args.json:
-        print(
-            json.dumps(
-                {
-                    "project": project_path.name,
-                    "log": str(events_file),
-                    "total_queries": len(queries),
-                    "total_wakeups": len(wakeups),
-                    "total_tokens_used": total_tokens_used,
-                    "est_total_full_cost": total_full_cost,
-                    "total_tokens_saved": total_saved,
-                    "avg_reduction_ratio": round(avg_ratio, 1),
-                },
-                indent=2,
-            )
-        )
+        payload = {
+            "project": project_path.name,
+            "log": str(events_file),
+            "total_queries": len(queries),
+            "total_wakeups": len(wakeups),
+            "total_tokens_used": total_tokens_used,
+            "est_total_full_cost": total_full_cost,
+            "total_tokens_saved": total_saved,
+            "avg_reduction_ratio": round(avg_ratio, 1),
+        }
+        if dollars is not None:
+            payload["dollars"] = dollars
+        print(json.dumps(payload, indent=2))
         return
 
     scope = "global" if use_global else project_path.name
@@ -468,6 +484,15 @@ def cmd_savings(args):
     print(f"  Tokens actually used : {total_tokens_used:>10,}")
     print(f"  Est. cost without NM : {total_full_cost:>10,}  (at {est_full:,} tokens/query)")
     print(f"  Tokens saved         : {total_saved:>10,}")
+    if dollars is not None:
+        print()
+        print(
+            f"  Priced with {dollars['model']} input rate "
+            f"(${dollars['input_rate_per_million']:.2f}/1M, as of {dollars['rates_as_of']}):"
+        )
+        print(f"    Cost without NM    : ${dollars['cost_without_neuralmind']:>12,.2f}")
+        print(f"    Cost with NM       : ${dollars['cost_with_neuralmind']:>12,.2f}")
+        print(f"    Dollars saved      : ${dollars['dollars_saved']:>12,.2f}")
     if queries:
         print()
         print("  Most recent queries:")
@@ -2232,6 +2257,17 @@ def main():
         dest="global_",
         action="store_true",
         help="Show savings across ALL projects (reads the global event log).",
+    )
+    savings_p.add_argument(
+        "--dollars",
+        action="store_true",
+        help="Also price the measured token savings in USD (input-rate; see --model).",
+    )
+    savings_p.add_argument(
+        "--model",
+        default=None,
+        help="Model to price against when using --dollars "
+        "(e.g. gpt-4o, gemini-1.5-pro; default claude-3-5-sonnet).",
     )
     savings_p.add_argument("--json", "-j", action="store_true")
     savings_p.set_defaults(func=cmd_savings)

--- a/neuralmind/rate_card.py
+++ b/neuralmind/rate_card.py
@@ -1,0 +1,74 @@
+"""Model pricing rate card — single source of truth for dollar costing.
+
+Used by the ``savings --dollars`` CLI option to translate NeuralMind's
+measured token counts into a defensible dollar figure. Rates are USD per 1M
+tokens and reflect published list prices as of ``RATES_AS_OF``; keeping them
+in one module means a provider price change is a one-line edit.
+
+NeuralMind reduces the *input context* fed to the model, so token savings are
+priced at each model's **input** rate (see ``input_cost``). Output pricing is
+carried for completeness but is not what NeuralMind moves.
+"""
+
+from __future__ import annotations
+
+RATES_AS_OF = "2026-07-15"
+
+
+class ModelRate:
+    """USD-per-1M-token rates for one model."""
+
+    __slots__ = ("model_id", "input_per_million", "output_per_million", "provider")
+
+    def __init__(
+        self,
+        model_id: str,
+        input_per_million: float,
+        output_per_million: float,
+        provider: str = "",
+    ) -> None:
+        self.model_id = model_id
+        self.input_per_million = input_per_million
+        self.output_per_million = output_per_million
+        self.provider = provider
+
+
+# Keyed by canonical model id. Aliases (substring matches) are resolved by
+# ``resolve()`` so callers may pass dated ids ("claude-3-5-sonnet-20241022")
+# or short ids ("claude-3-5-sonnet").
+DEFAULT_RATES: dict[str, ModelRate] = {
+    "claude-3-5-sonnet": ModelRate("claude-3-5-sonnet", 3.00, 15.00, "Anthropic"),
+    "claude-3-haiku": ModelRate("claude-3-haiku", 0.25, 1.25, "Anthropic"),
+    "claude-3-opus": ModelRate("claude-3-opus", 15.00, 75.00, "Anthropic"),
+    "gpt-4o-mini": ModelRate("gpt-4o-mini", 0.15, 0.60, "OpenAI"),
+    "gpt-4o": ModelRate("gpt-4o", 2.50, 10.00, "OpenAI"),
+    "gemini-1.5-flash": ModelRate("gemini-1.5-flash", 0.075, 0.30, "Google"),
+    "gemini-1.5-pro": ModelRate("gemini-1.5-pro", 1.25, 5.00, "Google"),
+}
+
+DEFAULT_MODEL = "claude-3-5-sonnet"
+
+
+def resolve(model: str) -> ModelRate:
+    """Resolve a (possibly dated/aliased) model id to a ModelRate.
+
+    Falls back to the default model rather than raising, so a report never
+    crashes on an unseen id. Callers can detect the fallback by comparing
+    ``rate.model_id`` to ``DEFAULT_MODEL``.
+    """
+    if model in DEFAULT_RATES:
+        return DEFAULT_RATES[model]
+    m = model.lower()
+    for key, rate in DEFAULT_RATES.items():
+        if key in m:
+            return rate
+    return DEFAULT_RATES[DEFAULT_MODEL]
+
+
+def input_cost(tokens: int, model: str) -> float:
+    """USD cost of ``tokens`` input/context tokens for ``model``."""
+    return (tokens / 1_000_000) * resolve(model).input_per_million
+
+
+def known_model_ids() -> list[str]:
+    return list(DEFAULT_RATES.keys())


### PR DESCRIPTION
Superseded. This PR's branch was rewritten to contain only the `neuralmind savings --dollars` feature; the change is tracked in a fresh PR. Closing.