### PR TITLE
fix(deps): cap mcp &lt;2 — SDK 2.0 removes the server's decorator API

### DIFF
--- a/neuralmind/__init__.py
+++ b/neuralmind/__init__.py
@@ -109,7 +109,10 @@ from .trace import RetrievalTrace
 from .watcher import FileActivityWatcher
 
 __version__ = "2.0.0"
-__version_info__ = (1, 12, 0)
+# Derived so it can never drift from __version__ again (release-please only
+# rewrites the string literal above; the old hardcoded tuple sat at (1, 12, 0)
+# through three releases).
+__version_info__ = tuple(int(part) for part in __version__.split("."))
 # ChromaDB backend (lazy-exposed via ``__getattr__`` below), and ChromaDB is an
 # opt-in extra as of v0.29.0. Listing it in ``__all__`` would make
 # ``from neuralmind import *`` resolve the lazy attribute and import ChromaDB,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,10 @@ requires-python = ">=3.10"
 dependencies = [
     "pyyaml>=6.0",
     "toml>=0.10",
-    "mcp>=1.27.2",
+    # <2: the 2.0 SDK removes the low-level Server list_tools/call_tool
+    # decorator API that mcp_server.py registers tools with; lift the cap
+    # only when the server is migrated to the 2.x handler API.
+    "mcp>=1.27.2,<2",
     # Tier 2: license signing, encryption
     "cryptography>=41.0",
     "pydantic>=2.0",

--- a/requirements-pinned.txt
+++ b/requirements-pinned.txt
@@ -19,6 +19,9 @@ toml==0.10.2
 # Optional: MCP Server
 # Bumped from 0.1.0 to 1.23.0 to resolve three GHSA alerts on the MCP SDK:
 #   FastMCP validation DoS, Streamable HTTP DoS, DNS-rebinding default.
+# Held at 1.x: mcp 2.0.0 drops the low-level Server decorator API the
+# server uses (see the cap in pyproject.toml); do not bump to 2.x until
+# mcp_server.py is migrated.
 mcp==1.28.1
 
 # Optional: Development & Testing


### PR DESCRIPTION
## Description

Hotfix intended to ride into **v3.0.0** before release PR #416 merges.

**1. Cap `mcp>=1.27.2,<2`.** mcp 2.0.0 (published to PyPI in the last day) removes the low-level `Server.list_tools()` / `Server.call_tool()` decorator API that `neuralmind/mcp_server.py:1189-1193` registers its tools with — verified in a clean venv: the 2.0 `Server` exposes only `add_request_handler`/`add_notification_handler` and a new `MCPServer` class. With the previous uncapped range, every fresh `pip install neuralmind` now resolves mcp 2.0.0 and the MCP server dies with `AttributeError` at startup — the flagship agent-integration path. Cap held until the server is migrated to the 2.x handler API; hold documented in `requirements-pinned.txt` (which stays at 1.28.1 — dependabot #417's bump to 2.0.0 will be declined for the same reason).

**2. Derive `__version_info__` from `__version__`.** The hardcoded tuple has been stuck at `(1, 12, 0)` since v1.12 because release-please only rewrites the `__version__` string literal. Now computed, so it can never drift again.

## Type of Change

- [x] 🐛 Bug fix

## How Has This Been Tested?

- [x] Manual testing

Clean-venv verification that `mcp==2.0.0` lacks the decorator API (`AttributeError` surface confirmed) while imports we use (`Server`, `stdio_server`, `TextContent`, `Tool`) still resolve; `tomllib` parse of the new range; `py_compile` on `neuralmind/__init__.py`; derived tuple check `(2, 0, 0)`; `scripts/check_commercial_terms.py` green.

## Additional Notes

Merging this before #416 lets release-please fold it into v3.0.0, so the release ships with a working dependency range instead of needing an immediate v3.0.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JSNbm726sy9vVhY3kPSEcH

---
_Generated by [Claude Code](https://claude.ai/code/session_01JSNbm726sy9vVhY3kPSEcH)_