### PR TITLE
fix(tier2): enforce the free-tier seat limit and align pricing with commercial-terms

### DIFF
--- a/LICENSING.md
+++ b/LICENSING.md
@@ -5,7 +5,7 @@ NeuralMind is **open-core**. One repository, two licenses, one clear line:
 | Tree | License | What it is |
 |------|---------|------------|
 | Everything except the directory below | [MIT](LICENSE) | The core engine: code graph, synapse learning, retrieval, MCP server, hooks, CLI, compliance annotation engine, VS Code extension. **All token savings live here and are free, forever.** |
-| `neuralmind/tier2/` | [Commercial Modules License](neuralmind/tier2/LICENSE) (source-available) | Team-tier governance: seats, hash-chained audit, self-hosted control plane, license machinery. |
+| `neuralmind/tier2/` | [Commercial Modules License](neuralmind/tier2/LICENSE) (source-available) | Team-tier modules: seats, hash-chained audit, self-hosted control plane, license machinery. Every feature runs under the free 1-seat license; a paid Team license buys seats beyond one (5-50) plus support. |
 
 **What this means in practice**
 

--- a/README.md
+++ b/README.md
@@ -263,10 +263,13 @@ neuralmind benchmark .
   (decisions, SOPs, meeting notes, policies) and your code graph —
   adjacency-matched compounds, title-reference cross-links, frequency-capped
   tags. 56 tests.
