### PR TITLE
fix(site): correct stale public-benchmark recall claim on neuralmind.uk

### DIFF
--- a/site/src/components/sections/Benchmarks.tsx
+++ b/site/src/components/sections/Benchmarks.tsx
@@ -3,7 +3,7 @@
 const dataPoints = [
     { metric: 'Query Latency', value: '0.81s', detail: 'on 1,486-node repo (TurboVec)' },
     { metric: 'Token Reduction', value: '63.6×', detail: 'on live production codebase' },
-    { metric: 'Gold-File Recall', value: '100%', detail: 'on public benchmark (requests, click)' },
+    { metric: 'Gold-File Recall', value: '79-100%', detail: 'on public benchmark (requests, click, flask, rich)' },
     { metric: 'Setup time', value: '~15 min', detail: 'one CLI command' },
     { metric: 'Ongoing overhead', value: '~0', detail: 'post-commit hook auto-rebuilds' },
 ];

--- a/site/src/components/sections/BusinessCase.tsx
+++ b/site/src/components/sections/BusinessCase.tsx
@@ -17,7 +17,7 @@ const cards = [
         title: 'Fewer wrong answers, faster teams',
         accent: 'text-electric',
         points: [
-            '100% gold-file recall on the public benchmark (requests, click).',
+            '79-100% gold-file recall (93.75% mean) on the public benchmark (requests, click, flask, rich).',
             'Team dashboard shows synapse memory health, ingestion status, savings, latency trends — all read-only, all local.',
             'Self-documenting code: DocEvolver finds undocumented methods and evolves JSDoc that actually improves retrieval.',
             '100% local with zero code egress — verifiable on the wire. Works with the agents you already run: Claude Code, Cursor, Cline, any MCP agent. No rip-and-replace.',

--- a/site/src/components/sections/Hero.tsx
+++ b/site/src/components/sections/Hero.tsx
@@ -6,7 +6,7 @@ const tags = ['Claude Code', 'Codex', 'Cursor', 'Cline', 'Continue', 'MCP'];
 const heroStats = [
     { label: 'Query Latency', value: '<1s', highlight: true },
     { label: 'Token Reduction', value: '65.6×', highlight: false },
-    { label: 'Gold-File Recall', value: '100%', highlight: false },
+    { label: 'Gold-File Recall', value: '79-100%', highlight: false },
     { label: 'Free Tier', value: 'Auto-provisioned', highlight: false },
 ];
 


### PR DESCRIPTION
## Description

Follow-up to #430. That PR corrected the public-benchmark recall claim ("100% gold-file recall at 38–85× fewer tokens" → "79–100% gold-file recall (93.75% mean) at 45–257× fewer tokens") across every doc surface in the repo, but `site/` — the neuralmind.uk marketing site — wasn't in scope, since it lives in a separate tree and duplicates its own copy of some claims rather than reading them from docs.

This PR fixes the 3 places on the live site that independently repeated the old claim:

- `site/src/components/sections/Hero.tsx` — homepage hero stat badge
- `site/src/components/sections/Benchmarks.tsx` — benchmarks section
- `site/src/components/sections/BusinessCase.tsx` — "For the CTO" card

All three now read "79-100% gold-file recall" (Hero also states this range; Benchmarks and BusinessCase add "(93.75% mean)" and list all 4 pinned repos — `requests`, `click`, `flask`, `rich` — instead of just the original 2).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 📝 Documentation update

## How Has This Been Tested?

- `npm run build` in `site/` — succeeds, static export generates cleanly (18/18 pages).
- Verified the corrected text is present in the exported static HTML (`site/out/index.html`).
- No other site files reference this claim (`git grep` swept the whole `site/` tree for the old phrasing and related number formats — clean).

### Test Configuration

* **Node**: site's existing `node_modules` / Next.js static export
* **Test command**: `npm run build` (site/)

## Documentation & discoverability

- [x] N/A — internal-only change, no user-facing CLI/MCP/hook/env-var surface; this *is* the user-facing fix (marketing site copy)

## Checklist

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] Build passes locally

## Additional Notes

Small, mechanical follow-up — same root cause as #430 (a benchmark snapshot that changed didn't get propagated everywhere it was quoted), just a surface `docs/`-fixing didn't reach.

---

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01JSNbm726sy9vVhY3kPSEcH

---
_Generated by [Claude Code](https://claude.ai/code/session_01JSNbm726sy9vVhY3kPSEcH)_