### PR TITLE
site: business-audience refresh — fix version badge + C4 stat, reconcile privacy page, add CFO/CTO business case

### DIFF
--- a/site/src/app/page.tsx
+++ b/site/src/app/page.tsx
@@ -1,6 +1,7 @@
 import Hero from '@/components/sections/Hero';
 import HowItWorks from '@/components/sections/HowItWorks';
 import Benchmarks from '@/components/sections/Benchmarks';
+import BusinessCase from '@/components/sections/BusinessCase';
 import Features from '@/components/sections/Features';
 import Assessment from '@/components/sections/Assessment';
 import FAQ from '@/components/sections/FAQ';
@@ -16,6 +17,7 @@ export default function Page() {
                 <Hero />
                 <HowItWorks />
                 <Benchmarks />
+                <BusinessCase />
                 <Features />
                 <Assessment />
                 <FAQ />

--- a/site/src/app/privacy/page.tsx
+++ b/site/src/app/privacy/page.tsx
@@ -6,31 +6,50 @@ export const metadata = {
     description: 'Privacy policy for NeuralMind. The engine runs 100% locally with no telemetry — this policy explains the little that\'s left.',
 };
 
-const sections = [
+type Section = {
+    title: string;
+    body: string | string[];
+    list?: string[];
+};
+
+const sections: Section[] = [
     {
         title: 'Overview',
-        body: 'NeuralMind is built on a simple principle: your code stays on your machine. We designed the product to function 100% locally, with zero cloud calls for any code processing. This policy explains what data we collect (very little), why, and your rights.',
+        body: 'NeuralMind is built on a simple principle: your code stays on your machine. We designed the product to function 100% locally, with zero cloud calls for any code processing. This policy explains what data we collect (very little), why, and your rights. The full, canonical GDPR policy is maintained in the open at github.com/dfrostar/neuralmind/blob/main/docs/PRIVACY-POLICY.md.',
     },
     {
         title: 'Data We Do Not Collect',
-        body: 'We do not collect, transmit, or store your source code, queries, file paths, graph data, synapse weights, or any file contents. The index lives entirely in your project\'s `.neuralmind/` and `graphify-out/` directories on your machine. The NeuralMind software has no telemetry of any kind — not opt-in, not anonymous, none. It makes zero network calls of its own; the only network traffic in your workflow is what your AI agent sends to its own model provider, which NeuralMind minimizes but does not control.',
+        body: 'We do not collect, transmit, or store your source code, queries, file paths, graph data, synapse weights, or any file contents. The index lives entirely in your project\'s `.neuralmind/` and `graphify-out/` directories on your machine. The NeuralMind software has no telemetry of any kind — not opt-in, not anonymous, none. It makes zero network calls of its own; the only network traffic in your workflow is what your AI agent sends to its own model provider, which NeuralMind minimizes but does not control. Payment card data never touches our systems — it is handled entirely by Stripe.',
     },
     {
         title: 'Data We Collect',
         body: [
-            'From the software: nothing. There is no telemetry mechanism in the product.',
+            'From the open-source software: nothing. There is no telemetry mechanism in the product.',
+            'Team tier license data: your email address (and optional company name) when you purchase a license, the seat email addresses you add, and license metadata (tier, seats, expiry, signature hash).',
+            'Payment: a Stripe customer ID for reconciliation. Card data is handled entirely by Stripe (PCI-DSS Level 1) and never touches our systems.',
+            'License portal: IP address and user agent are recorded in audit logs when you use the license portal, for security monitoring and fraud prevention.',
             'PyPI download counts (public registry data, collected by PyPI, not by us)',
             'Website visitor analytics on neuralmind.uk (see Cloudflare section below)',
+        ],
+    },
+    {
+        title: 'Data Retention',
+        body: 'We keep Team-tier data only as long as the law and license validation require:',
+        list: [
+            'Active license data: duration of the license + 3 years after expiry',
+            'Audit logs (with IP): 3 years after creation, then anonymized',
+            'Financial records (Stripe): 7 years, required for tax compliance',
+            'Deleted customer records: personal data anonymized immediately; financial records retained per above',
         ],
     },
     {
         title: 'GDPR & Your Rights',
         body: 'Because we have minimal data collection, exercising your rights is simple:',
         list: [
-            'Right to access: we hold no personal data about you to access; for website analytics questions email hello@neuralmind.uk',
-            'Right to deletion: your index is local files you control — delete your project\'s `.neuralmind/` directory (or run `neuralmind reset`) and it is gone completely',
+            'Right to access: for the open-source tool we hold no personal data about you at all; Team-tier customers can request a copy of their license and audit data at hello@neuralmind.uk',
+            'Right to deletion: your index is local files you control — delete your project\'s `.neuralmind/` directory (or run `neuralmind reset`) and it is gone completely. Team-tier customers: email hello@neuralmind.uk and personal data is deleted (financial records are anonymized per the retention policy above)',
             'Right to portability: your local data is already in open formats (SQLite and JSON) inside your project directory',
-            'EU Representative: Darren Frost, Cheval-Volant LLC, Delaware, USA',
+            'EU Representative: Darren Frost, Cheval-Volant LLC, Texas, USA',
         ],
     },
     {
@@ -39,7 +58,7 @@ const sections = [
     },
     {
         title: 'Cookies & Tracking',
-        body: 'NeuralMind does not use cookies on neuralmind.uk or any of its services. We have no advertising pixels, no cross-site trackers, and no fingerprinting.',
+        body: 'NeuralMind does not use cookies on neuralmind.uk. The Team license portal uses a single strictly-necessary session cookie for authentication — nothing else. We have no advertising pixels, no cross-site trackers, and no fingerprinting anywhere.',
     },
     {
         title: 'Third-Party Services',
@@ -47,11 +66,12 @@ const sections = [
             'GitHub: for source code hosting and releases. GitHub\'s privacy policy applies.',
             'PyPI: for package distribution. Python Software Foundation privacy policy applies.',
             'Cloudflare: for domain, DNS, and Pages hosting. Cloudflare\'s privacy policy applies.',
+            'Stripe: payment processing for Team licenses. Card data goes directly to Stripe; Stripe\'s privacy policy applies.',
         ],
     },
     {
         title: 'Changes to This Policy',
-        body: 'We may update this policy as the product evolves. Material changes will be announced on the GitHub repository and linked from this page. Last updated: July 2026.',
+        body: 'We may update this policy as the product evolves. Material changes will be announced on the GitHub repository and linked from this page. Last updated: July 20, 2026.',
     },
     {
         title: 'Contact',
@@ -66,11 +86,22 @@ export default function Privacy() {
             <main className="pt-32 pb-20 px-4 md:px-6">
                 <article className="max-w-3xl mx-auto">
                     <h1 className="font-display text-3xl sm:text-4xl md:text-5xl font-bold text-white mb-4">Privacy Policy</h1>
-                    <p className="text-slate-400 text-lg mb-12">Last updated: July 2026</p>
+                    <p className="text-slate-400 text-lg mb-12">Last updated: July 20, 2026</p>
                     {sections.map((s) => (
                         <div key={s.title} className="mb-10">
                             <h2 className="font-display text-2xl font-bold text-white mb-3 border-l-4 border-electric pl-4">{s.title}</h2>
-                            <p className="text-slate-300 leading-relaxed">{s.body}</p>
+                            {Array.isArray(s.body) ? (
+                                <ul className="space-y-2 text-slate-300">
+                                    {s.body.map((item) => (
+                                        <li key={item} className="flex items-start gap-2">
+                                            <span className="text-emerald-400 mt-1.5">•</span>
+                                            <span>{item}</span>
+                                        </li>
+                                    ))}
+                                </ul>
+                            ) : (
+                                <p className="text-slate-300 leading-relaxed">{s.body}</p>
+                            )}
                             {s.list && (
                                 <ul className="mt-3 space-y-2 text-slate-300">
                                     {s.list.map((item) => (

--- a/site/src/components/sections/Assessment.tsx
+++ b/site/src/components/sections/Assessment.tsx
@@ -3,6 +3,7 @@
 const assessmentIncludes = [
     'A measured token-reduction ratio on one of your own repos — run locally, nothing leaves your machine',
     'A spend model in your numbers: per-seat subscriptions, usage-based API (OpenRouter, Bedrock, Vertex), and self-hosted GPU',
+    'A productivity model: hours lost to context-limit thrashing and re-prompting, valued at your fully-loaded rate',
     'An honest fit verdict — if your workload is generation-heavy or caching already covers you, we say so',
 ];
 

--- a/site/src/components/sections/BusinessCase.tsx
+++ b/site/src/components/sections/BusinessCase.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+const cards = [
+    {
+        audience: 'For the CFO',
+        title: 'The savings are free',
+        accent: 'text-proton',
+        points: [
+            'The 40–70× token compression ships in the free MIT core — the savings cost nothing, and you can measure them on your own repo in ~15 minutes.',
+            'Modeled at 30 code questions per developer per day, a 50-developer team gets back ~$310/mo on inference alone.',
+            'The bigger line is time: ~$1,650/mo per 50-dev team recovered from context-limit thrashing and re-prompting, at a $50/hr fully-loaded rate.',
+            'The Team tier ($29/user/mo) buys governance, audit, and self-hosting — not the savings. Those ship free.',
+        ],
+    },
+    {
+        audience: 'For the CTO',
+        title: 'Fewer wrong answers, faster teams',
+        accent: 'text-electric',
+        points: [
+            'Blast-radius analysis before every refactor (`neuralmind impact`), and decision provenance for "why is the code like this?" (`neuralmind why`).',
+            'Team memory that gives a new engineer day-one context — committed to the repo, inherited automatically on their first build.',
+            'A hash-chained, tamper-evident audit log and seat governance that stand up to a compliance review.',
+            '100% local with zero code egress — verifiable on the wire. Works with the agents you already run: Claude Code, Cursor, Cline, any MCP agent. No rip-and-replace.',
+        ],
+    },
+];
+
+export default function BusinessCase() {
+    return (
+        <section id="business-case" className="relative py-16 md:py-32 px-4 md:px-6">
+            <div className="absolute top-1/3 left-1/2 -translate-x-1/2 w-[700px] h-[500px] bg-proton/3 rounded-full blur-[200px] -z-10" />
+
+            <div className="max-w-5xl mx-auto">
+                <div className="text-center mb-12 md:mb-16">
+                    <span className="text-proton text-sm font-semibold tracking-wider uppercase mb-3 block">
+                        The business case
+                    </span>
+                    <h2 className="font-display text-3xl sm:text-4xl md:text-5xl font-bold text-white mb-4">
+                        The savings are free. The tier is control.
+                    </h2>
+                    <p className="text-slate-400 text-base sm:text-lg md:text-xl max-w-2xl mx-auto">
+                        Dollar figures below are modeled, with published assumptions — the free
+                        assessment runs the same model in your numbers.
+                    </p>
+                </div>
+
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-4 md:gap-6 mb-10">
+                    {cards.map((card) => (
+                        <div key={card.audience} className="glow-card rounded-2xl p-6 md:p-8">
+                            <span className={`text-xs font-semibold uppercase tracking-wider ${card.accent} mb-2 block`}>
+                                {card.audience}
+                            </span>
+                            <h3 className="font-display text-xl md:text-2xl font-bold text-white mb-4">{card.title}</h3>
+                            <ul className="space-y-3">
+                                {card.points.map((point) => (
+                                    <li key={point} className="flex items-start gap-3 text-sm text-slate-300 leading-relaxed">
+                                        <svg className="w-5 h-5 text-emerald-400 shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                                        </svg>
+                                        {point}
+                                    </li>
+                                ))}
+                            </ul>
+                        </div>
+                    ))}
+                </div>
+
+                <div className="flex flex-col sm:flex-row items-center justify-center gap-6 text-sm">
+                    <a
+                        href="https://github.com/dfrostar/neuralmind/blob/main/docs/BUSINESS-CASE.md"
+                        className="text-electric hover:text-white transition-colors font-medium"
+                    >
+                        Read the full business case, assumptions included →
+                    </a>
+                    <a
+                        href="#assessment"
+                        className="text-proton hover:text-white transition-colors font-medium"
+                    >
+                        Get the numbers for your team →
+                    </a>
+                </div>
+            </div>
+        </section>
+    );
+}

--- a/site/src/components/sections/FAQ.tsx
+++ b/site/src/components/sections/FAQ.tsx
@@ -17,7 +17,15 @@ const faqs = [
     },
     {
         q: 'What is the CI-gated tuner?',
-        a: 'NeuralMind runs a population-based evolutionary search over its own retrieval parameters. Candidate configs are evaluated against your fixture queries by an independent quality harness. Promotion requires both harness pass AND beating the incumbent by a hysteresis margin. The daemon proposes; the harness disposes.',
+        a: 'A self-improvement engine landing in the next release: a population-based evolutionary search over NeuralMind\'s own retrieval parameters. Candidate configs are evaluated against your fixture queries by an independent quality harness. Promotion requires both harness pass AND beating the incumbent by a hysteresis margin. The daemon proposes; the harness disposes.',
+    },
+    {
+        q: 'Is NeuralMind free? What does the paid tier actually buy?',
+        a: 'The MIT core is free forever — including all of the token compression; the 40–70× savings cost nothing. A 1-seat free license auto-issues the first time you run a `neuralmind team` command, no signup. NeuralMind Team ($29/user/mo, annual, 5–50 seats) adds what engineering organizations need on top: admin-controlled memory governance, a tamper-evident hash-chained audit log, seat management, and self-hosted deployment. You are paying for compliance and control, not for the compression.',
+    },
+    {
+        q: 'What\'s the business case for a team?',
+        a: 'Two lines: the measured token reduction (free, verify it on your own repo in ~15 minutes), and modeled productivity recovery — engineers stop losing hours to context-limit thrashing and re-prompting. We publish the full model with its assumptions, and the free assessment runs it in your numbers. If your workload is generation-heavy or prompt caching already covers you, we say so.',
     },
     {
         q: 'What languages does it support?',

--- a/site/src/components/sections/Features.tsx
+++ b/site/src/components/sections/Features.tsx
@@ -53,7 +53,7 @@ const featureList = [
         icon: '⚙️',
         title: 'CI-Gated Tuner',
         desc: 'Population-based evolutionary search proposes configs. An independent quality harness validates against fixture queries before promotion. The daemon proposes; the harness disposes.',
-        badge: 'v1.2.0',
+        badge: 'In development',
     },
     {
         icon: '🔒',

--- a/site/src/components/sections/Hero.tsx
+++ b/site/src/components/sections/Hero.tsx
@@ -6,7 +6,7 @@ const tags = ['Claude Code', 'Cursor', 'Cline', 'Continue', 'MCP'];
 const heroStats = [
     { label: 'Token Ratio', value: '40–70×', highlight: true },
     { label: 'Languages Indexed', value: '10', highlight: false },
-    { label: 'CI-Gated Tuner', value: 'C4', highlight: false },
+    { label: 'Gold-File Recall', value: '100%', highlight: false },
     { label: 'Impact Tool', value: 'Blast Radius', highlight: false },
 ];
 


### PR DESCRIPTION
Same-day refresh ahead of a business-buyer demo. Two goals: fix accuracy issues a diligent CTO would catch, and tighten the CFO/CTO message using only claims the repo can defend.

## Credibility fixes
- **Features**: CI-Gated Tuner badge `v1.2.0` → `In development` — that version doesn't exist (latest release is v1.1.1; the tuner feat landed after it). Also per CLAUDE.md: never hardcode versions, including anticipated ones.
- **Hero**: internal codename stat `C4` → restored `Gold-File Recall 100%`.
- **FAQ**: tuner answer now says it's landing in the next release.
- **Privacy page** reconciled with canonical `docs/PRIVACY-POLICY.md`: **Texas** (Delaware was flagged in-repo as entity drift), Team-tier data collection + retention disclosed (email/seats/Stripe ID/audit IPs — live surface since the v0.56 license portal), portal session-cookie caveat, `Last updated: July 20, 2026`, and array sections now render as bullet lists (was concatenated prose).

## CFO/CTO message tightening
Strategy per the repo's own enterprise analysis: token savings alone can't carry a per-seat pitch — the story is **the savings are free (MIT core); the tier sells governance and control**.
- New **BusinessCase** section (between Benchmarks and Features): CFO card (modeled ~$310/mo tokens + ~$1,650/mo productivity per 50-dev team, sourced from `docs/BUSINESS-CASE.md`, labeled modeled) and CTO card (impact, why, team memory, audit, 100% local, no rip-and-replace).
- **FAQ**: two business-buyer entries (free vs paid tier; the team business case).
- **Assessment**: added the productivity-model bullet.
- **Untouched by design**: Benchmarks (CI-measured numbers stay segregated from modeled dollars), Hero headline, CTA, /security.

Verified: `npm run build` clean (type-checked, 7/7 pages); built output greps confirm new strings present, `v1.2.0`/`Delaware` absent. Merging fires `deploy-site.yml` → Cloudflare Pages (~3–5 min to live).

⚠️ One pre-merge confirmation: privacy page now says **Cheval-Volant LLC, Texas, USA** (per the canonical policy). If the LLC is Delaware-registered and Texas-operated, tell me and I'll adjust to "Cheval-Volant LLC (Delaware LLC), operating from Texas, USA".

🤖 Generated with [Claude Code](https://claude.com/claude-code)