### PR TITLE
feat(savings): mark `--cost` figures as estimates and disclose the basis

### DIFF
--- a/docs/wiki/CLI-Reference.md
+++ b/docs/wiki/CLI-Reference.md
@@ -1714,6 +1714,12 @@ baseline as the token report, priced on **input** tokens only — retrieval
 decides which input tokens ship, so output pricing never enters the math.
 Prices are a 2026-07 snapshot (`MODEL_PRICING_PER_MTOK` in `neuralmind/memory.py`).
 
+Only the *with-NeuralMind* cost is measured from logged tokens; *without-NM*
+(and therefore *saved* / *projected*) is estimated from the fixed baseline, so
+those figures are marked `(est)` in the human output. The JSON `dollar_savings`
+block makes this machine-readable too: `estimated: true`, a `basis` string, and
+`baseline_tokens_per_query`.
+
 Memory logging must be enabled (answer yes when first prompted, or set `NEURALMIND_MEMORY=1`).
 
 ---

--- a/neuralmind/cli.py
+++ b/neuralmind/cli.py
@@ -457,6 +457,19 @@ def cmd_savings(args):
             query_tokens_saved=query_tokens_baseline - query_tokens_used,
             query_count=len(queries),
         )
+        # Make the estimate basis machine-readable (kept in the CLI so memory's
+        # public API stays untouched): only the with-NM cost is measured from
+        # logged tokens; without-NM — and therefore saved/projected — is
+        # estimated from the fixed per-query baseline.
+        dollar_info = {
+            **dollar_info,
+            "baseline_tokens_per_query": est_full,
+            "estimated": True,
+            "basis": (
+                "with-NM cost is measured from logged tokens; without-NM (and "
+                "saved/projected) is estimated from the fixed per-query baseline"
+            ),
+        }
 
     if args.json:
         out = {
@@ -490,14 +503,15 @@ def cmd_savings(args):
             f"  Dollar savings — {dollar_info['model']} "
             f"@ ${dollar_info['price_per_mtok']}/MTok input"
         )
-        print(f"    Cost without NM : ${dollar_info['baseline_cost_total']:>10,.2f}")
-        print(f"    Cost with NM    : ${dollar_info['actual_cost_total']:>10,.2f}")
-        print(f"    Saved           : ${dollar_info['saved_total']:>10,.2f}")
+        print(f"    Cost without NM (est): ${dollar_info['baseline_cost_total']:>10,.2f}")
+        print(f"    Cost with NM         : ${dollar_info['actual_cost_total']:>10,.2f}")
+        print(f"    Saved (est)          : ${dollar_info['saved_total']:>10,.2f}")
         print(
-            f"    Projected       : ${dollar_info['daily_saved']:,.2f}/day · "
+            f"    Projected (est)      : ${dollar_info['daily_saved']:,.2f}/day · "
             f"${dollar_info['monthly_saved']:,.2f}/month  "
             f"(at {dollar_info['queries_per_day']} queries/day)"
         )
+        print(f"    (without-NM estimated from {est_full:,} tok/query baseline)")
     if queries:
         print()
         print("  Most recent queries:")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1042,6 +1042,41 @@ class TestCLISavings:
         assert ds["daily_saved"] == 24.75  # 49,500 tok/event * 100/day * $5/MTok
         assert ds["monthly_saved"] == 742.5
 
+    def test_savings_cost_surfaces_estimate_basis(self, tmp_path, capsys):
+        """--cost --json marks the dollar figures as estimated and shows the basis."""
+        import json as _json
+
+        from neuralmind import memory
+        from neuralmind.cli import cmd_savings
+
+        log_file = memory.project_query_events_file(tmp_path)
+        log_file.parent.mkdir(parents=True, exist_ok=True)
+        event = {
+            "event_type": "query",
+            "timestamp": "2026-01-01T00:00:00+00:00",
+            "project_path": str(tmp_path),
+            "session_id": "s1",
+            "query": "test",
+            "retrieval_summary": {"tokens": 500, "reduction_ratio": 100.0},
+        }
+        log_file.write_text(_json.dumps(event) + "\n")
+
+        args = MagicMock()
+        args.project_path = str(tmp_path)
+        args.global_ = False
+        args.json = True
+        args.cost = True
+        args.model = "claude-opus-4-8"
+        args.queries_per_day = 100
+
+        cmd_savings(args)
+        ds = json.loads(capsys.readouterr().out)["dollar_savings"]
+        # the measured cost is still present, now flagged as an estimate basis
+        assert ds["actual_cost_total"] == 0.0025  # measured: 500 tok * $5/MTok
+        assert ds["estimated"] is True
+        assert ds["baseline_tokens_per_query"] == 50_000
+        assert "basis" in ds and "estimated" in ds["basis"]
+
     def test_savings_cost_text_output(self, tmp_path, capsys):
         """savings --cost adds a dollar-savings block to the text report."""
         import json as _json


### PR DESCRIPTION
## Description

Small honesty polish on the `savings --cost` reporting shipped in v0.45.0.

`--cost` anchors the **without-NeuralMind** cost (and therefore *saved* / *projected*) to the fixed 50k-token per-query baseline, while **with-NeuralMind** is measured from logged tokens. The output didn't distinguish the two, so the dollar figures could read as fully measured. This makes the split explicit:

- **Human output** labels the estimated figures `(est)` and adds a one-line note: `(without-NM estimated from 50,000 tok/query baseline)`.
- **JSON `dollar_savings`** gains `estimated: true`, a `basis` string, and `baseline_tokens_per_query`, so programmatic consumers can see the estimate basis too.

Pricing and `memory.estimate_dollar_savings` are unchanged — this is output-labelling only.

### Background
This branch previously carried a standalone `--dollars` flag (opened before v0.45.0's `--cost` landed). That would have duplicated `--cost`, so it was dropped; only the measured-vs-estimated framing — the genuinely additive idea, reinforced by earlier review feedback — was ported here. (Note: `--model` is already constrained by argparse `choices`, so an unpriced/dated model can't reach the pricing path via the CLI; no model-fallback handling was needed.)

Fixes # (n/a)

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 📝 Documentation update

## How Has This Been Tested?

- [x] Manual testing

### Test Configuration

* **Python version**: 3.12
* **Operating System**: Linux
* **Test command**: `pytest tests/test_cli.py::TestCLISavings` + `black --check .` / `ruff check .`

Verification:
- `savings --cost --json` now emits `estimated`/`basis`/`baseline_tokens_per_query`; existing `dollar_savings` math keys unchanged (existing `test_savings_cost_json_math` still passes).
- Human output shows `(est)` labels + the baseline note.
- Added `test_savings_cost_surfaces_estimate_basis`; all 7 `TestCLISavings` tests pass. Lint clean.

## Documentation & discoverability

- [x] `docs/wiki/CLI-Reference.md` — `savings --cost` section notes the measured-vs-estimated split and the new JSON fields.
- [ ] SEO — no new product noun; skipped.
- [x] Did **not** edit `CHANGELOG.md` or hand-bump `pyproject.toml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MmE53xF8bVTrMRChxNvKBW)_