-- **Team tier ($29/user/mo).** Governance, append-only hash-chained audit
-  log, seat management, self-hosted deployment. MIT core stays MIT — the
-  Team tier only activates with a license; tier2 is
-  source-available, not MIT — see [LICENSING.md](LICENSING.md). See [pricing](https://neuralmind.uk/pricing/).
+- **Team tier ($29/user/mo).** The license buys seats and support: a
+  multi-seat license (5-50), priority support, and an annual invoice.
+  The features themselves — shared-memory governance, append-only
+  hash-chained audit log, self-hosted deployment — run under the
+  auto-issued free license at 1 seat, so you can evaluate everything
+  before paying. MIT core stays MIT; tier2 is source-available, not
+  MIT — see [LICENSING.md](LICENSING.md) and [pricing](https://neuralmind.uk/pricing/).
 
 How it works under the hood: [Architecture](docs/wiki/Architecture.md) ·
 [brain-like learning](docs/brain_like_learning.md).

--- a/commercial-terms.json
+++ b/commercial-terms.json
@@ -10,14 +10,14 @@
     "free": {
       "price_usd_per_user_per_month": 0,
       "seats": "1, auto-issued on first run, never expires, no signup",
-      "includes": "the entire MIT core — all token compression and savings"
+      "includes": "the entire MIT core (all token compression and savings) plus the tier2 features — shared-memory governance, hash-chained audit log, self-hosted — at 1 seat"
     },
     "team": {
       "price_usd_per_user_per_month": 29,
       "display": "$29/user/mo",
       "seats": "5-50",
       "billing": "annual contract",
-      "includes": "shared-memory governance, seat management, hash-chained audit log, compliance export, self-hosted deployment"
+      "includes": "seats beyond one (5-50), priority support, annual invoice, self-hosted deployment support; the product features themselves are not gated — they run under the free 1-seat license"
     },
     "enterprise": {
       "price": "custom",

--- a/docs/wiki/Tier2-Operator-Guide.md
+++ b/docs/wiki/Tier2-Operator-Guide.md
@@ -8,21 +8,22 @@
 
 ## What Tier 2 (Team) gives you
 
-Tier 2 is the paid tier on top of the MIT core. **The MIT core's 12-50x token reduction is free forever** — Tier 2 adds engineering-team governance, audit, and seat management.
+Tier 2 is the paid tier on top of the MIT core. **The MIT core's 12-50x token reduction is free forever**, and the tier2 feature set — governance, audit, self-hosted — runs under the auto-issued free 1-seat license too. A paid Team license buys **seats beyond one (5-50), priority support, and an annual invoice**, not hidden features.
 
-| Feature | MIT core (free) | Team ($29/user/mo) |
-|---------|-----------------|---------------------|
+| Feature | Free license (1 seat) | Team ($29/user/mo, 5-50 seats) |
+|---------|-----------------------|--------------------------------|
 | 12-50x token reduction | Yes | Yes |
 | Synapse learning | Yes | Yes |
 | MCP server | Yes | Yes |
 | Memory publish/inherit | Yes | Yes |
-| Governance (publish scope, weight threshold) | No | Yes |
-| Audit log (SHA-256 hash-chained) | No | Yes |
-| Seat management (add/remove/list) | No | Yes |
-| Self-hosted deployment | No | Yes |
-| License validation (Ed25519 + 30-day grace) | No | Yes |
+| Governance (publish scope, weight threshold) | Yes, at 1 seat | Yes |
+| Audit log (SHA-256 hash-chained) | Yes, at 1 seat | Yes |
+| Self-hosted deployment | Yes, at 1 seat | Yes, with deployment support |
+| Seats beyond one | No | Yes (up to 50) |
+| Priority support + annual invoice | No | Yes |
+| License validation (Ed25519 + 30-day grace) | Auto-issued free license | Signed Team license |
 
-**You are paying for compliance and control, not for the compression.**
+**You are paying for seats and support, not for features — everything is evaluable free at 1 seat.**
 
 ---
 

--- a/neuralmind/tier2/cli.py
+++ b/neuralmind/tier2/cli.py
@@ -299,12 +299,12 @@ def cmd_team_seats(args) -> int:
         return cmd_team_seats_sync(args, config=config, audit=audit)
 
     # Every seat mutation requires admin authentication.
-    # Free-tier seats bypass the limit check (handled inside sm.add_seat),
-    # but admin authentication still applies for auditability.
+    # The seat limit always comes from the license: the free license
+    # includes one seat, a Team license covers 5-50 — see LICENSING.md.
     if args.subcommand == "add":
         try:
             gov.require_admin(admin)
-            sm.add_seat(args.email, config.seats, tier=config.tier)
+            sm.add_seat(args.email, config.seats)
             audit.log(actor=admin, action="seat_add", target=args.email)
             print(f"Seat added: {args.email}")
             return 0
@@ -313,6 +313,11 @@ def cmd_team_seats(args) -> int:
             return 1
         except SeatLimitError as e:
             print(f"Seat limit reached: {e}")
+            if config.tier == "free":
+                print(
+                    "The free license includes 1 seat. A Team license covers "
+                    "5-50 seats — https://neuralmind.uk/pricing/"
+                )
             return 1
 
     if args.subcommand == "remove":
@@ -421,7 +426,6 @@ def cmd_team_seats_sync(args, config=None, audit=None) -> int:
         seats_db,
         manifest,
         license_limit=config.seats,
-        tier=config.tier,
         admin=admin,
     )
 

--- a/neuralmind/tier2/governance.py
+++ b/neuralmind/tier2/governance.py
@@ -10,7 +10,9 @@ Gate before any edge enters the shared namespace:
 3. Weight threshold — edges below threshold are rejected.
 4. Content-hash dedup — identical bundles aren't re-published.
 
-Governance only activates with a valid license. MIT users are unaffected.
+Governance runs under any valid license, including the auto-issued free
+1-seat license — a paid Team license adds seats (5-50) and support, not
+hidden features. Users who never run ``neuralmind team`` are unaffected.
 
 Example:
     >>> from pathlib import Path

--- a/neuralmind/tier2/pricing.py
+++ b/neuralmind/tier2/pricing.py
@@ -9,12 +9,15 @@ from pathlib import Path
 
 import yaml
 
+# Per-seat prices must agree with commercial-terms.json ($29/user/mo, the
+# CI-gated source of truth) — longer terms are the flat monthly rate, no
+# invented discounts.
 DEFAULT_PRICING = {
     "team": {
-        "monthly": {"base_per_seat": 50.00, "currency": "USD"},
-        "quarterly": {"base_per_seat": 135.00, "currency": "USD"},
-        "annual": {"base_per_seat": 540.00, "currency": "USD"},
-        "biennial": {"base_per_seat": 960.00, "currency": "USD"},
+        "monthly": {"base_per_seat": 29.00, "currency": "USD"},
+        "quarterly": {"base_per_seat": 87.00, "currency": "USD"},
+        "annual": {"base_per_seat": 348.00, "currency": "USD"},
+        "biennial": {"base_per_seat": 696.00, "currency": "USD"},
     },
     "free": {"seats": 1, "never_expires": True},
     "partners": {
@@ -46,14 +49,14 @@ def calculate_price(
         return 0.0
     tier_pricing = pricing.get("team", {})
     if term_months == 1:
-        base = tier_pricing.get("monthly", {}).get("base_per_seat", 50.0)
+        base = tier_pricing.get("monthly", {}).get("base_per_seat", 29.0)
     elif term_months == 3:
-        base = tier_pricing.get("quarterly", {}).get("base_per_seat", 135.0)
+        base = tier_pricing.get("quarterly", {}).get("base_per_seat", 87.0)
     elif term_months == 12:
-        base = tier_pricing.get("annual", {}).get("base_per_seat", 540.0)
+        base = tier_pricing.get("annual", {}).get("base_per_seat", 348.0)
     elif term_months == 24:
-        base = tier_pricing.get("biennial", {}).get("base_per_seat", 960.0)
+        base = tier_pricing.get("biennial", {}).get("base_per_seat", 696.0)
     else:
         # Monthly rate for other terms
-        base = tier_pricing.get("monthly", {}).get("base_per_seat", 50.0)
+        base = tier_pricing.get("monthly", {}).get("base_per_seat", 29.0)
     return base * seats

--- a/neuralmind/tier2/seats.py
+++ b/neuralmind/tier2/seats.py
@@ -4,7 +4,8 @@
 """seats.py — Seat management for Team tier.
 
 Each team seat is an email with an active/inactive flag. The seat limit comes
-from the license (Tier2Config.seats). Adding a seat beyond the limit raises
+from the license (Tier2Config.seats) for every tier — the auto-issued free
+license includes exactly one seat. Adding a seat beyond the limit raises
 SeatLimitError.
 """
 
@@ -92,10 +93,8 @@ class SeatManager:
         with self._lock:
             return sum(1 for s in self._seats.values() if s.active)
 
-    def can_add_seat(self, license_limit: int, tier: str | None = None) -> bool:
+    def can_add_seat(self, license_limit: int) -> bool:
         """True if active seats < license limit."""
-        if tier == "free":
-            return True
         with self._lock:
             return self.active_count() < license_limit
 
@@ -108,14 +107,14 @@ class SeatManager:
         with self._lock:
             return sorted(self._seats.values(), key=lambda s: s.email)
 
-    def add_seat(self, email: str, license_limit: int, tier: str | None = None) -> Seat:
+    def add_seat(self, email: str, license_limit: int) -> Seat:
         """Add a new seat. Idempotent if email already exists."""
         normalized = email.strip().lower()
         with self._lock:
             if normalized in self._seats:
                 if self._seats[normalized].active:
                     return self._seats[normalized]
-                if tier != "free" and self.active_count() >= license_limit:
+                if self.active_count() >= license_limit:
                     raise SeatLimitError(
                         f"Seat limit reached: {self.active_count() + 1}/{license_limit}"
                     )
@@ -124,7 +123,7 @@ class SeatManager:
                 self._save()
                 return self._seats[normalized]
 
-            if not self.can_add_seat(license_limit, tier=tier):
+            if not self.can_add_seat(license_limit):
                 raise SeatLimitError(
                     f"Seat limit reached: {self.active_count() + 1}/{license_limit}"
                 )
@@ -171,7 +170,6 @@ def sync_seats(
     seats_db_path: Path,
     manifest: dict[str, Any],
     license_limit: int,
-    tier: str,
     admin: str,
 ) -> dict[str, Any]:
     """Reconcile local seats from a verified manifest."""
@@ -184,7 +182,7 @@ def sync_seats(
         if not email:
             continue
         try:
-            sm.add_seat(email, license_limit, tier=tier)
+            sm.add_seat(email, license_limit)
             added.append(email)
         except SeatLimitError as e:
             failed.append({"email": email, "reason": str(e)})

--- a/site/src/app/pricing/page.tsx
+++ b/site/src/app/pricing/page.tsx
@@ -6,7 +6,7 @@ import type { Metadata } from 'next';
 export const metadata: Metadata = {
     title: 'Pricing — NeuralMind',
     description:
-        'NeuralMind is MIT-licensed open source. Team and Enterprise tiers add shared memory governance, seat management, and self-hosted deployment.',
+        'NeuralMind is MIT-licensed open source with every feature free at 1 seat. The Team tier licenses seats beyond one (5-50) with priority support; Enterprise adds custom SLAs.',
 };
 
 const tiers = [
@@ -14,12 +14,14 @@ const tiers = [
         name: 'Free',
         price: '$0',
         period: 'forever',
-        description: 'MIT-licensed open source. One user, personal memory, community support.',
+        description:
+            'MIT core plus every tier2 feature at 1 seat — governance, audit, self-hosted. Nothing is gated.',
         features: [
             'MIT OSS — full source code',
-            'Single user',
+            '1-seat license, auto-issued, never expires',
             'Personal memory graph',
             'L0–L3 progressive disclosure',
+            'Governance, audit & self-hosted at 1 seat',
             'Community support (Discord/GitHub)',
         ],
         cta: 'pip install neuralmind',
@@ -30,13 +32,14 @@ const tiers = [
         name: 'Team',
         price: '$29',
         period: 'per user / month',
-        description: 'Shared memory governance, seat management, signed manifests, admin audit.',
+        description:
+            'The license buys seats and support — the features are already free at 1 seat, so evaluate everything first.',
         features: [
-            'Team memory governance',
-            'Seat management (add/remove)',
-            'Shared context across agents',
-            'Signed synapse manifests',
-            'Admin audit trail',
+            'Multi-seat license (5-50 seats)',
+            'Priority support',
+            'Annual invoice — procurement-friendly',
+            'Signed seat manifests + admin audit at team scale',
+            'Self-hosted deployment support',
         ],
         cta: 'Contact us about Team',
         ctaHref: 'mailto:hello@neuralmind.uk?subject=NeuralMind%20Team%20tier',
@@ -63,15 +66,15 @@ const tiers = [
 const faqs = [
     {
         q: 'Is NeuralMind really open source?',
-        a: 'Yes. The core engine is MIT-licensed — full source on GitHub, no feature gates. Team and Enterprise tiers build on top with governance and deployment features, not by withholding the OSS core.',
+        a: 'Yes. The core engine is MIT-licensed — full source on GitHub, no feature gates. The paid tiers do not unlock hidden features: the Team license covers seats beyond one, priority support, and an annual invoice. Everything is evaluable on the free 1-seat license first.',
     },
     {
         q: 'How does billing work for Team?',
-        a: 'Per-seat monthly billing. Add or remove seats at any time; prorated adjustments apply. Annual commitments available at a discount.',
+        a: '$29 per user per month on an annual contract, 5-50 seats, invoiced — contact hello@neuralmind.uk to start. There is no self-serve checkout. Seats are reassignable as your team changes.',
     },
     {
         q: 'Where is my team data stored?',
-        a: 'All synapse data is stored locally by default. Team tier syncs through an encrypted relay we host; you can also self-host the relay. Enterprise runs entirely within your own infrastructure. We never train on your code.',
+        a: 'All synapse data is stored locally. Team memory bundles publish and import through your own git repository — no relay, no server of ours in the path. Enterprise can run fully air-gapped in your infrastructure. We never train on your code.',
     },
 ];
 
@@ -89,8 +92,9 @@ export default async function PricingPage() {
                     </h1>
                     <p className="text-lg text-slate-300 max-w-2xl mx-auto">
                         NeuralMind&apos;s core engine ({version}) is MIT-licensed open source —
-                        free forever. Add Team or Enterprise tiers when you need shared
-                        memory governance, seat management, or self-hosted deployment.
+                        free forever, including governance, audit, and self-hosted at
+                        1 seat. The Team tier licenses seats beyond one; Enterprise
+                        adds custom SLAs and onboarding.
                     </p>
                 </section>
 

--- a/tests/test_paid_governance.py
+++ b/tests/test_paid_governance.py
@@ -43,7 +43,7 @@ def test_seat_mutation_audited(tmp_path):
     sm = SeatManager(tmp_path / "seats.json")
 
     gov.require_admin(_ADMIN)
-    sm.add_seat(_USER1, config.seats, tier=config.tier)
+    sm.add_seat(_USER1, config.seats)
     audit.log(actor=_ADMIN, action="seat_add", target=_USER1)
     assert audit.count() == 1
 
@@ -87,7 +87,7 @@ def test_free_tier_but_admin_required():
     sm = SeatManager(td / "seats.json")
 
     gov.require_admin(_ADMIN)
-    sm.add_seat(_USER1, config.seats, tier="free")
+    sm.add_seat(_USER1, config.seats)
     with pytest.raises(PermissionError):
         gov.require_admin("intruder")
 

--- a/tests/test_paid_seats.py
+++ b/tests/test_paid_seats.py
@@ -10,7 +10,7 @@ import pytest
 from neuralmind.tier2.audit import AuditLog
 from neuralmind.tier2.config import Tier2Config
 from neuralmind.tier2.governance import TeamGovernance
-from neuralmind.tier2.seats import SeatManager
+from neuralmind.tier2.seats import SeatLimitError, SeatManager
 
 ADMIN = "admin"
 NON_ADMIN = "intruder"
@@ -31,8 +31,28 @@ def test_add_seat_requires_admin():
         sm = SeatManager(td / "seats.json")
 
         g.require_admin(ADMIN)
-        seat = sm.add_seat("newuser", config.seats, tier=config.tier)
+        seat = sm.add_seat("newuser", config.seats)
         assert seat.email == "newuser"
+
+
+def test_free_license_refuses_second_seat():
+    """The free 1-seat license enforces its limit — the only licensed gate."""
+    with tempfile.TemporaryDirectory() as td:
+        td = Path(td)
+        config = Tier2Config()
+        config.governance.admin_emails = [ADMIN]
+        config.seats = 1
+        config.tier = "free"
+        config.license_file = str(td / "license.json")
+        config.audit_db = str(td / "audit.jsonl")
+        audit = AuditLog(td / "audit.jsonl")
+        g = TeamGovernance(td, config, audit)
+        sm = SeatManager(td / "seats.json")
+
+        g.require_admin(ADMIN)
+        sm.add_seat("first", config.seats)
+        with pytest.raises(SeatLimitError):
+            sm.add_seat("second", config.seats)
 
 
 def test_remove_seat_requires_admin():
@@ -50,7 +70,7 @@ def test_remove_seat_requires_admin():
         sm = SeatManager(td / "seats.json")
 
         g.require_admin(ADMIN)
-        sm.add_seat("newuser", config.seats, tier=config.tier)
+        sm.add_seat("newuser", config.seats)
         g.require_admin(ADMIN)
         seat = sm.remove_seat("newuser")
         assert seat.email == "newuser"

--- a/tests/test_paid_seats_sync.py
+++ b/tests/test_paid_seats_sync.py
@@ -71,7 +71,7 @@ class TestSyncSeats:
             keypair["private_key_hex"],
         )
         seats_db = tmp_path / "seats.json"
-        result = sync_seats(seats_db, manifest, license_limit=5, tier="team", admin=_ADMIN)
+        result = sync_seats(seats_db, manifest, license_limit=5, admin=_ADMIN)
         assert result["status"] == "ok"
         assert len(result["added"]) == 2
 
@@ -81,7 +81,7 @@ class TestSyncSeats:
             keypair["private_key_hex"],
         )
         seats_db = tmp_path / "seats.json"
-        result = sync_seats(seats_db, manifest, license_limit=2, tier="team", admin=_ADMIN)
+        result = sync_seats(seats_db, manifest, license_limit=2, admin=_ADMIN)
         assert result["status"] == "partial"
         assert len(result["failed"]) == 1
         assert result["failed"][0]["email"] == "userc"

--- a/tests/test_tier2_seats.py
+++ b/tests/test_tier2_seats.py
@@ -58,31 +58,38 @@ class TestSeatManagerBasic:
         assert seats.active_count() == 1
 
 
-class TestSeatManagerFreeTier:
-    """Free tier bypasses seat-limit enforcement."""
+class TestSeatManagerLimitEnforcement:
+    """The license seat limit applies to every tier — free includes one seat."""
 
     @pytest.fixture
     def seats(self, tmp_path: Path) -> SeatManager:
         return SeatManager(tmp_path / "seats.json")
 
-    def test_free_tier_can_add_beyond_limit(self, seats: SeatManager) -> None:
-        seats.add_seat(EMAIL1, license_limit=1, tier="free")
-        seats.add_seat(EMAIL2, license_limit=1, tier="free")
-        assert seats.active_count() == 2
-
-    def test_free_tier_can_add_seat_unlimited(self, seats: SeatManager) -> None:
-        for i in range(10):
-            seats.add_seat(f"user{i}@example.org", license_limit=1, tier="free")
-        assert seats.active_count() == 10
-
-    def test_paid_tier_still_enforces_limit(self, seats: SeatManager) -> None:
-        seats.add_seat(EMAIL1, license_limit=1, tier="team")
+    def test_free_license_enforces_single_seat(self, seats: SeatManager) -> None:
+        seats.add_seat(EMAIL1, license_limit=1)
         with pytest.raises(SeatLimitError):
-            seats.add_seat(EMAIL2, license_limit=1, tier="team")
+            seats.add_seat(EMAIL2, license_limit=1)
+        assert seats.active_count() == 1
 
-    def test_free_tier_reactivate_does_not_count_limit(self, seats: SeatManager) -> None:
-        seat = seats.add_seat(EMAIL1, license_limit=1, tier="free")
+    def test_team_license_enforces_its_limit(self, seats: SeatManager) -> None:
+        seats.add_seat(EMAIL1, license_limit=2)
+        seats.add_seat(EMAIL2, license_limit=2)
+        with pytest.raises(SeatLimitError):
+            seats.add_seat("third@example.org", license_limit=2)
+
+    def test_remove_frees_a_slot(self, seats: SeatManager) -> None:
+        seats.add_seat(EMAIL1, license_limit=1)
         seats.remove_seat(EMAIL1)
-        # Reactivate should succeed even though we were at limit before
-        seat2 = seats.add_seat(EMAIL1, license_limit=1, tier="free")
+        seat2 = seats.add_seat(EMAIL2, license_limit=1)
         assert seat2.active is True
+        assert seats.active_count() == 1
+
+    def test_reactivation_respects_limit(self, seats: SeatManager) -> None:
+        seats.add_seat(EMAIL1, license_limit=1)
+        seats.remove_seat(EMAIL1)
+        # Reactivating the only seat fits within the 1-seat limit...
+        seat = seats.add_seat(EMAIL1, license_limit=1)
+        assert seat.active is True
+        # ...but a second distinct seat still does not.
+        with pytest.raises(SeatLimitError):
+            seats.add_seat(EMAIL2, license_limit=1)


### PR DESCRIPTION
## What

The honest-reframe pass on the Team tier: make the code's licence model and the marketing say the same thing, and make the one real gate actually work.

- **Seat limit enforced for every tier.** `can_add_seat()` returned `True` unconditionally for `tier="free"`, so a free install could add unlimited seats — bypassing the only capability the Team licence sells. The `tier` parameter is removed from the seat API; the limit always comes from the licence (free = 1 seat). The CLI now points free users at the pricing page on `SeatLimitError`.
- **Pricing drift fixed.** `tier2/pricing.py` said `$50/seat/mo` (with invented quarterly/biennial discounts); `commercial-terms.json`, README, and the site say **$29/user/mo**. Code now matches the CI-gated source of truth; longer terms are the flat monthly rate.
- **Copy reframed** (README, LICENSING.md, site pricing page, commercial-terms `includes`, Tier2 Operator Guide): every tier2 feature — governance, audit, self-hosted — runs under the auto-issued free 1-seat licence; the paid licence buys **seats beyond one (5-50), priority support, and an annual invoice**, not hidden features.
- **Two false marketing claims removed** from the pricing-page FAQ: a hosted encrypted sync relay (violates `do_not_market`: real-time sync is roadmap-only; team memory travels via the customer's own git remote) and monthly prorated billing with discounts (billing is an annual contract, contact-based).

## Why

Strategy review (2026-08-07) found the gate leaky, the price contradictory in a source-available module buyers can read, and the marketing claiming feature-gates the code never had. Decision: align to the code's actual design (features free at 1 seat) rather than claw features back.

## Tests

- New: `test_free_license_refuses_second_seat` (tests/test_paid_seats.py); `TestSeatManagerFreeTier` rewritten as `TestSeatManagerLimitEnforcement` (free enforces 1 seat, team enforces its limit, remove frees a slot, reactivation respects limit).
- 50 tier2 tests pass locally; `scripts/check_commercial_terms.py` passes; black clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)