### PR TITLE
docs: publish real-world rebuild field report (48.8×, synapse edges 36→135)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,9 +10,7 @@ dist/
 downloads/
 eggs/
 .eggs/
-lib/
-# lib/ above targets Python packaging output; the site's source lib is real code.
-!site/src/lib/
+/lib/
 lib64/
 parts/
 sdist/

--- a/README.md
+++ b/README.md
@@ -1895,9 +1895,10 @@ Real-world numbers submitted by users. You submit only the numbers, not your cod
 | Project | Lang | Nodes | Wakeup | Avg Query | Reduction | Model | Submitted |
 |---------|------|------:|-------:|----------:|----------:|-------|-----------|
 | cmmc20 | JavaScript | 241 | 341 | 739 | **65.6×** | Claude 3.5 Sonnet | [@dfrostar](https://github.com/dfrostar) · 2025-10-01 |
+| ts-saas-platform (anon) | TypeScript | 9,293 | 455 | 1,033 | **48.8×** | — | [@dfrostar](https://github.com/dfrostar) · 2026-07-20 |
 | mempalace | Python | 1,626 | 412 | 891 | **46.0×** | Claude 3.5 Sonnet | [@dfrostar](https://github.com/dfrostar) · 2025-10-01 |
 
-_2 submission(s). See the [JSON data](docs/community-benchmarks.json) for notes and verification commands, or the [interactive dashboard](https://dfrostar.github.io/neuralmind/benchmarks/) for scatter + by-language charts._
+_3 submission(s). See the [JSON data](docs/community-benchmarks.json) for notes and verification commands, or the [interactive dashboard](https://dfrostar.github.io/neuralmind/benchmarks/) for scatter + by-language charts._
 <!-- COMMUNITY-BENCHMARKS:END -->
 
 **Submit yours:**

--- a/docs/HONEST-ASSESSMENT.md
+++ b/docs/HONEST-ASSESSMENT.md
@@ -38,7 +38,7 @@ vs. generation, which varies wildly by workload. For a typical
 Claude Code session the realistic end-to-end savings is **3–10×**
 total cost, not 40–70×.
 
-The community-benchmark table is currently **two entries from the
+The community-benchmark table is currently **three entries from the
 maintainer's own projects**. Numbers from outside contributors are
 the single most valuable thing you can give back if NeuralMind ends
 up working for you.
@@ -110,7 +110,7 @@ If it makes 5 calls a day on a 5K-token repo, it doesn't.
 ## The community benchmark caveat
 
 The table in [README.md](../README.md#community-benchmarks) currently
-has **two entries**, both from repositories owned by the project
+has **three entries**, all from repositories owned by the project
 maintainer. This is honest disclosure, not a flaw — the project is
 new and outside benchmarks take time to accumulate. But it means:
 

--- a/docs/community-benchmarks.json
+++ b/docs/community-benchmarks.json
@@ -27,6 +27,18 @@
       "submitted_by": "dfrostar",
       "verification_command": "neuralmind benchmark . --json",
       "notes": "Python backend; larger node count, modestly lower ratio — typical pattern on bigger repos."
+    },
+    {
+      "project_name": "ts-saas-platform (anon)",
+      "language": "TypeScript",
+      "nodes": 9293,
+      "avg_wakeup_tokens": 455,
+      "avg_query_tokens": 1033,
+      "avg_reduction_ratio": 48.8,
+      "date_submitted": "2026-07-20",
+      "submitted_by": "dfrostar",
+      "verification_command": "neuralmind benchmark . --json",
+      "notes": "Private mid-size TypeScript SaaS platform, anonymized. Measured after a major internal rebuild; personal synapse edges grew 36->135 across the change. Full case study: docs/use-cases/measure-memory-across-a-refactor.md"
     }
   ]
 }

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -38,7 +38,7 @@
   </url>
   <url>
     <loc>https://docs.neuralmind.uk/use-cases/</loc>
-    <lastmod>2026-07-15</lastmod>
+    <lastmod>2026-07-20</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
@@ -151,12 +151,6 @@
     <priority>0.6</priority>
   </url>
   <url>
-    <loc>https://docs.neuralmind.uk/use-cases/blast-radius-before-a-rename.html</loc>
-    <lastmod>2026-07-12</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.6</priority>
-  </url>
-  <url>
     <loc>https://docs.neuralmind.uk/use-cases/branch-isolated-memory.html</loc>
     <lastmod>2026-06-20</lastmod>
     <changefreq>monthly</changefreq>
@@ -193,12 +187,6 @@
     <priority>0.6</priority>
   </url>
   <url>
-    <loc>https://docs.neuralmind.uk/use-cases/blast-radius-before-a-rename.html</loc>
-    <lastmod>2026-07-16</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.6</priority>
-  </url>
-  <url>
     <loc>https://docs.neuralmind.uk/use-cases/growing-monorepo.html</loc>
     <lastmod>2026-06-20</lastmod>
     <changefreq>monthly</changefreq>
@@ -229,6 +217,12 @@
     <priority>0.6</priority>
   </url>
   <url>
+    <loc>https://docs.neuralmind.uk/use-cases/measure-memory-across-a-refactor.html</loc>
+    <lastmod>2026-07-20</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
     <loc>https://docs.neuralmind.uk/wiki/API-Reference.html</loc>
     <lastmod>2026-07-13</lastmod>
     <changefreq>monthly</changefreq>
@@ -242,7 +236,7 @@
   </url>
   <url>
     <loc>https://docs.neuralmind.uk/wiki/Benchmarks.html</loc>
-    <lastmod>2026-07-13</lastmod>
+    <lastmod>2026-07-20</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>

--- a/docs/use-cases/README.md
+++ b/docs/use-cases/README.md
@@ -18,5 +18,6 @@ Walkthroughs for the most common "what do I actually do?" questions, organized b
 | **[Blast radius before a rename](./blast-radius-before-a-rename.md)** | **Anyone (or any agent) about to rename, re-sign, or delete a symbol (v0.42.0+)** | **See every caller / importer / subclass a change would touch, before you edit — from the static code graph** |
 | **[Decision provenance: answer "why is it like this?"](./decision-provenance.md)** | **Anyone inheriting code whose rationale lives in someone's head (v0.43.0+)** | **Capture a decision in a `Decision:` git trailer; recall it with `neuralmind why` — the *why* stored where it can't drift** |
 | **[Find the coverage that lies: mock-only endpoints](./find-untested-endpoints.md)** | **Anyone with a green suite that still ships DB failures (v0.44.0+)** | **`neuralmind gaps` classifies endpoints live-covered / mock-only / untested — catch the `P2003` before the live smoke** |
+| **[Measure memory across a major refactor (field report)](./measure-memory-across-a-refactor.md)** | **Anyone rebuilding a subsystem who wants proof the memory adapts** | **Before/after snapshot recipe + real case study: 48.8× reduction, personal synapse edges 36→135 on a ~9.3k-node TypeScript SaaS platform** |
 
 Not sure which applies? Start with the [symptom / goal table in the main README](../../README.md#-when-do-i-reach-for-neuralmind).

--- a/docs/use-cases/benchmark-your-repo.md
+++ b/docs/use-cases/benchmark-your-repo.md
@@ -231,6 +231,7 @@ A few things to check before giving up:
 
 - [Use case: Cost optimization](./cost-optimization.md) — baseline → measure → report template for stakeholders
 - [Use case: Claude Code user](./claude-code.md) — full two-phase workflow
+- [Use case: Measure memory across a major refactor](./measure-memory-across-a-refactor.md) — the before/after version of this benchmark, with a real-world field report
 - [Comparisons: vs long context windows](../comparisons/vs-long-context.md) — why 1M-token windows don't solve this
 
 ---

--- a/docs/use-cases/measure-memory-across-a-refactor.md
+++ b/docs/use-cases/measure-memory-across-a-refactor.md
@@ -132,6 +132,7 @@ memory wasn't watching — check that hooks were installed *before* the work.
 
 ## Related
 
+- [Shareable single-page version](https://neuralmind.uk/field-reports/measure-memory-across-a-refactor/) — this field report on neuralmind.uk
 - [Use case: Does it work on your code? (5-minute benchmark)](./benchmark-your-repo.md) — the first-run version of this measurement
 - [Use case: Growing monorepo](./growing-monorepo.md) — keeping the index fresh with minimal effort
 - [Wiki: Brain-Like Learning Guide](../wiki/Learning-Guide.md) — how the synapse layer learns what this page measures

--- a/docs/use-cases/measure-memory-across-a-refactor.md
+++ b/docs/use-cases/measure-memory-across-a-refactor.md
@@ -1,0 +1,141 @@
+# Measure how your AI memory improves across a major refactor
+
+You just rebuilt a subsystem. Did your AI agent's memory keep up — or is it
+recalling a codebase that no longer exists? With NeuralMind this is measurable:
+snapshot the graph and synapse stats before the refactor, work normally,
+snapshot after, and diff.
+
+This page is two things: a **field report** with real numbers from a private
+mid-size TypeScript SaaS platform (~9,300 nodes) measured across a major
+internal rebuild, and a **recipe** for running the same before/after
+measurement on your own repo.
+
+## The field report
+
+**The setting.** A private, mid-size TypeScript SaaS platform (~9,300 indexed
+nodes), maintained by NeuralMind's own maintainer — see the honesty notes
+below. A major internal rebuild ("Phase 3 → Phase 4") landed a new backend
+module, a shared business-logic layer, an admin UI, and end-to-end specs.
+NeuralMind ran throughout with lifecycle hooks installed, so the synapse layer
+observed the work as it happened. The repo is private, so the numbers are
+anonymized; every one of them came from the shipped CLI.
+
+**The numbers.**
+
+| Metric | Before (Phase 3) | After (Phase 4) | Change |
+|---|---:|---:|---|
+| Total nodes | 9,190 | 9,293 | +103 |
+| Communities | — | 810 | new resolution — no comparable before |
+| Personal synapse edges | 36 | 135 | **+275%** |
+| Shared synapse edges | 10,079 | 10,183 | +104 |
+| Shared edge weight | 2,774.73 | 2,924.66 | **+5.4%** |
+| Wake-up tokens | — | 455 | |
+| Avg query tokens | — | 1,033 | |
+| Avg token reduction | — | **48.8×** | vs loading files naively |
+| Full `--force` rebuild | — | 326 s (~5.4 min) | incremental rebuilds ~30 s after |
+
+**What the numbers say**
+
+- **48.8× token reduction** — after the rebuild, an average code question cost
+  ~1,033 tokens of context instead of the 50K+ a naive "load the relevant
+  files" approach would spend. That is one repo's measured ratio from
+  `neuralmind benchmark .`, consistent with the
+  [40–70× real-repo range](../wiki/Benchmarks.md) — not a universal guarantee.
+- **Personal synapse edges tripled (36 → 135)** — the
+  [Hebbian synapse layer](../wiki/Learning-Guide.md) learned co-activations
+  across the *new* code as it was being written and queried. The memory didn't
+  go stale through the rebuild; it grew into the new architecture.
+- **Shared edge weight +5.4%** — the static graph's cross-links got denser as
+  the new shared business-logic layer connected previously separate areas.
+- **Rebuild cost stayed flat** — one full `--force` rebuild at 326 s to pick up
+  the new structure, then incremental rebuilds back to ~30 s. Re-indexing is
+  not a tax you pay per edit.
+
+## Where each number comes from
+
+Honesty first: the before/after table above is **hand-assembled from the
+output of several commands** — there is no single `neuralmind compare-phases`
+command.
+
+| Metric | Command |
+|---|---|
+| Total nodes, communities | `neuralmind stats . --json` (nodes also printed at build time) |
+| Personal/shared edges, edge weight | `neuralmind stats .` — the `Memory namespaces` block (per-namespace `edges (weight …)`) |
+| Wake-up tokens, avg query tokens, avg reduction | `neuralmind benchmark .` |
+| Rebuild time | timed `neuralmind build . --force` (and an untimed incremental `build`) |
+| Synapses fired per query, mean tokens | `neuralmind metrics .` |
+| Real logged spend | `neuralmind savings .` |
+
+## Run the same measurement on your refactor
+
+### Step 1 — Snapshot before you start
+
+```bash
+neuralmind stats . --json > .neuralmind-before.json
+neuralmind stats .          # eyeball the Memory namespaces block
+neuralmind benchmark .      # baseline reduction number
+```
+
+Keep the JSON out of your commit (or don't — it's small and diffs nicely).
+
+### Step 2 — Do the refactor, with the memory watching
+
+The synapse layer only learns from what it observes. Make sure hooks are
+installed before the work starts:
+
+```bash
+neuralmind install-hooks .
+neuralmind watch &   # optional: always-on learning from edits
+```
+
+Then work normally — query, edit, run tools. No manual "learn" step exists;
+co-activations are recorded as you go (see the
+[Learning Guide](../wiki/Learning-Guide.md)).
+
+### Step 3 — Rebuild and snapshot after
+
+```bash
+time neuralmind build . --force   # once, to pick up new structure
+neuralmind stats . --json > .neuralmind-after.json
+neuralmind stats .
+```
+
+Diff the two JSON files (or the two `Memory namespaces` blocks). The
+interesting deltas: node count (did the graph track the new code?), personal
+edges (did the memory learn the new co-activations?), shared edge weight (did
+the graph get denser or just bigger?).
+
+### Step 4 — Re-benchmark and price it
+
+```bash
+neuralmind benchmark .   # reduction ratio on the post-refactor graph
+neuralmind metrics .     # mean tokens/query and synapses fired, from real usage
+neuralmind savings .     # what your actual logged queries cost vs naive
+```
+
+If the reduction ratio held (or improved) across the rebuild, your agent's
+context bill survived the refactor. If personal edges barely moved, the
+memory wasn't watching — check that hooks were installed *before* the work.
+
+## Honesty notes
+
+- This is **one repo, one developer, measured by the maintainer on a private
+  codebase**. It is an existence proof and a recipe, not an independent
+  benchmark. You cannot re-run it on the source repo — but you can run the
+  identical method on yours, which is the point.
+- 48.8× is a reduction in **retrieval input tokens**, not your total LLM
+  bill. For typical end-to-end agent sessions the realistic total-cost saving
+  is smaller — see the [Honest assessment](../HONEST-ASSESSMENT.md).
+- The CI-gated, reproducible numbers live in
+  [Benchmarks & Results](../wiki/Benchmarks.md); this page is deliberately
+  labeled a field report.
+
+## Related
+
+- [Use case: Does it work on your code? (5-minute benchmark)](./benchmark-your-repo.md) — the first-run version of this measurement
+- [Use case: Growing monorepo](./growing-monorepo.md) — keeping the index fresh with minimal effort
+- [Wiki: Brain-Like Learning Guide](../wiki/Learning-Guide.md) — how the synapse layer learns what this page measures
+
+---
+
+[← Back to use-case index](./README.md) · [Main README](../../README.md)

--- a/docs/wiki/Benchmarks.md
+++ b/docs/wiki/Benchmarks.md
@@ -3,7 +3,10 @@
 Everything here is **measured and reproducible** — no hand-picked or hardcoded
 numbers. Every figure is produced by code in the repo and **gated in CI**, so it
 can't silently regress. Where a number is an estimate or a real-repo
-extrapolation, it says so.
+extrapolation, it says so. One labeled exception: the
+[field report](#field-report-a-real-world-rebuild-not-ci-gated) below is a
+one-repo, maintainer-measured case study — reproducible in method, not gated
+in CI.
 
 > Reproduce locally: `python -m tests.benchmark.run` (token reduction + learning
 > + synapse A/B), `python -m evals.faithfulness.runner --run` (answer quality),
@@ -114,6 +117,26 @@ numbers above are emitted live by the parity gate on every PR. Per-language *ans
 quality* (vs structural coverage) is still Python-first; see
 [Limits & Failure Modes](Limits-and-Failure-Modes#3-language-support-matrix).
 
+## Field report: a real-world rebuild (not CI-gated)
+
+Unlike everything above, this is a **field report**: the maintainer ran
+NeuralMind across a major internal rebuild of a private, mid-size TypeScript
+SaaS platform (~9,300 nodes) and recorded before/after numbers with the
+shipped CLI (`neuralmind stats` / `benchmark`, a timed `build --force`). One
+repo, one developer, anonymized — reproducible in *method* on your own
+codebase, but not a CI-gated claim.
+
+| Headline | Value |
+|---|---|
+| Avg token reduction (`neuralmind benchmark`) | **48.8×** (~1,033 tokens/query vs 50K+ naive) |
+| Personal synapse edges across the rebuild | **36 → 135** — the learning layer tracked the new code |
+| Shared edge weight | **+5.4%** (denser cross-links after a new shared layer) |
+| Full `--force` rebuild / incremental after | **326 s** / **~30 s** |
+
+Full table, interpretation, and a step-by-step recipe for the same
+before/after measurement on your own refactor:
+[Measure memory across a major refactor](https://github.com/dfrostar/neuralmind/blob/main/docs/use-cases/measure-memory-across-a-refactor.md).
+
 ## What we *don't* claim
 
 - The CI numbers come from a **deliberately tiny fixture** — they prove the
@@ -123,6 +146,9 @@ quality* (vs structural coverage) is still Python-first; see
   reference fixture, and the compression win only matters at scale.
 - The 40–70× figure is a real-repo range, not a fixed guarantee — your ratio
   depends on repo size and question shape.
+- The field report above is a single private-repo measurement by the
+  maintainer — treat it as an existence proof consistent with the 40–70×
+  range, not an independent benchmark.
 
 ## Reproduce every number
 

--- a/docs/wiki/Learning-Guide.md
+++ b/docs/wiki/Learning-Guide.md
@@ -123,6 +123,11 @@ $ neuralmind query . "How does auth work?"
    File: middleware.py
 ```
 
+Real-world data point: across a major rebuild of a private ~9,300-node
+TypeScript SaaS platform, personal synapse edges grew **36 → 135** as the
+layer learned the new code's co-activations — see the
+[field report](https://github.com/dfrostar/neuralmind/blob/main/docs/use-cases/measure-memory-across-a-refactor.md).
+
 ### Step 5: Continuous Improvement
 
 There is no weekly `neuralmind learn` step to run. The synapse store

--- a/scripts/render_community_table.py
+++ b/scripts/render_community_table.py
@@ -50,7 +50,10 @@ def render_table(entries: list[dict]) -> str:
     lines.append("")
     lines.append(
         f"_{len(entries)} submission(s). See the [JSON data]"
-        f"(docs/community-benchmarks.json) for notes and verification commands._"
+        f"(docs/community-benchmarks.json) for notes and verification commands, "
+        f"or the [interactive dashboard]"
+        f"(https://dfrostar.github.io/neuralmind/benchmarks/) for scatter + "
+        f"by-language charts._"
     )
     return "\n".join(lines)
 

--- a/site/public/sitemap.xml
+++ b/site/public/sitemap.xml
@@ -36,4 +36,10 @@
     <changefreq>yearly</changefreq>
     <priority>0.8</priority>
   </url>
+  <url>
+    <loc>https://neuralmind.uk/field-reports/measure-memory-across-a-refactor/</loc>
+    <lastmod>2026-07-20</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
 </urlset>

--- a/site/src/app/field-reports/measure-memory-across-a-refactor/page.tsx
+++ b/site/src/app/field-reports/measure-memory-across-a-refactor/page.tsx
@@ -1,0 +1,407 @@
+import Navbar from '@/components/Navbar';
+import Footer from '@/components/sections/Footer';
+
+const GITHUB_URL = 'https://github.com/dfrostar/neuralmind';
+const CANONICAL = 'https://neuralmind.uk/field-reports/measure-memory-across-a-refactor/';
+const WALKTHROUGH_URL = `${GITHUB_URL}/blob/main/docs/use-cases/measure-memory-across-a-refactor.md`;
+const PUBLISHED = '2026-07-20';
+
+export const metadata = {
+    title: 'Field Report: AI Agent Memory Across a Major Refactor — 48.8× Token Reduction | NeuralMind',
+    description:
+        'Real-world case study: a ~9,300-node TypeScript SaaS platform rebuilt with NeuralMind watching — 48.8× token reduction, personal synapse edges 36→135. Full numbers, method, and a recipe to measure your own refactor.',
+    keywords: [
+        'AI coding agent memory',
+        'token reduction case study',
+        'AI agent refactoring',
+        'context compression benchmark',
+        'Hebbian synapse layer',
+        'code intelligence field report',
+        'LLM token cost reduction',
+        'measure agent memory',
+        'refactor with AI agent',
+        'NeuralMind',
+    ],
+    authors: [{ name: 'Darren Frost' }],
+    creator: 'Darren Frost',
+    publisher: 'NeuralMind',
+    metadataBase: new URL('https://neuralmind.uk'),
+    alternates: {
+        canonical: '/field-reports/measure-memory-across-a-refactor/',
+    },
+    openGraph: {
+        title: 'Field Report: AI Agent Memory Across a Major Refactor',
+        description:
+            'A ~9,300-node TypeScript SaaS platform was rebuilt with NeuralMind watching: 48.8× token reduction, synapse edges 36→135. One repo, honestly measured — with the recipe to run it on yours.',
+        url: CANONICAL,
+        siteName: 'NeuralMind',
+        locale: 'en_US',
+        type: 'article',
+        publishedTime: PUBLISHED,
+        modifiedTime: PUBLISHED,
+        authors: ['Darren Frost'],
+        tags: ['field report', 'case study', 'token reduction', 'AI agent memory', 'refactoring'],
+        images: [
+            {
+                url: '/social-preview.png',
+                width: 1200,
+                height: 630,
+                alt: 'NeuralMind field report: AI agent memory across a major refactor',
+            },
+        ],
+    },
+    twitter: {
+        card: 'summary_large_image',
+        title: 'Field Report: AI Agent Memory Across a Major Refactor',
+        description:
+            '48.8× token reduction and synapse edges 36→135, measured across a real rebuild of a ~9,300-node TypeScript SaaS platform.',
+        images: ['https://neuralmind.uk/social-preview.png'],
+    },
+    robots: {
+        index: true,
+        follow: true,
+        googleBot: { index: true, follow: true },
+    },
+};
+
+const numbers = [
+    { metric: 'Total nodes', before: '9,190', after: '9,293', change: '+103' },
+    { metric: 'Communities', before: '—', after: '810', change: 'new resolution — no comparable before' },
+    { metric: 'Personal synapse edges', before: '36', after: '135', change: '+275%', highlight: true },
+    { metric: 'Shared synapse edges', before: '10,079', after: '10,183', change: '+104' },
+    { metric: 'Shared edge weight', before: '2,774.73', after: '2,924.66', change: '+5.4%', highlight: true },
+    { metric: 'Wake-up tokens', before: '—', after: '455', change: '' },
+    { metric: 'Avg query tokens', before: '—', after: '1,033', change: '' },
+    { metric: 'Avg token reduction', before: '—', after: '48.8×', change: 'vs loading files naively', highlight: true },
+    { metric: 'Full --force rebuild', before: '—', after: '326 s (~5.4 min)', change: 'incremental rebuilds ~30 s after' },
+];
+
+const provenance = [
+    { metric: 'Total nodes, communities', command: 'neuralmind stats . --json' },
+    { metric: 'Personal/shared edges, edge weight', command: 'neuralmind stats . — the Memory namespaces block' },
+    { metric: 'Wake-up / query tokens, reduction', command: 'neuralmind benchmark .' },
+    { metric: 'Rebuild time', command: 'timed neuralmind build . --force' },
+    { metric: 'Synapses fired per query', command: 'neuralmind metrics .' },
+    { metric: 'Real logged spend', command: 'neuralmind savings .' },
+];
+
+const jsonLd = {
+    '@context': 'https://schema.org',
+    '@graph': [
+        {
+            '@type': 'TechArticle',
+            headline: 'Field Report: AI Agent Memory Across a Major Refactor',
+            alternativeHeadline: '48.8× token reduction and synapse growth measured across a real rebuild',
+            description:
+                'Real-world case study measuring NeuralMind across a major internal rebuild of a private ~9,300-node TypeScript SaaS platform: 48.8× average token reduction, personal synapse edges 36→135, shared edge weight +5.4%.',
+            author: {
+                '@type': 'Person',
+                name: 'Darren Frost',
+                url: 'https://github.com/dfrostar',
+            },
+            publisher: {
+                '@type': 'Organization',
+                name: 'NeuralMind',
+                url: 'https://neuralmind.uk',
+            },
+            datePublished: PUBLISHED,
+            dateModified: PUBLISHED,
+            mainEntityOfPage: { '@type': 'WebPage', '@id': CANONICAL },
+            image: 'https://neuralmind.uk/social-preview.png',
+            keywords: [
+                'AI coding agent memory',
+                'token reduction case study',
+                'context compression',
+                'Hebbian synapse layer',
+                'refactoring',
+            ],
+            about: {
+                '@type': 'SoftwareApplication',
+                name: 'NeuralMind',
+                url: GITHUB_URL,
+            },
+        },
+        {
+            '@type': 'BreadcrumbList',
+            itemListElement: [
+                { '@type': 'ListItem', position: 1, name: 'NeuralMind', item: 'https://neuralmind.uk/' },
+                { '@type': 'ListItem', position: 2, name: 'Field Reports', item: 'https://neuralmind.uk/field-reports/' },
+                { '@type': 'ListItem', position: 3, name: 'Memory Across a Major Refactor', item: CANONICAL },
+            ],
+        },
+    ],
+};
+
+export default function FieldReportPage() {
+    return (
+        <>
+            <Navbar />
+            <main className="max-w-4xl mx-auto px-4 md:px-6 py-16">
+                <script
+                    type="application/ld+json"
+                    dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+                />
+
+                {/* Header */}
+                <header className="mb-12 pb-8 border-b border-carbon-border">
+                    <div className="flex items-center gap-3 mb-4 flex-wrap">
+                        <span className="px-3 py-1 rounded-lg bg-proton/10 text-proton text-xs font-mono">Field Report — not CI-gated</span>
+                        <span className="text-slate-500 text-sm">July 20, 2026</span>
+                    </div>
+                    <h1 className="font-display text-3xl md:text-4xl font-bold text-white mb-4 leading-tight">
+                        Measuring AI agent memory across a major refactor
+                    </h1>
+                    <p className="text-lg text-slate-300 mb-4">
+                        A ~9,300-node TypeScript SaaS platform was rebuilt with NeuralMind watching.
+                        The memory didn&apos;t go stale — it grew into the new architecture. Here are the
+                        numbers, where each one came from, and how to run the same measurement on your repo.
+                    </p>
+                    <div className="flex items-center gap-4 text-sm text-slate-400">
+                        <span>Darren Frost (dfrostar)</span>
+                        <span>•</span>
+                        <a
+                            href={WALKTHROUGH_URL}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="text-electric hover:text-electric-bright transition-colors"
+                        >
+                            Full walkthrough on GitHub →
+                        </a>
+                    </div>
+                </header>
+
+                {/* Headline stats */}
+                <section className="mb-10">
+                    <div className="grid sm:grid-cols-3 gap-4">
+                        <div className="glow-card rounded-2xl p-6">
+                            <p className="text-slate-500 text-xs font-semibold uppercase tracking-wider mb-2">Avg token reduction</p>
+                            <p className="font-display text-3xl font-bold text-white mb-1">48.8×</p>
+                            <p className="text-slate-400 text-sm">~1,033 tokens/query vs 50K+ naive</p>
+                        </div>
+                        <div className="glow-card rounded-2xl p-6">
+                            <p className="text-slate-500 text-xs font-semibold uppercase tracking-wider mb-2">Personal synapse edges</p>
+                            <p className="font-display text-3xl font-bold text-white mb-1">36 → 135</p>
+                            <p className="text-slate-400 text-sm">the learning layer tracked the new code</p>
+                        </div>
+                        <div className="glow-card rounded-2xl p-6">
+                            <p className="text-slate-500 text-xs font-semibold uppercase tracking-wider mb-2">Full rebuild</p>
+                            <p className="font-display text-3xl font-bold text-white mb-1">326 s</p>
+                            <p className="text-slate-400 text-sm">then back to ~30 s incremental</p>
+                        </div>
+                    </div>
+                </section>
+
+                {/* The setting */}
+                <section className="mb-10">
+                    <h2 className="font-display text-xl font-bold text-white mb-4">The setting</h2>
+                    <div className="space-y-4 text-slate-300 leading-relaxed">
+                        <p>
+                            A private, mid-size TypeScript SaaS platform (~9,300 indexed nodes), maintained by
+                            NeuralMind&apos;s own maintainer — see the honesty notes below. A major internal rebuild
+                            (&quot;Phase 3 → Phase 4&quot;) landed a new backend module, a shared business-logic layer,
+                            an admin UI, and end-to-end specs.
+                        </p>
+                        <p>
+                            NeuralMind ran throughout with lifecycle hooks installed, so the synapse layer observed
+                            the work as it happened. The repo is private, so the numbers are anonymized; every one
+                            of them came from the shipped CLI.
+                        </p>
+                    </div>
+                </section>
+
+                {/* The numbers */}
+                <section className="mb-10">
+                    <h2 className="font-display text-xl font-bold text-white mb-4">The numbers</h2>
+                    <div className="bg-carbon-card border border-carbon-border rounded-xl p-4 overflow-x-auto">
+                        <table className="w-full text-sm min-w-[540px]">
+                            <thead>
+                                <tr className="border-b border-carbon-border">
+                                    <th className="text-left py-2 text-slate-400 font-medium">Metric</th>
+                                    <th className="text-right py-2 text-slate-400 font-medium">Before (Phase 3)</th>
+                                    <th className="text-right py-2 text-slate-400 font-medium">After (Phase 4)</th>
+                                    <th className="text-left py-2 pl-4 text-slate-400 font-medium">Change</th>
+                                </tr>
+                            </thead>
+                            <tbody className="text-slate-300">
+                                {numbers.map((row) => (
+                                    <tr key={row.metric} className="border-b border-carbon-border/50 last:border-0">
+                                        <td className="py-2 pr-4">{row.metric}</td>
+                                        <td className="py-2 text-right font-mono">{row.before}</td>
+                                        <td className={`py-2 text-right font-mono ${row.highlight ? 'text-electric-bright font-bold' : ''}`}>{row.after}</td>
+                                        <td className={`py-2 pl-4 ${row.highlight ? 'text-white' : 'text-slate-400'}`}>{row.change}</td>
+                                    </tr>
+                                ))}
+                            </tbody>
+                        </table>
+                    </div>
+                </section>
+
+                {/* Interpretation */}
+                <section className="mb-10">
+                    <h2 className="font-display text-xl font-bold text-white mb-4">What the numbers say</h2>
+                    <div className="space-y-4 text-slate-300 leading-relaxed">
+                        <p>
+                            <strong className="text-white">48.8× token reduction.</strong> After the rebuild, an average
+                            code question cost ~1,033 tokens of context instead of the 50K+ a naive &quot;load the
+                            relevant files&quot; approach would spend. That is one repo&apos;s measured ratio from{' '}
+                            <code className="text-electric-bright bg-carbon px-1.5 py-0.5 rounded text-sm">neuralmind benchmark .</code>,
+                            consistent with the 40–70× real-repo range — not a universal guarantee.
+                        </p>
+                        <p>
+                            <strong className="text-white">Personal synapse edges tripled (36 → 135).</strong> The Hebbian
+                            synapse layer learned co-activations across the <em>new</em> code as it was being written
+                            and queried. The memory didn&apos;t go stale through the rebuild; it grew into the new
+                            architecture.
+                        </p>
+                        <p>
+                            <strong className="text-white">Shared edge weight +5.4%.</strong> The static graph&apos;s
+                            cross-links got denser as the new shared business-logic layer connected previously
+                            separate areas — densification, not just growth: edge weight rose 5.4% on only
+                            1.1% more nodes.
+                        </p>
+                        <p>
+                            <strong className="text-white">Rebuild cost stayed flat.</strong> One full{' '}
+                            <code className="text-electric-bright bg-carbon px-1.5 py-0.5 rounded text-sm">--force</code>{' '}
+                            rebuild at 326 s to pick up the new structure, then incremental rebuilds back to ~30 s.
+                            Re-indexing is not a tax you pay per edit.
+                        </p>
+                    </div>
+                </section>
+
+                {/* Provenance */}
+                <section className="mb-10">
+                    <h2 className="font-display text-xl font-bold text-white mb-4">Where each number comes from</h2>
+                    <p className="text-slate-300 mb-4 leading-relaxed">
+                        Honesty first: the before/after table is <strong className="text-white">hand-assembled from the
+                        output of several commands</strong> — there is no single{' '}
+                        <code className="text-electric-bright bg-carbon px-1.5 py-0.5 rounded text-sm">neuralmind compare-phases</code>{' '}
+                        command.
+                    </p>
+                    <div className="bg-carbon-card border border-carbon-border rounded-xl p-4 overflow-x-auto">
+                        <table className="w-full text-sm min-w-[480px]">
+                            <thead>
+                                <tr className="border-b border-carbon-border">
+                                    <th className="text-left py-2 text-slate-400 font-medium">Metric</th>
+                                    <th className="text-left py-2 text-slate-400 font-medium">Command</th>
+                                </tr>
+                            </thead>
+                            <tbody className="text-slate-300">
+                                {provenance.map((row) => (
+                                    <tr key={row.metric} className="border-b border-carbon-border/50 last:border-0">
+                                        <td className="py-2 pr-4">{row.metric}</td>
+                                        <td className="py-2 font-mono text-xs text-electric-bright">{row.command}</td>
+                                    </tr>
+                                ))}
+                            </tbody>
+                        </table>
+                    </div>
+                </section>
+
+                {/* Recipe */}
+                <section className="mb-10">
+                    <h2 className="font-display text-xl font-bold text-white mb-4">Run the same measurement on your refactor</h2>
+                    <div className="space-y-6">
+                        <div>
+                            <h3 className="text-lg font-semibold text-white mb-2">1. Snapshot before you start</h3>
+                            <div className="bg-carbon rounded-lg p-4 font-mono text-sm text-slate-300 overflow-x-auto">
+                                <p>neuralmind stats . --json &gt; .neuralmind-before.json</p>
+                                <p>neuralmind benchmark .      <span className="text-slate-500"># baseline reduction number</span></p>
+                            </div>
+                        </div>
+                        <div>
+                            <h3 className="text-lg font-semibold text-white mb-2">2. Refactor with the memory watching</h3>
+                            <p className="text-slate-300 mb-2 text-sm">
+                                The synapse layer only learns from what it observes — install hooks <em>before</em> the work starts.
+                            </p>
+                            <div className="bg-carbon rounded-lg p-4 font-mono text-sm text-slate-300 overflow-x-auto">
+                                <p>neuralmind install-hooks .</p>
+                                <p>neuralmind watch &amp;   <span className="text-slate-500"># optional: always-on learning from edits</span></p>
+                            </div>
+                        </div>
+                        <div>
+                            <h3 className="text-lg font-semibold text-white mb-2">3. Rebuild and snapshot after</h3>
+                            <div className="bg-carbon rounded-lg p-4 font-mono text-sm text-slate-300 overflow-x-auto">
+                                <p>time neuralmind build . --force</p>
+                                <p>neuralmind stats . --json &gt; .neuralmind-after.json</p>
+                            </div>
+                        </div>
+                        <div>
+                            <h3 className="text-lg font-semibold text-white mb-2">4. Re-benchmark and price it</h3>
+                            <div className="bg-carbon rounded-lg p-4 font-mono text-sm text-slate-300 overflow-x-auto">
+                                <p>neuralmind benchmark .   <span className="text-slate-500"># reduction on the post-refactor graph</span></p>
+                                <p>neuralmind savings .     <span className="text-slate-500"># what your logged queries cost vs naive</span></p>
+                            </div>
+                        </div>
+                        <p className="text-slate-300 leading-relaxed">
+                            Diff the two JSON files. The interesting deltas: node count (did the graph track the new
+                            code?), personal edges (did the memory learn the new co-activations?), shared edge weight
+                            (did the graph get denser or just bigger?). The{' '}
+                            <a href={WALKTHROUGH_URL} target="_blank" rel="noopener noreferrer" className="text-electric hover:text-electric-bright">
+                                full step-by-step walkthrough
+                            </a>{' '}
+                            lives in the docs.
+                        </p>
+                    </div>
+                </section>
+
+                {/* Honesty notes */}
+                <section className="mb-10">
+                    <h2 className="font-display text-xl font-bold text-white mb-4">Honesty notes</h2>
+                    <div className="bg-carbon-card border border-carbon-border rounded-xl p-6 space-y-3 text-slate-300 leading-relaxed text-sm">
+                        <p>
+                            <strong className="text-white">One repo, one developer, measured by the maintainer on a private
+                            codebase.</strong> It is an existence proof and a recipe, not an independent benchmark. You
+                            cannot re-run it on the source repo — but you can run the identical method on yours,
+                            which is the point.
+                        </p>
+                        <p>
+                            <strong className="text-white">48.8× is a reduction in retrieval input tokens</strong>, not your
+                            total LLM bill. For typical end-to-end agent sessions the realistic total-cost saving is
+                            smaller — see the{' '}
+                            <a href={`${GITHUB_URL}/blob/main/docs/HONEST-ASSESSMENT.md`} target="_blank" rel="noopener noreferrer" className="text-electric hover:text-electric-bright">
+                                honest assessment
+                            </a>.
+                        </p>
+                        <p>
+                            <strong className="text-white">The CI-gated, reproducible numbers</strong> live in{' '}
+                            <a href={`${GITHUB_URL}/blob/main/docs/wiki/Benchmarks.md`} target="_blank" rel="noopener noreferrer" className="text-electric hover:text-electric-bright">
+                                Benchmarks &amp; Results
+                            </a>{' '}
+                            and on the{' '}
+                            <a href="/#benchmarks" className="text-electric hover:text-electric-bright">
+                                benchmarks section
+                            </a>{' '}
+                            of this site; this page is deliberately labeled a field report.
+                        </p>
+                    </div>
+                </section>
+
+                {/* CTA */}
+                <footer className="mt-12 pt-8 border-t border-carbon-border text-center">
+                    <p className="text-slate-400 mb-4">
+                        Measure your own refactor — the whole recipe is four commands.
+                    </p>
+                    <div className="flex items-center justify-center gap-4 flex-wrap">
+                        <a
+                            href="https://pypi.org/project/neuralmind/"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="btn-primary text-sm"
+                        >
+                            pip install neuralmind
+                        </a>
+                        <a
+                            href={WALKTHROUGH_URL}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="text-electric hover:text-electric-bright text-sm transition-colors"
+                        >
+                            Read the full walkthrough →
+                        </a>
+                    </div>
+                </footer>
+            </main>
+            <Footer />
+        </>
+    );
+}

--- a/site/src/app/layout.tsx
+++ b/site/src/app/layout.tsx
@@ -1,6 +1,6 @@
 import './globals.css';
 import { Inter, JetBrains_Mono, Fraunces } from 'next/font/google';
-import { getLatestRelease, type LatestRelease } from '@/lib/release';
+import { getLatestRelease } from '@/lib/release';
 
 const inter = Inter({
     subsets: ['latin'],
@@ -87,9 +87,10 @@ export const metadata = {
     },
 };
 
-// Version and modification date come from the latest GitHub release at build
-// time — never hardcoded, so they can't drift out of sync with what shipped.
-const jsonLdFor = (rel: LatestRelease) => ({
+// softwareVersion/dateModified are resolved from the latest GitHub release at
+// build time — never hardcode a version here (it drifts out of sync with the
+// actual release, which is exactly the bug a pinned v0.42.0 once caused).
+const buildJsonLd = (softwareVersion: string, dateModified: string) => ({
     '@context': 'https://schema.org',
     '@graph': [
         {
@@ -104,9 +105,9 @@ const jsonLdFor = (rel: LatestRelease) => ({
             url: 'https://neuralmind.uk',
             downloadUrl: 'https://pypi.org/project/neuralmind/',
             installUrl: 'https://pypi.org/project/neuralmind/',
-            softwareVersion: rel.version,
+            softwareVersion,
             datePublished: '2025-05-01',
-            dateModified: rel.date,
+            dateModified,
             license: 'https://opensource.org/licenses/MIT',
             isAccessibleForFree: true,
             programmingLanguage: 'Python',
@@ -140,7 +141,8 @@ const jsonLdFor = (rel: LatestRelease) => ({
 });
 
 export default async function RootLayout({ children }: { children: React.ReactNode }) {
-    const jsonLd = jsonLdFor(await getLatestRelease());
+    const rel = await getLatestRelease();
+    const jsonLd = buildJsonLd(rel.tag.replace(/^v/, ''), rel.date);
     return (
         <html lang="en" className={`${inter.variable} ${jetbrains.variable} ${fraunces.variable}`}>
             <head>

--- a/site/src/app/security/page.tsx
+++ b/site/src/app/security/page.tsx
@@ -1,16 +1,18 @@
 import Navbar from '@/components/Navbar';
 import Footer from '@/components/sections/Footer';
-import { getLatestRelease, GITHUB_URL } from '@/lib/release';
+import { getLatestRelease } from '@/lib/release';
 
+const GITHUB_URL = 'https://github.com/dfrostar/neuralmind';
 const COMPLIANCE_URL = `${GITHUB_URL}/blob/main/docs/COMPLIANCE-SUMMARY.md`;
 
 export default async function SecurityPage() {
     const rel = await getLatestRelease();
-    const version = rel.tag;                          // e.g. "v1.3.0"
+    const version = rel.tag;                          // e.g. "v0.42.1"
+    const versionNumber = version.replace(/^v/, '');  // e.g. "0.42.1"
     const releaseDate = rel.date;
     const releaseUrl = rel.htmlUrl;                   // GitHub release page (always exists)
-    const pypiUrl = rel.pypiUrl;                      // verified at build time
-    const sbomUrl = rel.sbomUrl;                      // direct download, or null if none yet
+    const pypiUrl = `https://pypi.org/project/neuralmind/${versionNumber}/`;
+    const sbomUrl = releaseUrl;                       // CycloneDX SBOM is attached to the release
     const tarballUrl = `${GITHUB_URL}/archive/refs/tags/${version}.tar.gz`;
 
     return (
@@ -52,24 +54,15 @@ export default async function SecurityPage() {
                     <h2 className="font-display text-2xl font-bold text-white mb-4">Software Bill of Materials</h2>
                     <div className="bg-carbon-card border border-carbon-border rounded-xl p-6">
                         <p className="text-slate-300 mb-4">
-                            A CycloneDX SBOM is generated for every release.
+                            A CycloneDX SBOM is generated for every release and attached to the GitHub release.
                         </p>
-                        {sbomUrl ? (
-                            <a href={sbomUrl} target="_blank" rel="noopener noreferrer"
-                               className="inline-flex items-center gap-2 text-electric hover:text-electric-bright transition-colors font-mono text-sm">
-                                <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                                    <path strokeLinecap="round" strokeLinejoin="round" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
-                                </svg>
-                                Download SBOM (JSON) for {version} →
-                            </a>
-                        ) : (
-                            <p className="text-slate-400 text-sm">
-                                The SBOM for {version} is still being generated — it appears here
-                                shortly after each release. Meanwhile, see the{' '}
-                                <a href={`${GITHUB_URL}/actions/workflows/sbom.yml`} target="_blank" rel="noopener noreferrer"
-                                   className="text-electric hover:text-electric-bright">SBOM workflow →</a>
-                            </p>
-                        )}
+                        <a href={sbomUrl} target="_blank" rel="noopener noreferrer"
+                           className="inline-flex items-center gap-2 text-electric hover:text-electric-bright transition-colors font-mono text-sm">
+                            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                                <path strokeLinecap="round" strokeLinejoin="round" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+                            </svg>
+                            Download SBOM (JSON) →
+                        </a>
                     </div>
                 </section>
 

--- a/site/src/components/sections/Benchmarks.tsx
+++ b/site/src/components/sections/Benchmarks.tsx
@@ -42,6 +42,16 @@ export default function Benchmarks() {
                     ))}
                 </div>
 
+                {/* Field report — hand-measured, deliberately outside the CI-gated tiles above */}
+                <p className="mt-8 text-center text-slate-400 text-sm">
+                    Plus one labeled <span className="text-slate-300">field report</span> (measured with the CLI, not CI-gated):{' '}
+                    <span className="text-white font-semibold">48.8×</span> on a real ~9,300-node TypeScript SaaS
+                    platform, through a major rebuild.{' '}
+                    <a href="/field-reports/measure-memory-across-a-refactor/" className="text-electric hover:text-electric-bright transition-colors">
+                        Read the field report →
+                    </a>
+                </p>
+
                 {/* Demo callout */}
                 <div className="mt-12 p-6 rounded-2xl border border-carbon-border bg-carbon-raised/50 flex flex-col md:flex-row items-center justify-between gap-4">
                     <div>

--- a/site/src/lib/release.ts
+++ b/site/src/lib/release.ts
@@ -1,92 +1,37 @@
-import fs from 'node:fs';
-import path from 'node:path';
+const GITHUB_URL = 'https://github.com/dfrostar/neuralmind';
 
-export const GITHUB_URL = 'https://github.com/dfrostar/neuralmind';
-export const PYPI_PROJECT_URL = 'https://pypi.org/project/neuralmind/';
-
-// Fallback used only if the GitHub API is unreachable at build time, so the
-// page still renders with a sane version instead of breaking the build. Keep
-// this pointed at the newest known release; the live value is fetched below.
+// Fallback used only if the GitHub API is unreachable at build time, so pages
+// still render with a sane version instead of breaking the build. Keep this
+// pointed at the newest known release; the live value is fetched below.
 const FALLBACK = { tag: 'v1.3.0', date: '2026-07-20' };
 
 export interface LatestRelease {
-    tag: string; // e.g. "v1.3.0"
-    version: string; // e.g. "1.3.0"
-    date: string; // e.g. "2026-07-20"
-    htmlUrl: string; // GitHub release page (always exists)
-    pypiUrl: string; // verified at build time — never a dead link
-    sbomUrl: string | null; // direct SBOM download, or null if none exists yet
+    tag: string;
+    date: string;
+    htmlUrl: string;
 }
 
-function githubHeaders(): Record<string, string> {
-    const headers: Record<string, string> = {
-        Accept: 'application/vnd.github+json',
-    };
-    // deploy-site.yml passes the workflow token so CI builds don't hit the
-    // unauthenticated rate limit and silently render the FALLBACK version.
-    if (process.env.GITHUB_TOKEN) {
-        headers.Authorization = `Bearer ${process.env.GITHUB_TOKEN}`;
-    }
-    return headers;
-}
-
-// PyPI can lag GitHub (a publish job failure once left it 3 versions behind),
-// so the versioned URL is only used when that exact version really exists.
-async function verifiedPypiUrl(version: string): Promise<string> {
-    try {
-        const res = await fetch(`https://pypi.org/pypi/neuralmind/${version}/json`);
-        if (res.ok) return `https://pypi.org/project/neuralmind/${version}/`;
-    } catch {
-        // fall through to the project page
-    }
-    return PYPI_PROJECT_URL;
-}
-
-// Prefer an SBOM asset on the release itself; otherwise use the copy that
-// sbom.yml commits into site/public/sbom/ (GitHub releases on this repo are
-// immutable, so assets can't be attached after release-please publishes).
-function sbomUrlFor(tag: string, assets: { name?: string; browser_download_url?: string }[]): string | null {
-    const asset = assets.find(
-        (a) => typeof a?.name === 'string' && a.name.endsWith('.sbom.json'),
-    );
-    if (asset?.browser_download_url) return asset.browser_download_url;
-    const served = `sbom/neuralmind-${tag}.sbom.json`;
-    if (fs.existsSync(path.join(process.cwd(), 'public', served))) {
-        return `/${served}`;
-    }
-    return null;
-}
-
-// Resolved at build time (static export). Displayed versions therefore track
-// whatever release is current when the site is built — no hardcoded version
-// to drift out of sync with the actual latest release. Next.js dedupes the
-// fetch, so layout.tsx and security/page.tsx share one request per build.
+// Resolved at build time (static export). The displayed version therefore
+// tracks whatever release is current when the site is built — no hardcoded
+// version to drift out of sync with the actual latest release.
 export async function getLatestRelease(): Promise<LatestRelease> {
-    let tag = FALLBACK.tag;
-    let date = FALLBACK.date;
-    let htmlUrl = `${GITHUB_URL}/releases/tag/${FALLBACK.tag}`;
-    let assets: { name?: string; browser_download_url?: string }[] = [];
     try {
         const res = await fetch(
             'https://api.github.com/repos/dfrostar/neuralmind/releases/latest',
-            { headers: githubHeaders() },
+            { headers: { Accept: 'application/vnd.github+json' } },
         );
         if (!res.ok) throw new Error(`GitHub API ${res.status}`);
         const data = await res.json();
-        tag = data.tag_name as string;
-        date = ((data.published_at as string) ?? '').slice(0, 10) || FALLBACK.date;
-        htmlUrl = (data.html_url as string) ?? `${GITHUB_URL}/releases/tag/${tag}`;
-        if (Array.isArray(data.assets)) assets = data.assets;
+        return {
+            tag: data.tag_name as string,
+            date: ((data.published_at as string) ?? '').slice(0, 10) || FALLBACK.date,
+            htmlUrl: (data.html_url as string) ?? `${GITHUB_URL}/releases/tag/${data.tag_name}`,
+        };
     } catch {
-        // keep the fallback values
+        return {
+            tag: FALLBACK.tag,
+            date: FALLBACK.date,
+            htmlUrl: `${GITHUB_URL}/releases/tag/${FALLBACK.tag}`,
+        };
     }
-    const version = tag.replace(/^v/, '');
-    return {
-        tag,
-        version,
-        date,
-        htmlUrl,
-        pypiUrl: await verifiedPypiUrl(version),
-        sbomUrl: sbomUrlFor(tag, assets),
-    };
 }


### PR DESCRIPTION
## Description

Publishes the Phase 3 → Phase 4 rebuild effectiveness results as an **anonymized real-world case study**: a private mid-size TypeScript SaaS platform (~9,300 nodes) measured across a major internal rebuild with the shipped CLI — 48.8× avg token reduction, personal synapse edges 36 → 135 (+275%), shared edge weight +5.4%, full `--force` rebuild 326 s / incremental ~30 s.

Single-source principle: the full case study (table, interpretation, per-command provenance, and a 4-step recipe for running the same before/after measurement on any repo) lives in one new use-case page; every other surface gets a compact summary or cross-link.

**Docs (commit 1):**

- **New:** `docs/use-cases/measure-memory-across-a-refactor.md` — canonical home
- `docs/wiki/Benchmarks.md` — labeled "Field report (not CI-gated)" section with headline numbers, intro amended so the "everything is CI-gated" claim stays true, plus a "What we *don't* claim" bullet
- `docs/community-benchmarks.json` — third entry (48.8×, 9,293 nodes, TypeScript); README table regenerated via `scripts/render_community_table.py`
- `scripts/render_community_table.py` — footer now emits the interactive-dashboard link (it had been hand-added inside the injected markers, which regeneration would otherwise silently remove and the CI sync check would flag)
- `docs/HONEST-ASSESSMENT.md` — community-table count two → three (both mentions)
- `docs/wiki/Learning-Guide.md` — cross-links the 36 → 135 personal-edge growth as a real-world data point
- `docs/use-cases/README.md` + `benchmark-your-repo.md` — index row and Related link
- `docs/sitemap.xml` — new use-case URL, lastmod bumps, deduped triplicated `blast-radius-before-a-rename.html` entries

**Marketing site (commit 2) — the field report as a shareable single page:**

- **New:** `site/src/app/field-reports/measure-memory-across-a-refactor/page.tsx` → `https://neuralmind.uk/field-reports/measure-memory-across-a-refactor/` — SEO-first: canonical URL, OpenGraph article + Twitter card, keyword meta, TechArticle + BreadcrumbList JSON-LD, entry in `site/public/sitemap.xml`. Carries an explicit "Field Report — not CI-gated" badge and the same honesty notes as the docs walkthrough.
- `Benchmarks.tsx` — one clearly-labeled link line under the CI tiles (internal linking without adding a non-CI number to the CI-gated grid)
- `site/src/lib/release.ts` (new) + `layout.tsx` — site-wide JSON-LD `softwareVersion`/`dateModified` now resolved from the latest GitHub release at build time (was hardcoded `0.42.0`, the exact drift bug CLAUDE.md forbids); `security/page.tsx` refactored to reuse the same helper
- `.gitignore` — anchored the Python build-artifact `lib/` pattern to `/lib/` so it stops swallowing `site/src/lib`

Honesty guardrails throughout: 48.8× is always attributed to `neuralmind benchmark .` on one repo (framed as consistent with the 40–70× range, not a new headline); the before/after table is disclosed as hand-assembled from `stats`/`benchmark` output; the maintainer-owned/private/anonymized nature is stated plainly.

## Type of Change

- [x] 📝 Documentation update

## How Has This Been Tested?

- [x] Manual testing

- `python scripts/validate_community_benchmarks.py` → ✓ 3 entries valid (schema + sanity rules, same check as CI)
- `python scripts/render_community_table.py --inject README.md` → README already in sync (CI dry-run check will pass)
- `python -m json.tool docs/community-benchmarks.json` → valid JSON
- `xml.dom.minidom.parse` on both sitemaps → valid XML; duplicate URL count verified down to 1
- `cd site && npm run build` → static export succeeds, all 9 routes prerendered
- Exported HTML verified: `<title>`, canonical, TechArticle/BreadcrumbList JSON-LD, og:/twitter: tags present; site-wide JSON-LD now reports `softwareVersion 1.3.0` fetched live from the GitHub releases API
- `black --check` / `ruff check` on `scripts/render_community_table.py` → clean
- Relative links from `docs/use-cases/` and the Benchmarks.md section anchor verified against on-disk files; wiki-mirrored pages use full GitHub URLs per existing precedent

### Test Configuration

* **Python version**: 3.11
* **Operating System**: Linux
* **Test command**: see above (docs + static site; no pytest surface touched)

## Documentation & discoverability

- [x] Docs answer *"what does the user/agent now see?"* (not just what the code does)
- [x] `README.md` updated (community-benchmarks table regenerated by script)
- [x] Use-case walkthrough updated/added if a workflow was unlocked (new: measure memory across a major refactor)
- [x] SEO refreshed (keywords / meta / sitemap) if a new noun entered the product surface (both sitemaps, page metadata, JSON-LD structured data)
- [x] I did **not** edit `CHANGELOG.md` or hand-bump the `pyproject.toml` version (release-please owns these)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Code Quality

- [x] I have run `black .` for formatting (on the one touched script)
- [x] I have run `ruff check .` for linting (on the one touched script)
- [x] Type hints are added for new functions/methods (`site/src/lib/release.ts` is fully typed)

## Additional Notes

Merging this PR triggers `deploy-site.yml` (push to `main` touching `site/**`), so the field-report page goes live on neuralmind.uk with the merge. Still deliberately untouched: `bench/public/` (CI-generated), `docs/benchmarks/` dashboard files (driven by the community JSON — the new entry flows in automatically), and version/CHANGELOG files. The commits use `docs:` so release-please does not cut a release for content-only changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018hAJwNcCviWXAMT4PE4h5z