### PR TITLE
docs: commercial offerings page + UK-costed legal path (£220 total)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 NeuralMind Contributors
+Copyright (c) 2024-2026 Darren Frost (NeuralMind)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/docs/ASSESSMENT.md
+++ b/docs/ASSESSMENT.md
@@ -88,6 +88,7 @@ assumptions and mark every estimated input as estimated.
 
 ---
 
-*The software is MIT-licensed and free. Commercial support for
-deployment, integration, and evaluation is available — ask on the
-call.*
+*The software is MIT-licensed and free. If the assessment numbers
+justify going further, the paid engagements — fixed-fee pilot,
+support & assurance subscription — are described in
+[OFFERINGS.md](OFFERINGS.md).*

--- a/docs/ENTERPRISE.md
+++ b/docs/ENTERPRISE.md
@@ -70,3 +70,5 @@ Three things to do first so the pitch survives scrutiny:
 3. **Pilot with one team for two weeks** before a wider rollout. Multi-language monorepos, generated code, and unusual project structures can drop retrieval quality below the headline numbers.
 
 For deployment-architecture details (where artifacts live, how to refresh indexes in CI, what happens during a graphify upgrade), see [DEPLOYMENT-GUIDE.md](DEPLOYMENT-GUIDE.md).
+
+If the pilot needs commercial backing — a fixed-fee structured evaluation, priority support with committed response times, or an auditor-ready compliance pack — see [OFFERINGS.md](OFFERINGS.md).

--- a/docs/OFFERINGS.md
+++ b/docs/OFFERINGS.md
@@ -1,0 +1,94 @@
+# Working with NeuralMind commercially
+
+The software is MIT-licensed and free, forever — that isn't changing.
+What's below is what you can *pay* for: accountability, assurance, and
+deployment help, for teams that need someone on the hook.
+
+Every engagement starts from measured numbers, not claims — usually via
+the [free AI-spend assessment](ASSESSMENT.md). If the numbers say
+NeuralMind isn't a fit for your workload, that's the answer you'll get
+([the failure modes are public](BUSINESS-CASE.md#the-case-is-weaker-if)).
+
+**Contact:** [hello@neuralmind.uk](mailto:hello@neuralmind.uk?subject=Commercial%20engagement)
+
+Introductory pricing below — early engagements shape the offering, and
+the price reflects that.
+
+---
+
+## 1. Free — the software and the assessment
+
+- Everything in this repository: the full retrieval + synapse engine,
+  team memory, audit log, all ten languages, every integration. MIT.
+- The [self-serve assessment](ASSESSMENT.md): run
+  `neuralmind benchmark .` on your own hardware, send the report, get a
+  three-line spend model back in your numbers.
+
+No seat counts, no feature gates, no time limits.
+
+## 2. Paid pilot — fixed fee, two weeks, your repo
+
+**$2,500–5,000 fixed** (scoped by repo count and team size).
+
+A structured two-week evaluation with one of your teams, run against
+the acceptance criteria in the [pilot BRD](PILOT-BRD.md):
+
+- Install + `doctor` green on your dev machines, index built on your
+  repo(s), hooks/MCP wired into your agents (Claude Code, Cursor,
+  Cline, Continue).
+- Your 30 golden queries measured: recall, token reduction,
+  faithfulness delta — the same harness as the
+  [public benchmark](benchmarks/public.md).
+- Team-memory baseline committed and onboarding lift measured.
+- Ends with a written verdict either way: the measured numbers, what
+  worked, what didn't, and whether a rollout is justified. If the
+  verdict is "don't roll this out," you still keep the report.
+
+## 3. Support & assurance — annual subscription
+
+**$3,000–6,000/yr flat** (by org size), for teams running NeuralMind in
+environments where "the maintainer might answer a GitHub issue" isn't
+an acceptable support posture:
+
+- **Priority support** with committed response times, backed by the
+  published [vulnerability disclosure SLA](../SECURITY.md).
+- **Upgrade assurance:** advance notice of breaking changes, migration
+  review for your deployment pattern, and a direct channel when an
+  upgrade misbehaves.
+- **Compliance pack, assembled for your deployment:** the
+  [compliance summary](COMPLIANCE-SUMMARY.md),
+  [security guide](SECURITY-GUIDE.md), SBOM + provenance walkthrough,
+  and deployment-architecture review — in the shape your auditors ask
+  for it.
+- **Air-gap deployment support:** the
+  [air-gapped install](use-cases/air-gapped.md) done with you, including
+  offline upgrade procedure.
+
+## 4. Enterprise add-on — design partners wanted
+
+The multi-user governance layer (SSO/RBAC around team memory,
+compliance export, audit retention policies) ships as a separate,
+commercially-licensed package — the MIT core is not being relicensed,
+and any license validation will be an **offline signed file**: this
+product will never phone home, including to us.
+
+It gets built in demand order: the first design partners pick the first
+features and get founding-customer pricing. If your security review
+needs one of these controls, [say so](mailto:hello@neuralmind.uk?subject=Enterprise%20design%20partner)
+— that's what sequences the roadmap.
+
+---
+
+## What we won't sell you
+
+Same rules as [everywhere else in this project](HONEST-ASSESSMENT.md):
+
+- **No hosted SaaS.** Local-first is the product. If you want someone
+  else to run it, we're the wrong vendor.
+- **No savings we didn't measure.** Engagements start by measuring your
+  ratio on your code; measured numbers are labeled measured, derived
+  numbers derived.
+- **No lock-in mechanics.** Everything your team learns (indexes,
+  synapse maps, team memory) lives in your repo and your
+  `.neuralmind/` directory in open formats. Walking away is a
+  `pip uninstall`.

--- a/docs/launch/README.md
+++ b/docs/launch/README.md
@@ -19,6 +19,7 @@ post there — we don't post under a disguise.
 | [`r-localllama.md`](r-localllama.md) | r/LocalLLaMA | Self-post, maker-disclosed, four-benefit block with live links. |
 | [`awesome-mcp-servers.md`](awesome-mcp-servers.md) | `awesome-mcp-servers` PR | One-line directory entry + PR description. |
 | [`hn-warmup-comments.md`](hn-warmup-comments.md) | Hacker News (other threads) | Genuine, on-topic, disclosed comments on adjacent posts. Not drive-by promo. |
+| [`linkedin-assessment.md`](linkedin-assessment.md) | LinkedIn (personal profile, founder voice) | Conversion posts — one CTA: the free AI-spend assessment. Post personal, reshare to company page. |
 | [`NEXT-SESSION.md`](NEXT-SESSION.md) | (internal) | Session handoff + "what we did" record + recommended next steps. Copy-paste to resume. |
 
 ## Live anchors (keep these accurate)

--- a/docs/launch/linkedin-assessment.md
+++ b/docs/launch/linkedin-assessment.md
@@ -1,0 +1,114 @@
+# LinkedIn — assessment-CTA posts (the conversion posts)
+
+The thought-leadership cadence lives in the maintainer's LinkedIn project
+files; these are the **conversion** posts whose only job is to book
+[free AI-spend assessments](../ASSESSMENT.md), which upsell into
+[OFFERINGS.md](../OFFERINGS.md).
+
+**Posting rules:**
+- **Post from the personal profile, founder voice** — reshare to the company
+  page (linkedin.com/company/neuralmind-dev), not the other way round.
+  Company-page posts get a fraction of the organic reach.
+- Disclosed-maker only, same as everything in this folder — trivially
+  satisfied on LinkedIn since the byline *is* the disclosure.
+- One CTA per post. Assessment or nothing. No "also check out the repo,
+  the wiki, the benchmarks…" link piles.
+- Cite only numbers that are measured and labeled as such in
+  [BUSINESS-CASE.md](../BUSINESS-CASE.md) — same honesty CI-guard spirit
+  as the rest of the repo.
+
+---
+
+## Post A — engineering-leader angle (recommended first)
+
+> Your AI coding bill grows linearly with your codebase. It doesn't have to.
+>
+> Every "how does auth work here?" your engineers' agents answer means
+> loading context from the repo — and the bigger the repo, the more tokens
+> that costs. Teams tell us the same story: the bill that was fine at 10K
+> lines isn't fine at 100K.
+>
+> I built NeuralMind to fix the retrieval side of that: a local index that
+> answers code questions in ~800 tokens instead of pasting whole files. On
+> our public CI benchmark that's a measured 6× reduction on a small fixture,
+> and 40–70× on real-world repos (community-submitted, methodology public).
+>
+> Honest caveat, because we publish those too: retrieval is one slice of an
+> agent's spend. End-to-end, teams should expect 3–10×, not 70×.
+>
+> If you run 10+ engineers on AI coding tools, I'll measure your actual
+> ratio for free: you run one command on your own hardware (nothing leaves
+> your machines — the tool makes no network calls of its own), send me the
+> report, and I send back a spend model in your numbers. If the numbers say
+> it's not worth deploying, that's what the model will say.
+>
+> Book it: hello@neuralmind.uk — or run it yourself first:
+> pip install neuralmind && neuralmind benchmark .
+>
+> #AIEngineering #EngineeringLeadership #DeveloperProductivity #LLMOps
+
+## Post B — CFO / spend-owner angle
+
+> "We approved the AI tooling budget. Is it working?"
+>
+> Most engineering orgs can't answer that with numbers. The invoices are
+> real; the counterfactual isn't measured.
+>
+> I do free AI-spend assessments for teams running AI coding agents. Not a
+> sales call — a working session that ends with a three-line model your
+> finance team can audit:
+>
+> 1. Per-seat subscriptions — where token efficiency does and doesn't move
+>    the number (flat-rate seats don't get cheaper; overage tiers do)
+> 2. Usage-based API spend — measured against your last three months of
+>    invoices
+> 3. Self-hosted GPU capacity — freed compute, priced at your contracted
+>    rate, not a blog post's
+>
+> Every assumption is written down so you can change it. Every number is
+> labeled measured or estimated. And if the honest answer is "your workload
+> doesn't benefit," you get that in writing too — the failure modes are
+> published on our site.
+>
+> The measurement runs on your hardware; your code never leaves your
+> machines.
+>
+> hello@neuralmind.uk
+>
+> #FinOps #CFO #AISpend #EngineeringFinance
+
+## Post C — compliance / regulated angle (security & GRC audience)
+
+> The teams that need AI coding assistants most are the ones whose security
+> policy bans them.
+>
+> Finance, healthcare, defense: code can't leave the building, so Copilot
+> and friends are off the table, and engineers watch everyone else get
+> faster.
+>
+> NeuralMind is the opposite architecture: the code intelligence runs
+> entirely on your hardware. No cloud index, no telemetry, no network calls
+> of its own — we publish the claim and CI-guard the wording. Air-gapped
+> install is a documented, supported path. Every recommendation is traceable
+> to extracted code, with a tamper-evident audit log your assessors can
+> verify.
+>
+> The software is MIT-licensed and free. What we sell is the part regulated
+> teams actually need: priority support with committed response times, an
+> auditor-ready compliance pack, and air-gap deployment done with you.
+>
+> If AI-assisted development is currently banned at your org, that's
+> exactly the conversation to have: hello@neuralmind.uk
+>
+> #InfoSec #GRC #AirGapped #RegulatedIndustries #AICompliance
+
+---
+
+## Cadence suggestion
+
+Slot these into the existing weekly rhythm as the **conversion** beats —
+roughly one per week after a thought-leadership post has warmed the same
+angle (A after a cost post, B after a CFO post, C after the zero-egress
+post). Track one metric only: assessment emails received. If four weeks of
+posting produces zero assessment bookings, change the offer's framing, not
+the posting frequency.

--- a/docs/plans/2026-07-15-enterprise-competition-plan.md
+++ b/docs/plans/2026-07-15-enterprise-competition-plan.md
@@ -129,11 +129,28 @@ Candidate contents (build in demand order, not speculatively):
 This is what `LICENSE-COMMERCIAL.md` should attach to. Today it attaches to
 nothing (§3).
 
-### Rung 4 — Trademark (parallel, cheap, durable)
+### Rung 4 — Name & IP protection (parallel, ~£220 total, durable)
 
-Register the **NeuralMind** mark. MIT gives away the code; it does not give
-away the name. A fork can't ship as "NeuralMind" — the one IP lever that
-survives a permissive core, and the cheapest item in this plan.
+MIT gives away the code; it does not give away the name. The UK-costed
+DIY path (no lawyers):
+
+- **Copyright: already owned, £0.** Copyright is automatic under the Berne
+  Convention — the public GitHub history (timestamped, hash-chained commits
+  since 2024) plus PyPI release dates is strong authorship evidence. Fix the
+  `LICENSE` notice to name the actual author instead of "NeuralMind
+  Contributors", and sign commits/tags going forward. Defer US Copyright
+  Office registration ($65) until there's an actual US infringement to act
+  on — it can be filed then.
+- **Trademark: UK IPO filing, £170** for one class, DIY online. **Run a
+  free clearance search first** (IPO + EUIPO + USPTO databases) — at least
+  one adjacent company uses a confusingly similar name (neuralmind.ai,
+  Brazilian AI firm), and a contested software class is better discovered
+  for £0 than after brand investment. Use ™ (no registration needed) until
+  the mark grants; unregistered "passing off" protection accrues from
+  trading use meanwhile. Defer US ($350/class) and EU (€850) filings until
+  revenue in those markets justifies them.
+- A fork can't ship as "NeuralMind" — the one IP lever that survives a
+  permissive core, and the cheapest item in this plan.
 
 ---
 
@@ -179,9 +196,16 @@ the recommendation is open-core on the merits, not on constraint.
 - [ ] Confirm open-core direction (§2 rungs 1–3) — yes/no/shape
 - [ ] Confirm MIT core is permanent (worth stating publicly once decided —
       it's a selling point against BSL-rug-pull anxiety)
-- [ ] Legal entity + governing law for the commercial paper (UK entity ≠
-      Delaware Inc. currently in the doc)
-- [ ] Trademark registration go/no-go
+- [ ] Legal entity: **recommended path is a UK private limited company**
+      (Companies House online, £50, ~24h; ~£34/yr thereafter) — not the
+      "NeuralMind, Inc." Delaware placeholder, which would add a registered
+      agent, franchise tax, and US filings for no benefit absent US VC
+      plans. Governing law for the commercial paper becomes England &
+      Wales; the Delaware/AAA arbitration clauses go. A company (vs. sole
+      trader) matters because the commercial license carries indemnity and
+      liability clauses that should sit on an entity, not a person.
+- [ ] Name clearance search (£0, DIY) → then UK trademark filing (£170) —
+      see §2 rung 4
 - [ ] Pricing recalibration (§4)
 
 ---
@@ -210,12 +234,18 @@ the third line, not the headline.
 
 ### Now (no product code)
 1. Maintainer runs the §3 decision gate.
-2. Rewrite `LICENSE-COMMERCIAL.md` to match the decision: real entity,
-   offline license validation, repriced tiers, scope = the private
-   enterprise package + assurance services (not features this repo ships).
-3. Publish a support & assurance offering page (docs site) built from the
-   existing SLA + SBOM + compliance docs. First sellable SKU.
-4. Trademark filing.
+2. Company formation (£50, Companies House) + name clearance search (£0)
+   + UK trademark filing (£170) — the whole legal substrate is ~£220.
+3. Rewrite `LICENSE-COMMERCIAL.md` to match the decision: real entity,
+   England & Wales law, offline license validation, repriced tiers, scope =
+   the private enterprise package + assurance services (not features this
+   repo ships).
+4. Publish the offerings page (`docs/OFFERINGS.md`) built from the existing
+   SLA + SBOM + compliance docs, linked from the free-assessment funnel.
+   First sellable SKUs.
+5. Fix the `LICENSE` copyright notice (automatic copyright attaches to the
+   author, not a fictional contributor collective) and enable signed
+   commits/tags.
 
 ### Next (CI/docs work)
 5. Network-isolation CI job proving zero-egress behaviorally (W1).

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -313,6 +313,12 @@
     <priority>0.5</priority>
   </url>
   <url>
+    <loc>https://docs.neuralmind.uk/OFFERINGS</loc>
+    <lastmod>2026-07-16</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
     <loc>https://docs.neuralmind.uk/ASSESSMENT</loc>
     <lastmod>2026-07-12</lastmod>
     <changefreq>monthly</changefreq>


### PR DESCRIPTION
## Description

Follow-up to #349 — makes the monetization plan's "Now" list concrete.

**New: `docs/OFFERINGS.md`** — the first sellable surface, in house honest-framing style:
1. Free tier restated (MIT forever, self-serve assessment)
2. **Fixed-fee two-week pilot** ($2.5–5K) run against the `PILOT-BRD.md` acceptance criteria, ends with a written verdict either way
3. **Support & assurance subscription** ($3–6K/yr) built entirely from already-shipped assets: vuln SLA, compliance summary, SBOM/provenance, air-gap walkthrough
4. **Enterprise add-on design-partner call** — states the MIT-core-permanent + offline-license-file commitments publicly
5. "What we won't sell you" section (no SaaS, no unmeasured savings, no lock-in)

Wired into the funnel: linked from `ASSESSMENT.md` footer (the free-assessment upsell) and `ENTERPRISE.md`; added to `docs/sitemap.xml`.

**Plan updates** (`docs/plans/2026-07-15-enterprise-competition-plan.md`): replaces the Delaware-Inc./generic-trademark items with the UK-costed path — Companies House Ltd (£50), automatic Berne copyright (notice fix + signed commits, defer US registration until needed), UK IPO trademark (£170) gated on a free clearance search with the neuralmind.ai name-conflict risk flagged. Total legal substrate: ~£220.

**`LICENSE`**: copyright notice now names the actual author ("Copyright (c) 2024-2026 Darren Frost (NeuralMind)") instead of the fictional "NeuralMind Contributors" — sole-author repo, automatic copyright should attach to a real party.

## Type of Change

- [x] 📝 Documentation update

## How Has This Been Tested?

- [x] Manual testing — verified every relative link in `OFFERINGS.md` resolves to an existing file; sitemap XML structure matches existing entries.

## Documentation & discoverability

- [x] Docs answer *"what does the user/agent now see?"* — the offerings page is written for the buying evaluator
- [x] SEO refreshed (sitemap entry for the new page)
- [x] I did **not** edit `CHANGELOG.md` or hand-bump the `pyproject.toml` version (release-please owns these)

## Checklist

- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation

## Additional Notes

Pricing on the offerings page is labeled introductory and matches the plan §4 proposal — adjust the numbers there if you want different list prices before this merges. The clearance search and Companies House filing are maintainer actions the repo can't do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BTThsU2psuvkU99fgpRok2

---
_Generated by [Claude Code](https://claude.ai/code/session_01BTThsU2psuvkU99fgpRok2)_