### PR TITLE
fix(site): source every marketing number, gate the site against claim drift

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,33 @@ builds it.
   that a hardcoded `v0.42.0` caused. Same rule for SBOM/tarball/release
   links: derive them from the release tag, don't pin a literal version.
 
+### `site/claims.json` is canon for site numbers
+
+Same contract as `commercial-terms.json`: **change the JSON first, then the
+copy**. Every performance ratio quoted on the homepage sections, `page.tsx`,
+or `layout.tsx` metadata must have an entry there naming where it was measured
+and the command that reproduces it. CI enforces it
+(`tests/test_site_claims.py`, stdlib-only), along with two rules the docs
+guard already applied everywhere *except* the site — no absolute privacy
+claims, and no naming a private client whose field report the docs anonymize.
+
+Rules that follow from it:
+
+- **No number without a measurement.** If the copy wants to say something the
+  repo can't measure, write the benchmark first
+  (`tests/benchmark/latency.py` exists because the site was quoting a query
+  latency nothing produced). Mechanism claims — "a local index lookup, not
+  another model call" — are fine unquantified; invented figures are not.
+- **Say which kind of evidence it is.** CI-gated, reproducible-on-demand, a
+  one-repo field report, and a community submission are not the same strength
+  of claim, and the site says which is which.
+- **Quote the mean and the range, publish the misses.** Gold-file recall is
+  93.75% mean / 79–100% per repo, not "100%". The docs already report where
+  NeuralMind loses; the site must not round that away.
+- A page that quotes a forbidden phrase in order to *disown* it (the
+  effectiveness page's list of overclaims) marks the line
+  `claims-guard:allow`.
+
 ## Internal docs — routed to the marketing repo
 
 Pure internal strategy material (BRDs, TRDs, competitive analysis) lives in

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ At a *matched* token budget, NeuralMind's selected context carries more of the g
 - **NOT a SaaS wrapper.** It's a code intelligence layer that runs in your infrastructure. We never see your code.
 - **NOT a model swap.** It works with whatever agent you already use — Claude, GPT, Gemini, or any MCP-compatible agent.
 - **NOT a replacement for Copilot/Cursor.** It composes with them. It's the memory layer that makes every agent smarter.
-- **SOC 2-ready posture, certification on the roadmap.** Our architecture *supports* SOC 2 deployment patterns (zero code egress, hash-chained audit log, RBAC). See [commercial-terms.json](commercial-terms.json).
+- **SOC 2-ready posture, certification on the roadmap.** Our architecture *supports* SOC 2 deployment patterns (an engine that makes no network calls of its own, hash-chained audit log, RBAC). See [commercial-terms.json](commercial-terms.json).
 - **NOT SSO/SAML today.** This is a roadmap feature. See [commercial-terms.json](commercial-terms.json) `do_not_market` list.
 
 **Technical limits:**
@@ -355,7 +355,8 @@ read the number. If it's not worth it, uninstall — and see the
 tier adds governance, audit, and seat management for organizations.
 
 **What about SOC 2?** Our architecture *supports* SOC 2 deployment
-patterns (zero code egress, audit log, RBAC). Certification is on the roadmap.
+patterns (no network calls of its own, audit log, RBAC). Certification is on
+the roadmap.
 See [commercial-terms.json](commercial-terms.json).
 
 **What about SSO/SAML?** Roadmap-only. Not available today. See

--- a/README.md
+++ b/README.md
@@ -96,20 +96,22 @@ The fixture number is the *floor of a floor*: small repo, conservative gate. The
 
 NeuralMind's moat is usage memory: a **Hebbian synapse layer** that learns what your team edits together and surfaces it on future queries.
 
-| Effect | Off | On | Lift |
-|--------|-----|-----|------|
-| **Synapse recall** — top-k retrieval hit rate (same warm graph) | 77.2% | **83.3%** | **+6.1 pts** |
-| **Onboarding lift** — top-k module hit-rate from a committed team baseline | — | — | **+11.6 pts** |
+| Effect | What CI enforces | Observed magnitude |
+|--------|------------------|--------------------|
+| **Synapse recall** — top-k retrieval hit rate (same warm graph) | recall-on ≥ recall-off, at a neutral token budget | **+3.5 to +14 pts** across runs |
+| **Onboarding lift** — top-k module hit-rate from a committed team baseline | lift ≥ 0, averaged over 3 runs | **+0.9 to +11.6 pts** across runs |
 
 Both are **budget-neutral by design**: recalled nodes *displace* the weakest hits rather than adding tokens.
 
+**Why a range, not a number.** Both A/Bs run against a ~500-line fixture through a ChromaDB HNSW index, so the deltas are small and jitter between runs — CI averages the onboarding lift over three runs for exactly that reason. What CI guarantees is the *direction*; the magnitude is whatever your own repo produces. Run `python -m tests.benchmark.run` for yours.
+
 ### 3. Finds the right code (not just less of it)
 
-**100% gold-file recall, MRR 0.96** on the public benchmark (`requests`, `click`). Beats the incumbent `codebase-memory-mcp` on retrieval ranking (0.96 vs 0.23). Reproducible — `python -m evals.public.run`.
+**93.75% mean gold-file recall (79–100% per repo)** across 40 pre-registered queries on four pinned OSS repos (`requests`, `click`, `flask`, `rich`) — every miss published, not rounded away. Reproducible — `python -m evals.public.run`. A separate, off-by-default eval on `requests`/`click` only put retrieval ranking at MRR 0.96 against the incumbent `codebase-memory-mcp`'s 0.23; that one has not been re-verified against the current four-repo corpus.
 
 ### 4. Better-grounded answers (not just shorter)
 
-At a *matched* token budget, NeuralMind's selected context carries more of the gold facts than naive truncation: **faithfulness +0.143, grounding 1.00**.
+At a *matched* token budget, NeuralMind's selected context carries more of the gold facts than naive truncation. CI gates the delta at **≥ 0**; the measured delta has ranged **+0.013 to +0.143** across runs on the reference fixture, with grounding at 1.00. Same caveat as above — the gate is the guarantee, the magnitude moves.
 
 ---
 
@@ -284,8 +286,8 @@ Measured, not marketed — the numbers are produced by CI on every commit
 with `python -m tests.benchmark.run`:
 
 - **79–100% gold-file recall (93.75% mean) at 45–257× fewer tokens** on the public benchmark.
-- **Synapse recall A/B:** +6.1 points top-k hit rate at ±0 token cost.
-- **Onboarding lift:** +6.5 points top-k module hit-rate from committed team baseline (a distinct eval from synapse recall A/B above — see `evals/onboarding/`).
+- **Synapse recall A/B:** lifts top-k hit rate at ±0 token cost — +3.5 to +14 points across runs; CI gates the direction, not the magnitude.
+- **Onboarding lift:** lifts top-k module hit-rate from a committed team baseline — +0.9 to +11.6 points across runs (a distinct eval from the synapse recall A/B above — see `evals/onboarding/`).
 - **Real production rebuild:** 48.8× average reduction, 1,033 tokens/query
   ([full field report](https://neuralmind.uk/effectiveness/)).
 - **6.1× token reduction** on the CI fixture (500-line, deliberately tiny — the floor of a floor).

--- a/docs/HONEST-ASSESSMENT.md
+++ b/docs/HONEST-ASSESSMENT.md
@@ -220,8 +220,9 @@ We'd downgrade our own claims if:
 - Community benchmarks (n ≥ 10 outside repos) show median
   reduction below 5×. (Currently directionally above this on n=2.)
 - Top-k retrieval hit rate on a real-world query set falls below
-  60%. (Currently 77.2% cold / 83.3% warm on the reference fixture — the
-  warm number reflects the learned synapse boost.)
+  60%. (Recent runs land in a 72–83% cold / 78–86% warm band on the
+  reference fixture — the warm number reflects the learned synapse boost.
+  The band is wide because the fixture is tiny and the index is jittery.)
 - A long-context + prompt-caching baseline closes the cost gap to
   within 1.5× on representative workloads.
 - A major agent vendor ships learned, git-portable **team** memory

--- a/docs/about.html
+++ b/docs/about.html
@@ -569,7 +569,7 @@ $ neuralmind query . "CMMC gap analysis"
                 <li><strong>Real pinned repos</strong>, not our fixtures &mdash; <code>git checkout &lt;sha&gt;</code> and audit.</li>
                 <li><strong>Objective gold, no LLM judge</strong> &mdash; each gold file is a symbol's definition site, verifiable with one <code>rg</code>; scoring reuses the same <code>neuralmind/quality.py</code> the CI gate runs.</li>
                 <li><strong>Cost + correctness jointly</strong>, never a lone reduction ratio; pre-registered queries, every one reported including losses.</li>
-                <li><strong>Deterministic</strong> &mdash; synapse injection is OFF (session-dependent learning can't be a fixed public number; its <strong>+6.1pt</strong> lift is measured separately by the synapse A/B eval). Re-running matches to the token.</li>
+                <li><strong>Deterministic</strong> &mdash; synapse injection is OFF (session-dependent learning can't be a fixed public number; its lift is measured separately by the synapse A/B eval, which CI gates on direction rather than magnitude). Re-running matches to the token.</li>
                 <li><strong>Forkable</strong> &mdash; <code>.github/workflows/bench-public.yml</code> regenerates the table on demand; raw per-query data at <code>bench/public/results.json</code>.</li>
             </ul>
             <p><a href="https://github.com/dfrostar/neuralmind/blob/main/docs/benchmarks/public.md">Full methodology, caveats, and where NeuralMind loses →</a> &middot; <a href="https://github.com/dfrostar/neuralmind/blob/main/docs/releases/RELEASE_NOTES_v0.31.0.md">v0.31.0 release notes →</a></p>
@@ -665,7 +665,7 @@ $ neuralmind query . "CMMC gap analysis"
             <h2>What's New in v0.25.0 — one learning system: the synapse layer</h2>
             <p><strong>NeuralMind now has a single learning signal.</strong> The old <code>learned_patterns</code> cooccurrence reranker is removed, and <code>neuralmind learn</code> becomes an exit-0 deprecation no-op. The Hebbian <strong>synapse layer</strong> — which already learns continuously from your queries, edits, and tool calls, and lets unused edges decay — is now the only thing that adapts retrieval to how you actually use the codebase. One system instead of two means automatic learning instead of a manual step, and decay instead of staleness. This is a removal, not a regression: warm-path recall is synapse-driven exactly as it was in v0.24.</p>
             <h3>The A/B evidence</h3>
-            <p>A 2&times;2 on the benchmark fixture measured top-k hit rate with the reranker on vs. off, crossed with synapses on vs. off. The reranker moved the number by <strong>0.0 points</strong> in both rows (77.2% &rarr; 77.2% cold, 83.3% &rarr; 83.3% warm), while the synapse layer alone moved it by <strong>+6.1 points</strong>. The reranker was also runtime-inert on the warm path — the synapse boost re-sort discarded its ordering anyway — required the manual <code>neuralmind learn</code> step to populate, and went stale between runs. The learning that matters is the synapse layer's, and that is the signal NeuralMind keeps.</p>
+            <p>A 2&times;2 on the benchmark fixture measured top-k hit rate with the reranker on vs. off, crossed with synapses on vs. off. The reranker moved the number by <strong>0.0 points</strong> in both rows (77.2% &rarr; 77.2% cold, 83.3% &rarr; 83.3% warm), while the synapse layer alone moved it (+3.5 to +14 points across runs — the absolute levels jitter on a fixture this small, so the finding is the reranker's 0.0, not the levels). The reranker was also runtime-inert on the warm path — the synapse boost re-sort discarded its ordering anyway — required the manual <code>neuralmind learn</code> step to populate, and went stale between runs. The learning that matters is the synapse layer's, and that is the signal NeuralMind keeps.</p>
             <h3>What the agent actually sees</h3>
             <ul>
                 <li><strong>No warm-path behavior change.</strong> Recall is synapse-driven exactly as before, through both the CLI and MCP. Claude Code, Cursor, Cline, and generic MCP clients all see the same results.</li>
@@ -777,7 +777,7 @@ $ neuralmind query . "CMMC gap analysis"
                 <li><strong>Zero machine-specific config.</strong> The launch spec is just <code>{"command": "neuralmind-mcp"}</code> — the MCP tools take a <code>project_path</code> per call, so there's nothing to bake in.</li>
             </ul>
             <h3>Why this matters — the moat</h3>
-            <p>AST-derived code graphs are becoming table stakes. NeuralMind's durable edge is usage memory + distribution. The self-benchmark already measures the learned uplift directly (Phase 3 — synapse-recall A/B: top-k hit rate 77.2% → 83.3%, +6.1 points with recall on, at a neutral token budget). v0.19.0 invests in the other half — making NeuralMind trivial to plug into every agent, so it sees more usage and learns more.</p>
+            <p>AST-derived code graphs are becoming table stakes. NeuralMind's durable edge is usage memory + distribution. The self-benchmark already measures the learned uplift directly (Phase 3 — synapse-recall A/B: top-k hit rate lifts with recall on, at a neutral token budget; +3.5 to +14 points across runs, CI-gated on direction). v0.19.0 invests in the other half — making NeuralMind trivial to plug into every agent, so it sees more usage and learns more.</p>
             <p><a href="https://github.com/dfrostar/neuralmind/blob/main/docs/releases/RELEASE_NOTES_v0.19.0.md">Full v0.19.0 release notes →</a></p>
         </div>
     </section>
@@ -1119,7 +1119,7 @@ $ neuralmind query . "CMMC gap analysis"
         <div class="container">
             <h2>Status & Roadmap</h2>
             <h3>Current Release: v0.19.0 — One-command MCP setup</h3>
-            <p>The latest release leans into the distribution moat: <code>neuralmind install-mcp --all</code> auto-detects your installed agents (Claude Code, Cursor, Cline, Claude Desktop) and registers NeuralMind's MCP server with each — a non-destructive, idempotent merge. The learned synapse layer's uplift is already measured by the self-benchmark's Phase-3 A/B (top-k hit rate 77.2% → 83.3% with recall on). See the <a href="https://github.com/dfrostar/neuralmind/blob/main/docs/releases/RELEASE_NOTES_v0.19.0.md">v0.19.0 release notes</a> or the <a href="#whats-new-v0190">summary above</a>.</p>
+            <p>The latest release leans into the distribution moat: <code>neuralmind install-mcp --all</code> auto-detects your installed agents (Claude Code, Cursor, Cline, Claude Desktop) and registers NeuralMind's MCP server with each — a non-destructive, idempotent merge. The learned synapse layer's uplift is already measured by the self-benchmark's Phase-3 A/B (top-k hit rate lifts with recall on — +3.5 to +14 points across runs). See the <a href="https://github.com/dfrostar/neuralmind/blob/main/docs/releases/RELEASE_NOTES_v0.19.0.md">v0.19.0 release notes</a> or the <a href="#whats-new-v0190">summary above</a>.</p>
 
             <h3>Future Releases</h3>
             <ul>

--- a/docs/benchmarks/public.md
+++ b/docs/benchmarks/public.md
@@ -175,7 +175,8 @@ Two loss modes, reported plainly:
   usage-dependent — they learn from how *you* work — so they cannot be part of a
   *fixed, reproducible* public number. Injection is OFF here. The learning lift
   is measured separately and reproducibly by the **synapse A/B eval**
-  (`tests/benchmark/run.py`, Phase 2): **+6.1 points** top-k hit-rate, budget-
+  (`tests/benchmark/run.py`, Phase 2): **+3.5 to +14 points** top-k hit-rate
+across runs, CI-gated on direction, budget-
   neutral, on the reference fixture. That is the differentiator a static index
   structurally cannot copy.
 - **End-to-end answer quality.** Gold-file recall is deliberately a *findability*

--- a/docs/comparisons/context-engineering-stack.md
+++ b/docs/comparisons/context-engineering-stack.md
@@ -36,7 +36,7 @@ The removal of the reranker highlights the efficacy of the synapse layer as a st
 | Memory Engine Configuration | Top-k Hit Rate (Cold Path) | Top-k Hit Rate (Warm Path) | Accuracy Gain |
 |---|---|---|---|
 | Synapses Off | 77.2% | 77.2% | 0.0 |
-| Synapses On | 83.3% | 83.3% | +6.1 pts |
+| Synapses On | 83.3% | 83.3% | positive |
 
 Reproduce locally: `python -m tests.benchmark.run`
 

--- a/docs/wiki/Architecture.md
+++ b/docs/wiki/Architecture.md
@@ -736,7 +736,7 @@ NeuralMind once had a second learning mechanism, the `learned_patterns`
 cooccurrence **reranker** (v0.3.2). **It was removed in v0.25.0** after a
 2×2 A/B on the benchmark fixture showed it added 0.0 points to top-k hit
 rate whether the synapse layer was on or off (77.2% → 77.2% cold, 83.3% →
-83.3% warm), while the synapse layer alone added +6.1 points. The
+83.3% warm — these are the levels that one run produced; the absolute hit rates move between runs, so the finding is the 0.0-point delta, not the levels), while the synapse layer alone moved it. The
 reranker was also runtime-inert on the warm path — the synapse boost
 re-sort discarded its ordering anyway. The architectural reason the two
 were never equivalent:

--- a/docs/wiki/Benchmarks.md
+++ b/docs/wiki/Benchmarks.md
@@ -26,10 +26,11 @@ on every repo; **(2) Finds the right code** — 100% gold-file recall, **MRR
 0.96**, beating the incumbent `codebase-memory-mcp` on retrieval ranking (0.96
 vs 0.23) — a separate, off-by-default eval on `requests`/`click` only, not yet
 re-verified against the current `flask`/`rich`-expanded corpus; **(3) Learns
-how you work** — the Hebbian synapse layer lifts top-k
-hit-rate **+6.1 points (77.2%→83.3%), budget-neutral** (reference fixture);
-**(4) Better-grounded answers** — at a matched budget, **faithfulness +0.143,
-grounding 1.00** (reference fixture). We report where NeuralMind *doesn't* win
+how you work** — the Hebbian synapse layer lifts top-k hit-rate, **budget-neutral**
+(reference fixture; +3.5 to +14 points across runs, CI gates the direction);
+**(4) Better-grounded answers** — at a matched budget its context carries more gold
+facts than naive truncation (reference fixture; delta +0.013 to +0.143 across runs,
+CI gates it at ≥ 0, grounding 1.00). We report where NeuralMind *doesn't* win
 too — a well-tuned vector RAG ties or beats it on pure findability and is
 cheaper on raw tokens, two repos have partial gold-file misses (see the public
 benchmark's "Where NeuralMind loses" section), and the competitor row is *pure
@@ -59,13 +60,16 @@ Yes, and it's measured. The **faithfulness eval** compares NeuralMind's selected
 context against naive truncation **at the same token budget** — the honest
 comparison, not "small context vs the whole repo."
 
-| Metric (built-in backend, gold set) | NeuralMind | Matched-budget naive | Delta |
-|---|---:|---:|---:|
-| Expected-fact recall | **0.717** | 0.574 | **+0.143** |
-| Grounding (right modules cited) | **1.000** | — | — |
+| Metric (built-in backend, gold set) | What CI enforces | Observed across runs |
+|---|---|---|
+| Expected-fact recall vs matched-budget naive | delta **≥ 0** | **+0.013 to +0.143** |
+| Grounding (right modules cited) | not gated — saturates on this fixture | 1.000 |
 
-A positive delta means smart selection beats dumb truncation **at equal cost**.
-Gated in CI at delta ≥ 0.
+A positive delta means smart selection beats dumb truncation **at equal cost**, and
+that is what CI guarantees. The *size* of the delta is not a fixed property: on a
+~500-line fixture behind an HNSW index it moves between runs, so we publish the
+gate and the observed band rather than a point estimate that goes stale the week
+after it is written.
 
 ## The learned memory layer (the differentiator)
 
@@ -73,10 +77,10 @@ NeuralMind's moat is usage memory: a Hebbian **synapse layer** that learns what
 your team edits together and surfaces it on future queries. Both effects are
 measured by isolated A/Bs:
 
-| Effect | Off | On | Lift |
-|---|---:|---:|---:|
-| **Synapse recall** — top-k retrieval hit rate (same warm graph) | 77.2% | **83.3%** | **+6.1 pts** |
-| **Onboarding lift** — top-k module hit-rate from a committed team baseline | 81.5% | **82.4%** | **+0.9 pts** |
+| Effect | What CI enforces | Observed across runs |
+|---|---|---|
+| **Synapse recall** — top-k retrieval hit rate (same warm graph) | recall-on **≥** recall-off, at a neutral token budget | **+3.5 to +14 pts** |
+| **Onboarding lift** — top-k module hit-rate from a committed team baseline | lift **≥ 0**, averaged over 3 runs | **+0.9 to +11.6 pts** |
 
 Both are **budget-neutral by design**: recalled nodes *displace* the weakest hits
 rather than adding tokens. The onboarding lift is the answer to "does an agent

--- a/docs/wiki/CLI-Reference.md
+++ b/docs/wiki/CLI-Reference.md
@@ -594,7 +594,7 @@ python -m evals.public.run
 ```
 
 The run is **deterministic** — synapse injection is **OFF** (session-dependent
-learning can't be a fixed, reproducible public number; its **+6.1pt** lift is
+learning can't be a fixed, reproducible public number; its lift is
 measured separately by the synapse A/B eval, `tests/benchmark/run.py` Phase 2).
 This reuses the same `NEURALMIND_SYNAPSE_INJECT=0` toggle documented in the
 [Environment Variables](#environment-variables) table. Re-running matches the
@@ -1131,7 +1131,8 @@ Learning is now handled entirely by the **synapse layer**, which learns
 continuously and automatically from queries, edits, and tool calls — no
 manual step, and edges decay instead of going stale. A 2×2 A/B on the
 benchmark fixture showed the old reranker added 0.0 points to top-k hit
-rate while the synapse layer alone adds +6.1 points.
+rate while the synapse layer alone moves it (+3.5 to +14 points across
+runs; CI gates the direction, not the magnitude).
 
 To see what's been learned, use [`neuralmind stats`](#stats) or
 [`neuralmind memory inspect`](#neuralmind-memory). For the full rationale

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -16,8 +16,8 @@ smaller-scope.
 |---|---|---|---|
 | 💸 | **Cheaper context** | **79–100% gold-file recall (93.75% mean) at 45–257× fewer tokens** than pasting files — beats `ripgrep` on cost on every repo, and on recall beats it on 2 of 4 and ties exactly on the other 2 | Public benchmark, **real OSS repos** (`requests`, `click`, `flask`, `rich`) |
 | 🎯 | **Finds the *right* code, not just less of it** | **100% gold-file recall, MRR 0.96** — ranks the correct file at the top; beats the incumbent `codebase-memory-mcp` on retrieval ranking (0.96 vs 0.23) | Same public benchmark, **real repos** |
-| 🧠 | **Learns how you work** | A Hebbian *synapse* layer that learns co-edited files lifts top-k retrieval hit-rate **+6.1 points (77.2%→83.3%)**, **budget-neutral** (no extra tokens) | Synapse A/B eval (**reference fixture** — smaller scope) |
-| 🔬 | **Better-grounded answers** | At a *matched* token budget, its context carries more of the gold facts than naive truncation: **faithfulness +0.143, grounding 1.00** | Faithfulness/parity gate (**reference fixture** — smaller scope) |
+| 🧠 | **Learns how you work** | A Hebbian *synapse* layer that learns co-edited files lifts top-k retrieval hit-rate — **+3.5 to +14 points across runs**, CI-gated on direction — **budget-neutral** (no extra tokens) | Synapse A/B eval (**reference fixture** — smaller scope) |
+| 🔬 | **Better-grounded answers** | At a *matched* token budget, its context carries more of the gold facts than naive truncation: **delta CI-gated ≥ 0, +0.013 to +0.143 observed**, grounding 1.00 | Faithfulness/parity gate (**reference fixture** — smaller scope) |
 
 *Honest scope:* the **cost** and **accuracy** rows run on real, pinned OSS repos
 (fully reproducible — see [methodology](https://github.com/dfrostar/neuralmind/blob/main/docs/benchmarks/public.md)); the "beats ripgrep" claim is specifically
@@ -173,9 +173,9 @@ The opt-in `turbovec` backend can now **embed *and* search with zero ChromaDB**:
 
 ### v0.20.0 — Measure the onboarding lift
 
-`neuralmind eval --onboarding` turns NeuralMind's differentiator into a number: does an agent that inherits a **committed team memory** retrieve better on its *first* queries than a cold agent? The headline is the **top-k module hit-rate lift** (currently **+0.9 points** on the reference fixture — down from the +6.5 points measured at this feature's introduction, because the cold-path baseline has itself gotten better since, leaving less headroom for the memory layer to add), with fact-recall + grounding as honest secondaries; budget-neutral, gated in CI at lift ≥ 0. Full details: [v0.20.0 release notes](https://github.com/dfrostar/neuralmind/blob/main/docs/releases/RELEASE_NOTES_v0.20.0.md).
+`neuralmind eval --onboarding` turns NeuralMind's differentiator into a number: does an agent that inherits a **committed team memory** retrieve better on its *first* queries than a cold agent? The headline is the **top-k module hit-rate lift** (run-dependent: **+0.9 to +11.6 points** observed across runs on the reference fixture, and trending toward the low end of that band as the cold-path baseline itself improves, leaving less headroom for the memory layer to add), with fact-recall + grounding as honest secondaries; budget-neutral, gated in CI at lift ≥ 0. Full details: [v0.20.0 release notes](https://github.com/dfrostar/neuralmind/blob/main/docs/releases/RELEASE_NOTES_v0.20.0.md).
 
-> 📊 New: a single **[Benchmarks & Results](Benchmarks)** page collects every measured, CI-gated number (token reduction, faithfulness delta, synapse +6.1 pts, onboarding +0.9 pts, ChromaDB-free parity) with reproduction commands.
+> 📊 New: a single **[Benchmarks & Results](Benchmarks)** page collects every measured, CI-gated number (token reduction, faithfulness delta, synapse and onboarding lift, pts, ChromaDB-free parity) with reproduction commands.
 
 ### v0.14.0 — Measure faithfulness
 
@@ -275,7 +275,7 @@ sections.
 || **[Multi-Project-Scoping](Multi-Project-Scoping.md)** | Working across multiple codebases — isolation rules for NeuralMind, memU, and agent memory |
 || **[Upgrade-Guide](Upgrade-Guide.md)** | Free → Team flow, downgrade, troubleshooting |
 | **[Compatibility Matrix](../COMPATIBILITY.md)** | Version compatibility, Python support, known issues, upgrade paths |
-| **[Benchmarks & Results](Benchmarks)** | Every measured, CI-gated number — token reduction, faithfulness delta, synapse +6.1 pts, onboarding +0.9 pts, ChromaDB-free parity — with reproduction commands |
+| **[Benchmarks & Results](Benchmarks)** | Every measured, CI-gated number — token reduction, faithfulness delta, synapse and onboarding lift, ChromaDB-free parity — with reproduction commands |
 
 ### Enterprise & Deployment
 

--- a/docs/wiki/Learning-Guide.md
+++ b/docs/wiki/Learning-Guide.md
@@ -309,8 +309,8 @@ next query re-ordered its L3 hits by a `+0.3` cooccurrence boost.
 
 **It was removed** after a 2×2 A/B on the benchmark fixture showed it
 added **0.0 points** to top-k hit rate whether the synapse layer was on
-or off (77.2% → 77.2% cold, 83.3% → 83.3% warm), while the synapse layer
-alone added **+6.1 points**. The reranker was also runtime-inert on the
+or off (77.2% → 77.2% cold, 83.3% → 83.3% warm — these are the levels that one run produced; the absolute hit rates move between runs, so the finding is the 0.0-point delta, not the levels), while the
+synapse layer alone moved it. The reranker was also runtime-inert on the
 warm path — the synapse boost re-sort discarded its ordering anyway — it
 required the manual `neuralmind learn` step to populate, and its JSON
 captured a snapshot that went stale between runs. The synapse layer is

--- a/docs/wiki/Limits-and-Failure-Modes.md
+++ b/docs/wiki/Limits-and-Failure-Modes.md
@@ -34,7 +34,7 @@ question NeuralMind is built to answer:
 **Where it's enough.** Locating the right files/symbols, understanding one
 subsystem, answering "how does X work", seeding a focused change. The faithfulness
 eval shows that at a **matched budget**, smart selection beats naive truncation
-(**+0.143 expected-fact recall**, [Benchmarks](Benchmarks)) — i.e. the ~2.5K
+(**expected-fact recall delta CI-gated ≥ 0; +0.013 to +0.143 observed across runs**, [Benchmarks](Benchmarks)) — i.e. the ~2.5K
 tokens are *better-chosen* tokens, not just fewer.
 
 **Where it gets thin.** A single ~2.5K-token window is a poor fit for work that

--- a/docs/wiki/Usage-Guide.md
+++ b/docs/wiki/Usage-Guide.md
@@ -484,7 +484,8 @@ Learning is now handled entirely by the **synapse layer**, which learns
 continuously and automatically from queries, edits, and tool calls — no
 manual step, and edges decay instead of going stale. The reranker was
 removed after a 2×2 A/B on the benchmark fixture showed it added 0.0
-points to top-k hit rate while the synapse layer alone adds +6.1 points.
+points to top-k hit rate while the synapse layer alone moves it (+3.5 to
++14 points across runs; CI gates the direction, not the magnitude).
 
 **What to do instead**: install the lifecycle hooks
 (`neuralmind install-hooks .`) and optionally run `neuralmind watch .` so

--- a/site/claims.json
+++ b/site/claims.json
@@ -136,16 +136,18 @@
       "note": "Do NOT round this to '100% recall'. Per-repo recall is 0.96 / 0.79 / 0.95 / 1.00; click is the weakest and every miss is published."
     },
     {
-      "claim": "Synapse recall lift +6.1 points top-k hit rate (77.2% -> 83.3%), budget-neutral",
+      "claim": "Synapse recall never lowers top-k hit rate, at a neutral token budget",
       "source": "docs/wiki/Benchmarks.md",
       "reproduce": "python -m tests.benchmark.run",
-      "evidence": "ci-gated"
+      "evidence": "ci-gated",
+      "note": "The CI gate is DIRECTIONAL: test_synapse_recall_does_not_reduce_hit_rate asserts on >= off, and test_synapse_recall_is_budget_neutral bounds the reduction delta. It does not gate a magnitude. The +6.1 pts (77.2% -> 83.3%) figure published in docs/wiki/ traces to the v0.25.0 2x2 study; the self-benchmark's current Phase 2 output reports +3.5 pts (74.6% -> 78.1%). Do not quote either magnitude as 'CI-gated' — quote the gate, and let the reproduction command give the number."
     },
     {
-      "claim": "Faithfulness +0.143 expected-fact recall vs naive truncation at a matched token budget; grounding 1.00",
+      "claim": "NeuralMind's selection beats naive truncation at a matched token budget",
       "source": "docs/wiki/Benchmarks.md",
       "reproduce": "python -m evals.faithfulness.runner --run",
-      "evidence": "ci-gated"
+      "evidence": "ci-gated",
+      "note": "Also DIRECTIONAL: ci-benchmark.yml asserts faithfulness_delta >= 0.0 on the shipped built-in backend. The +0.143 in docs/wiki/ is not the current measurement — this PR's parity gate reports a built-in delta of +0.013. Same rule: quote the gate, not a stale magnitude."
     },
     {
       "claim": "TurboVec fact recall 0.800 vs chroma float32 0.744, identical top-k hit@4",
@@ -170,6 +172,10 @@
     {
       "claim": "100% gold-file recall on the public benchmark",
       "why": "Contradicted by the current public benchmark: 0.96 on requests, 0.79 on click. The 100% figure came from an older, narrower competitor eval that the docs already flag as not re-verified against the expanded corpus."
+    },
+    {
+      "claim": "'+6.1 pts' or '+0.143' labelled CI-gated",
+      "why": "Both CI gates assert direction only (on >= off, delta >= 0.0), never a magnitude, and both published magnitudes are contradicted by current CI output. Quoting a number as gated when only its sign is gated is the same defect as quoting a number with no measurement at all."
     }
   ],
   "private_names_never_publish": [

--- a/site/claims.json
+++ b/site/claims.json
@@ -1,0 +1,179 @@
+{
+  "_comment": "Canon for every performance ratio quoted on the marketing site's high-traffic surfaces (homepage sections, page.tsx, layout.tsx metadata + JSON-LD). Same contract as commercial-terms.json: change this file first, then propagate. CI enforces it via tests/test_site_claims.py — a ratio on those surfaces that is not listed here fails the build. This exists because the site drifted: it carried a 65.6x figure attributed to three different repo sizes, a 63.6x typo of the same number, a 0.81s latency with no source in the repo, a '100% gold-file recall' that the current public benchmark contradicts (93.75% mean), and the real name of a private client whose field report the docs deliberately anonymize.",
+  "_evidence_levels": {
+    "ci-gated": "Recomputed and asserted on every PR. Cannot silently regress.",
+    "reproducible": "Not a gate, but any reader can rerun it from a fresh clone and get the same number.",
+    "field-report": "One repo, one developer, maintainer-measured. Reproducible in method, not in number. Must be labelled as such wherever it appears.",
+    "community": "Submitted to docs/community-benchmarks.json by a named submitter. n is small; treat as directional."
+  },
+  "ratios": [
+    {
+      "value": 45,
+      "context": "Low end of 'fewer tokens than pasting whole files', across the 40-query public benchmark (requests, at 44.9x, rounded down).",
+      "source": "docs/benchmarks/public.md",
+      "reproduce": "python -m evals.public.run",
+      "evidence": "reproducible"
+    },
+    {
+      "value": 257,
+      "context": "High end of the same range (rich, at 256.8x, rounded up).",
+      "source": "docs/benchmarks/public.md",
+      "reproduce": "python -m evals.public.run",
+      "evidence": "reproducible"
+    },
+    {
+      "value": 44.9,
+      "context": "requests @ 0e322af877 — tokens vs full-file baseline.",
+      "source": "docs/benchmarks/public.md",
+      "reproduce": "python -m evals.public.run",
+      "evidence": "reproducible"
+    },
+    {
+      "value": 99.6,
+      "context": "click @ 874ca2bc1c — tokens vs full-file baseline.",
+      "source": "docs/benchmarks/public.md",
+      "reproduce": "python -m evals.public.run",
+      "evidence": "reproducible"
+    },
+    {
+      "value": 76.4,
+      "context": "flask @ c12a5d874c — tokens vs full-file baseline.",
+      "source": "docs/benchmarks/public.md",
+      "reproduce": "python -m evals.public.run",
+      "evidence": "reproducible"
+    },
+    {
+      "value": 256.8,
+      "context": "rich @ 7f580bdc70 — tokens vs full-file baseline.",
+      "source": "docs/benchmarks/public.md",
+      "reproduce": "python -m evals.public.run",
+      "evidence": "reproducible"
+    },
+    {
+      "value": 12,
+      "context": "Low end of the published real-repo positioning range. Directional, not a guarantee — the docs say so explicitly.",
+      "source": "docs/wiki/Benchmarks.md",
+      "reproduce": "neuralmind benchmark <your repo>",
+      "evidence": "field-report"
+    },
+    {
+      "value": 50,
+      "context": "High end of the published real-repo positioning range.",
+      "source": "docs/wiki/Benchmarks.md",
+      "reproduce": "neuralmind benchmark <your repo>",
+      "evidence": "field-report"
+    },
+    {
+      "value": 48.8,
+      "context": "Field report: anonymized ~9,300-node private TypeScript SaaS platform. Never name the client — the docs and the community-benchmark entry are both anonymized on purpose.",
+      "source": "docs/use-cases/measure-memory-across-a-refactor.md",
+      "reproduce": "neuralmind benchmark <your repo>",
+      "evidence": "field-report"
+    },
+    {
+      "value": 65.6,
+      "context": "Community-submitted: project-alpha, JavaScript, 241 nodes. NOT a 1,486-node repo — that attribution was invented on the site and matches nothing in the data.",
+      "source": "docs/community-benchmarks.json",
+      "reproduce": "neuralmind benchmark . --json",
+      "evidence": "community"
+    },
+    {
+      "value": 46,
+      "context": "Community-submitted: project-beta, Python, 1,626 nodes.",
+      "source": "docs/community-benchmarks.json",
+      "reproduce": "neuralmind benchmark . --json",
+      "evidence": "community"
+    },
+    {
+      "value": 6.2,
+      "context": "Hermetic CI fixture (~500 lines) token reduction. Deliberately a floor of a floor.",
+      "source": "docs/wiki/Benchmarks.md",
+      "reproduce": "python -m tests.benchmark.run",
+      "evidence": "ci-gated"
+    },
+    {
+      "value": 4.0,
+      "context": "CI regression floor — the build fails below this.",
+      "source": "docs/wiki/Benchmarks.md",
+      "reproduce": "python -m tests.benchmark.run",
+      "evidence": "ci-gated"
+    },
+    {
+      "value": 5.5,
+      "context": "Average reduction printed by scripts/demo.sh across its 3 bundled-fixture queries.",
+      "source": "scripts/demo.sh",
+      "reproduce": "bash scripts/demo.sh",
+      "evidence": "reproducible"
+    },
+    {
+      "value": 5.7,
+      "context": "Single-query reduction in the same demo transcript.",
+      "source": "scripts/demo.sh",
+      "reproduce": "bash scripts/demo.sh",
+      "evidence": "reproducible"
+    },
+    {
+      "value": 8,
+      "context": "Low end of TurboVec 4-bit index vector shrink vs float32.",
+      "source": "docs/wiki/Benchmarks.md",
+      "reproduce": "python -m evals.parity.run",
+      "evidence": "ci-gated"
+    },
+    {
+      "value": 16,
+      "context": "High end of the same shrink range.",
+      "source": "docs/wiki/Benchmarks.md",
+      "reproduce": "python -m evals.parity.run",
+      "evidence": "ci-gated"
+    }
+  ],
+  "non_ratio_headline_claims": [
+    {
+      "claim": "93.75% gold-file recall (mean), 79-100% per repo, 90% found-rate, across 40 pre-registered queries on 4 pinned OSS repos",
+      "source": "docs/benchmarks/public.md",
+      "reproduce": "python -m evals.public.run",
+      "evidence": "reproducible",
+      "note": "Do NOT round this to '100% recall'. Per-repo recall is 0.96 / 0.79 / 0.95 / 1.00; click is the weakest and every miss is published."
+    },
+    {
+      "claim": "Synapse recall lift +6.1 points top-k hit rate (77.2% -> 83.3%), budget-neutral",
+      "source": "docs/wiki/Benchmarks.md",
+      "reproduce": "python -m tests.benchmark.run",
+      "evidence": "ci-gated"
+    },
+    {
+      "claim": "Faithfulness +0.143 expected-fact recall vs naive truncation at a matched token budget; grounding 1.00",
+      "source": "docs/wiki/Benchmarks.md",
+      "reproduce": "python -m evals.faithfulness.runner --run",
+      "evidence": "ci-gated"
+    },
+    {
+      "claim": "TurboVec fact recall 0.800 vs chroma float32 0.744, identical top-k hit@4",
+      "source": "docs/wiki/Benchmarks.md",
+      "reproduce": "python -m evals.parity.run",
+      "evidence": "ci-gated"
+    }
+  ],
+  "unsourced_do_not_use": [
+    {
+      "claim": "0.81s query latency",
+      "why": "No measurement anywhere in the repo produces this number. There is per-query latency instrumentation (neuralmind/metrics_pipeline.py) but no committed benchmark result, so the figure cannot be defended. Speed claims must be mechanism-based ('a local index lookup, not another model call') until a latency benchmark is committed."
+    },
+    {
+      "claim": "63.6x token reduction",
+      "why": "A transcription error for the 65.6x community submission. There is no 63.6x measurement."
+    },
+    {
+      "claim": "1,486-node production codebase",
+      "why": "Matches no repo in any dataset. 65.6x came from a 241-node repo; the 1,626-node repo measured 46.0x; the field report repo has ~9,300 nodes."
+    },
+    {
+      "claim": "100% gold-file recall on the public benchmark",
+      "why": "Contradicted by the current public benchmark: 0.96 on requests, 0.79 on click. The 100% figure came from an older, narrower competitor eval that the docs already flag as not re-verified against the expanded corpus."
+    }
+  ],
+  "private_names_never_publish": [
+    "Level2Logic",
+    "cmmc20"
+  ]
+}

--- a/site/src/app/effectiveness/page.tsx
+++ b/site/src/app/effectiveness/page.tsx
@@ -35,6 +35,7 @@ const honestyGate = [
         body: 'No co-view signal yet. Structural seeds exist, but synaptic learning needs weeks of sessions.',
     },
     {
+        // claims-guard:allow — this entry exists to disown the phrase, not to make it.
         title: 'Zero code egress',
         body: 'Overclaim. The agent layer still talks to its model. NeuralMind makes no network calls of its own.',
     },

--- a/site/src/app/layout.tsx
+++ b/site/src/app/layout.tsx
@@ -2,12 +2,13 @@ import './globals.css';
 import { getLatestRelease } from '@/lib/release';
 
 export const metadata = {
-    title: 'NeuralMind — Sub-Second Retrieval for AI Coding Agents | 65.6× Token Reduction',
+    title: 'NeuralMind — Code Memory for AI Coding Agents | 93.75% Gold-File Recall',
     description:
-        'Sub-second retrieval for AI coding agents. 65.6× token reduction on a 1,486-node production codebase. Local-first, zero telemetry.',
+        'Memory for AI coding agents that opens the right file first: 93.75% gold-file recall across 40 pre-registered queries on four public repos, at 45–257× fewer tokens than pasting them in. Local-first, no telemetry.',
     keywords: [
         'AI coding agent memory',
-        'sub-second code retrieval',
+        'gold-file recall',
+        'local code retrieval',
         'token reduction',
         'semantic code search',
         'context compression',
@@ -29,9 +30,9 @@ export const metadata = {
         canonical: '/',
     },
     openGraph: {
-        title: 'NeuralMind — Sub-Second Retrieval for AI Coding Agents',
+        title: 'NeuralMind — Code Memory for AI Coding Agents',
         description:
-            'Sub-second retrieval on a 1,486-node repo. 65.6× token reduction. Local-first, zero telemetry, honest benchmarks.',
+            '93.75% gold-file recall across 40 pre-registered queries on four public repos, at 45–257× fewer tokens. Local-first, no telemetry, honest benchmarks — every miss published.',
         url: 'https://neuralmind.uk',
         siteName: 'NeuralMind',
         locale: 'en_US',
@@ -41,15 +42,15 @@ export const metadata = {
                 url: '/social-preview.png',
                 width: 1200,
                 height: 630,
-                alt: 'NeuralMind — Sub-Second Retrieval for AI Coding Agents',
+                alt: 'NeuralMind — Code Memory for AI Coding Agents',
             },
         ],
     },
     twitter: {
         card: 'summary_large_image',
-        title: 'NeuralMind — Sub-Second Retrieval for AI Coding Agents',
+        title: 'NeuralMind — Code Memory for AI Coding Agents',
         description:
-            'Sub-second retrieval on a 1,486-node repo. 65.6× token reduction. Local-first, zero telemetry.',
+            '93.75% gold-file recall across 40 pre-registered queries on four public repos, at 45–257× fewer tokens. Local-first, no telemetry.',
         images: ['https://neuralmind.uk/social-preview.png'],
     },
     robots: {
@@ -91,8 +92,8 @@ const buildJsonLd = (softwareVersion: string, dateModified: string) => ({
             keywords:
                 'AI coding agent memory, code intelligence, token reduction, RAG, MCP server, knowledge graph, Hebbian synapses, progressive context disclosure',
             featureList: [
-                'Sub-second retrieval (0.81s/query) via TurboVec 4-bit quantized index',
-                '65.6× per-query token reduction measured on 1,486-node production codebase',
+                'ChromaDB-free TurboVec retrieval: 4-bit quantized index, 8–16× smaller vectors, parity gated in CI',
+                '45–257× fewer tokens than full-file context across 40 pre-registered queries on four public repos',
                 'Read-only team dashboard with synapse memory, ingestion, and latency trends',
                 'DocEvolver: evolutionary JSDoc optimization for undocumented methods',
                 'Brain-like Hebbian synapse layer that learns associations from how you use the codebase',

--- a/site/src/app/pricing/page.tsx
+++ b/site/src/app/pricing/page.tsx
@@ -74,7 +74,7 @@ const faqs = [
     },
     {
         q: 'Where is my team data stored?',
-        a: 'All synapse data is stored locally. Team memory bundles publish and import through your own git repository — no relay, no server of ours in the path. Enterprise can run fully air-gapped in your infrastructure. We never train on your code.',
+        a: 'All synapse data is stored locally. Team memory bundles publish and import through your own git repository — no relay, no server of ours in the path. Enterprise is air-gap installable in your infrastructure. We never train on your code.',
     },
 ];
 

--- a/site/src/app/services/page.tsx
+++ b/site/src/app/services/page.tsx
@@ -19,7 +19,7 @@ const offerings = [
         description:
             'Find out what NeuralMind actually does on your code before anyone installs anything team-wide.',
         features: [
-            'Benchmark on 1–3 of your repos, run on your hardware — nothing leaves your machines',
+            'Benchmark on 1–3 of your repos, run on your hardware — the benchmark makes no network calls of its own',
             'Measured retrieval reduction ratios (the same harness as our public CI numbers)',
             'Retrieval-quality spot checks against real questions from your team',
             'Fit across your agent stack: Claude Code, Cursor, Cline, Codex, any MCP client',
@@ -191,7 +191,7 @@ export default function ServicesPage() {
                         </p>
                         <ul className="space-y-2 mb-4">
                             {[
-                                'Local-first with zero telemetry — your code and learned memory never leave your infrastructure',
+                                'Local-first with zero telemetry — NeuralMind stores your code graph and learned memory on your own infrastructure and makes no network calls of its own',
                                 'Append-only, hash-chained audit log of team-memory governance actions',
                                 'Publish scoping and admin roles controlling what leaves each developer’s machine',
                                 'A CycloneDX SBOM published for every release',

--- a/site/src/app/team/page.tsx
+++ b/site/src/app/team/page.tsx
@@ -40,7 +40,7 @@ export default async function TeamPage() {
                     </h1>
                     <p className="text-lg text-slate-300 max-w-2xl mx-auto">
                         Shared codebase intelligence that learns how your team works —
-                        with governance controls so nothing leaves your control.
+                        with governance controls over what each developer publishes to the shared memory.
                     </p>
                     <p className="text-slate-500 text-sm mt-3">
                         Available in Team and Enterprise tiers •{' '}

--- a/site/src/components/sections/Assessment.tsx
+++ b/site/src/components/sections/Assessment.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 const assessmentIncludes = [
-    'A measured token-reduction ratio on one of your own repos — run locally, nothing leaves your machine',
+    'A measured token-reduction ratio on one of your own repos — run locally, with no network calls of its own',
     'A spend model in your numbers: per-seat subscriptions, usage-based API (OpenRouter, Bedrock, Vertex), and self-hosted GPU',
     'A productivity model: hours lost to context-limit thrashing and re-prompting, valued at your fully-loaded rate',
     'An honest fit verdict — if your workload is generation-heavy or caching already covers you, we say so',

--- a/site/src/components/sections/Benchmarks.tsx
+++ b/site/src/components/sections/Benchmarks.tsx
@@ -6,8 +6,8 @@
 const dataPoints = [
     { metric: 'Gold-file recall', value: '93.75%', detail: '40 pre-registered queries, 4 pinned OSS repos (79–100% per repo)' },
     { metric: 'Tokens vs. pasting files', value: '45–257×', detail: 'same 40 queries; cheaper than ripgrep on every repo' },
-    { metric: 'Synapse recall lift', value: '+6.1 pts', detail: '77.2% → 83.3% top-k hit rate, budget-neutral — CI-gated' },
-    { metric: 'Answer faithfulness', value: '+0.143', detail: 'vs. naive truncation at an equal token budget — CI-gated' },
+    { metric: 'Learned recall', value: 'Never worse', detail: 'CI asserts synapse recall ≥ no-recall on the same warm graph, at a neutral token budget' },
+    { metric: 'vs. naive truncation', value: 'Never worse', detail: 'CI asserts our selection beats truncation at an equal budget. Both magnitudes vary by repo — run them for yours' },
     { metric: 'Field report, one repo', value: '48.8×', detail: '~9,300-node private TypeScript codebase — method reproducible, not CI-gated' },
     { metric: 'Setup time', value: '~15 min', detail: 'one CLI command; post-commit hook keeps it current' },
 ];

--- a/site/src/components/sections/Benchmarks.tsx
+++ b/site/src/components/sections/Benchmarks.tsx
@@ -1,11 +1,15 @@
 'use client';
 
+// Sourced in site/claims.json; gated by tests/test_site_claims.py. Each row
+// says which kind of evidence it is — a CI gate, an on-demand reproduction, or
+// a single-repo field report — because they are not the same strength of claim.
 const dataPoints = [
-    { metric: 'Query Latency', value: '0.81s', detail: 'on 1,486-node repo (TurboVec)' },
-    { metric: 'Token Reduction', value: '63.6×', detail: 'on live production codebase' },
-    { metric: 'Gold-File Recall', value: '100%', detail: 'on public benchmark (requests, click)' },
-    { metric: 'Setup time', value: '~15 min', detail: 'one CLI command' },
-    { metric: 'Ongoing overhead', value: '~0', detail: 'post-commit hook auto-rebuilds' },
+    { metric: 'Gold-file recall', value: '93.75%', detail: '40 pre-registered queries, 4 pinned OSS repos (79–100% per repo)' },
+    { metric: 'Tokens vs. pasting files', value: '45–257×', detail: 'same 40 queries; cheaper than ripgrep on every repo' },
+    { metric: 'Synapse recall lift', value: '+6.1 pts', detail: '77.2% → 83.3% top-k hit rate, budget-neutral — CI-gated' },
+    { metric: 'Answer faithfulness', value: '+0.143', detail: 'vs. naive truncation at an equal token budget — CI-gated' },
+    { metric: 'Field report, one repo', value: '48.8×', detail: '~9,300-node private TypeScript codebase — method reproducible, not CI-gated' },
+    { metric: 'Setup time', value: '~15 min', detail: 'one CLI command; post-commit hook keeps it current' },
 ];
 
 export default function Benchmarks() {
@@ -22,7 +26,9 @@ export default function Benchmarks() {
                         Benchmarks
                     </h2>
                     <p className="text-slate-400 text-base sm:text-lg md:text-xl max-w-xl mx-auto">
-                        Every number is produced by CI on every commit. Run <code className="text-electric font-mono text-sm">neuralmind benchmark .</code> to verify.
+                        Two of these are recomputed by CI on every commit; the rest reproduce from a
+                        fresh clone with one command. Where a number comes from a single repo, it says so.
+                        Run <code className="text-electric font-mono text-sm">neuralmind benchmark .</code> for your own.
                     </p>
                 </div>
 

--- a/site/src/components/sections/BusinessCase.tsx
+++ b/site/src/components/sections/BusinessCase.tsx
@@ -6,10 +6,10 @@ const cards = [
         title: 'The savings are free',
         accent: 'text-proton',
         points: [
-            'The 65.6× token compression ships in the free MIT core — the savings cost nothing, and you can measure them on your own repo in ~15 minutes.',
-            'Modeled at 30 code questions per developer per day, a 50-developer team gets back ~$310/mo on inference alone (at 65.6×).',
+            'Token compression ships in the free MIT core — the savings cost nothing, and you can measure them on your own repo in ~15 minutes.',
+            'Modeled at 30 code questions per developer per day, a 50-developer team gets back ~$310/mo on inference alone. The figure barely moves with the exact ratio — 48.8× and 65.6× differ by under 1% of the saving, because both already remove ~98% of the tokens.',
             'The bigger line is time: ~$1,650/mo per 50-dev team recovered from context-limit thrashing and re-prompting, at a $50/hr fully-loaded rate.',
-            'Sub-second queries (0.81s) mean no more waiting 8+ seconds per question. That compounds across every developer, every day.',
+            'Recall is a local index lookup, not another model call — nothing in the loop between "I need to know X" and "I know X" waits on an API. That compounds across every developer, every day.',
         ],
     },
     {
@@ -17,10 +17,10 @@ const cards = [
         title: 'Fewer wrong answers, faster teams',
         accent: 'text-electric',
         points: [
-            '100% gold-file recall on the public benchmark (requests, click).',
+            '93.75% gold-file recall across 40 pre-registered queries on four public repos — 79–100% per repo, with every miss published rather than dropped.',
             'Team dashboard shows synapse memory health, ingestion status, savings, latency trends — all read-only, all local.',
             'Self-documenting code: DocEvolver finds undocumented methods and evolves JSDoc that actually improves retrieval.',
-            '100% local with zero code egress — verifiable on the wire. Works with the agents you already run: Claude Code, Cursor, Cline, any MCP agent. No rip-and-replace.',
+            'The engine makes no network calls of its own and sends no telemetry — verifiable on the wire. Works with the agents you already run: Claude Code, Cursor, Cline, any MCP agent. No rip-and-replace.',
         ],
     },
 ];

--- a/site/src/components/sections/Features.tsx
+++ b/site/src/components/sections/Features.tsx
@@ -3,8 +3,8 @@
 const featureList = [
     {
         icon: '⚡',
-        title: 'Sub-Second Retrieval',
-        desc: 'TurboVec backend: 0.81s per query on a 1,486-node repo. ChromaDB-free, 8× smaller index vectors (4-bit quantized).',
+        title: 'Local Retrieval, No Model Call',
+        desc: 'Recall is a local index lookup, not another round trip to a model. The ChromaDB-free TurboVec backend keeps 4-bit quantized vectors 8–16× smaller with fact recall 0.800 vs 0.744 for float32 — parity gated in CI.',
         badge: 'TurboVec',
     },
     {
@@ -16,8 +16,8 @@ const featureList = [
     {
         icon: '🔄',
         title: 'Progressive L0–L3 Disclosure',
-        desc: 'Retrieves exact bytes needed. Never pastes the whole repo. 65.6× compression measured on a 241-node production codebase.',
-        badge: '63.6×',
+        desc: 'Retrieves the exact bytes needed. Never pastes the whole repo. 45–257× fewer tokens than full-file context across 40 pre-registered queries on four public repos.',
+        badge: '45–257×',
     },
     {
         icon: '📊',

--- a/site/src/components/sections/Hero.tsx
+++ b/site/src/components/sections/Hero.tsx
@@ -8,7 +8,7 @@ const tags = ['Claude Code', 'Codex', 'Cursor', 'Cline', 'Continue', 'MCP'];
 const heroStats = [
     { label: 'Gold-file recall', value: '93.75%', highlight: true },
     { label: 'vs. pasting files', value: '45–257×', highlight: false },
-    { label: 'Synapse recall lift', value: '+6.1 pts', highlight: false },
+    { label: 'Pre-registered queries', value: '40', highlight: false },
     { label: 'Free Tier', value: 'Auto-provisioned', highlight: false },
 ];
 

--- a/site/src/components/sections/Hero.tsx
+++ b/site/src/components/sections/Hero.tsx
@@ -3,10 +3,12 @@
 import { useState, useEffect } from 'react';
 
 const tags = ['Claude Code', 'Codex', 'Cursor', 'Cline', 'Continue', 'MCP'];
+// Every figure here is registered in site/claims.json with its source and
+// reproduction command, and gated by tests/test_site_claims.py.
 const heroStats = [
-    { label: 'Query Latency', value: '<1s', highlight: true },
-    { label: 'Token Reduction', value: '65.6×', highlight: false },
-    { label: 'Gold-File Recall', value: '100%', highlight: false },
+    { label: 'Gold-file recall', value: '93.75%', highlight: true },
+    { label: 'vs. pasting files', value: '45–257×', highlight: false },
+    { label: 'Synapse recall lift', value: '+6.1 pts', highlight: false },
     { label: 'Free Tier', value: 'Auto-provisioned', highlight: false },
 ];
 
@@ -43,9 +45,10 @@ export default function Hero() {
                     <span className="gradient-text">Now it remembers your codebase.</span>
                 </h1>
                 <p className="text-base sm:text-lg md:text-xl text-slate-400 max-w-2xl mx-auto mb-8 leading-relaxed">
-                    Persistent neural memory for AI agents. Local-first synapse layer.{' '}
-                    <span className="text-white font-semibold">Works with every IDE your team already uses.</span>{' '}
-                    100% local, no telemetry.
+                    Persistent neural memory for AI agents. Your agent opens the right file
+                    first — <span className="text-white font-semibold">93.75% gold-file recall across 40
+                    pre-registered queries on four public repos</span>, at 45–257× fewer tokens than
+                    pasting those files in. Local-first, no telemetry.
                 </p>
 
                 {/* CTA buttons */}

--- a/site/src/components/sections/ProveIt.tsx
+++ b/site/src/components/sections/ProveIt.tsx
@@ -8,7 +8,7 @@ const steps = [
     {
         step: '2',
         title: 'Then measure YOUR codebase',
-        body: 'The fixture is tiny (~500 lines, ~5.5×). Real repos consistently hit 12–50× on the same pipeline — run the benchmark on your own code and read your own number. We measured 65.6× on a 1,486-node production codebase (Level2Logic).',
+        body: 'The fixture is tiny (~500 lines, ~5.5×). Real repos consistently hit 12–50× on the same pipeline — run the benchmark on your own code and read your own number. A maintainer field report on a ~9,300-node private TypeScript codebase measured 48.8×.',
         code: ['pip install neuralmind', 'cd /path/to/your-repo', 'neuralmind build .', 'neuralmind benchmark .'],
     },
     {

--- a/tests/benchmark/latency.py
+++ b/tests/benchmark/latency.py
@@ -1,0 +1,168 @@
+"""Recall-latency benchmark for the synapse layer.
+
+The marketing surface wanted to say "instant codebase recall" and reached for
+a query-latency figure (``0.81s``) that no code in this repo produces. This
+module is the fix: it measures the thing the claim is actually about — how
+long the associative layer takes to answer "what else matters here?" — so the
+number can be quoted with a reproduction command behind it.
+
+What it measures, on a synthetic store built to a fixed shape:
+
+- ``neighbors`` — the one-hop lookup behind ``synaptic_neighbors``, the call an
+  agent makes on every prompt to recover what it was working on.
+- ``spread`` — multi-hop spreading activation, the expensive path.
+- ``reinforce`` — the write side, which runs on every co-activation and must
+  stay off the critical path.
+
+It is deliberately **not** an end-to-end query benchmark: a full
+``NeuralMind.query`` includes embedding and vector search, whose cost depends
+on the backend and the machine. Those belong in a separate benchmark with
+their own baseline. This one isolates the synapse layer, which is stdlib-only
+and therefore reproducible anywhere, on any machine, with no dependencies.
+
+Run it::
+
+    python -m tests.benchmark.latency            # human-readable
+    python -m tests.benchmark.latency --json     # machine-readable
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+import statistics
+import tempfile
+import time
+from pathlib import Path
+from typing import Any
+
+from neuralmind.synapses import SynapseStore
+
+# Store shape. Roughly a mid-size repo's worth of symbols with a realistic
+# co-editing history: enough edges that an index actually matters, small
+# enough that the benchmark finishes in a couple of seconds in CI.
+NODE_COUNT = 4_000
+SYMBOLS_PER_FILE = 20
+CO_ACTIVATIONS = 3_000
+FILES_PER_CO_ACTIVATION = 4
+SAMPLES = 200
+SEED = 7
+
+
+def _percentile(values: list[float], fraction: float) -> float:
+    """Nearest-rank percentile — no interpolation, no numpy."""
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    index = min(len(ordered) - 1, int(fraction * len(ordered)))
+    return ordered[index]
+
+
+def _summarize(name: str, timings_ms: list[float]) -> dict[str, Any]:
+    return {
+        "operation": name,
+        "samples": len(timings_ms),
+        "p50_ms": round(statistics.median(timings_ms), 3),
+        "p95_ms": round(_percentile(timings_ms, 0.95), 3),
+        "max_ms": round(max(timings_ms), 3),
+    }
+
+
+def _seed_store(
+    store: SynapseStore,
+    nodes: list[str],
+    rng: random.Random,
+    co_activations: int,
+) -> list[float]:
+    """Reinforce a synthetic co-editing history; return per-write timings."""
+    timings: list[float] = []
+    for _ in range(co_activations):
+        group = rng.sample(nodes, FILES_PER_CO_ACTIVATION)
+        start = time.perf_counter()
+        store.reinforce(group)
+        timings.append((time.perf_counter() - start) * 1000.0)
+    return timings
+
+
+def run(
+    db_path: Path | None = None,
+    *,
+    node_count: int = NODE_COUNT,
+    co_activations: int = CO_ACTIVATIONS,
+    samples: int = SAMPLES,
+) -> dict[str, Any]:
+    """Measure synapse recall latency. Returns a JSON-shaped report.
+
+    The scale parameters exist so the CI gate can run a smaller store than the
+    published benchmark — the regression it is looking for (an index dropped,
+    a query turned into a scan) shows up at any size, and a two-second test is
+    one people keep.
+    """
+    rng = random.Random(SEED)
+    nodes = [f"module_{i // SYMBOLS_PER_FILE}.py::symbol_{i}" for i in range(node_count)]
+
+    tmp: tempfile.TemporaryDirectory | None = None
+    if db_path is None:
+        tmp = tempfile.TemporaryDirectory()
+        db_path = Path(tmp.name) / "synapses.db"
+
+    try:
+        store = SynapseStore(db_path)
+        write_ms = _seed_store(store, nodes, rng, co_activations)
+
+        neighbor_ms: list[float] = []
+        spread_ms: list[float] = []
+        edges_seen = 0
+        for _ in range(samples):
+            node = nodes[rng.randrange(len(nodes))]
+
+            start = time.perf_counter()
+            hits = store.neighbors(node)
+            neighbor_ms.append((time.perf_counter() - start) * 1000.0)
+            edges_seen += len(hits)
+
+            start = time.perf_counter()
+            store.spread([node])
+            spread_ms.append((time.perf_counter() - start) * 1000.0)
+
+        return {
+            "store": {
+                "nodes": node_count,
+                "co_activations": co_activations,
+                "mean_neighbors_per_node": round(edges_seen / samples, 2),
+            },
+            "operations": [
+                _summarize("neighbors", neighbor_ms),
+                _summarize("spread", spread_ms),
+                _summarize("reinforce", write_ms),
+            ],
+        }
+    finally:
+        if tmp is not None:
+            tmp.cleanup()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json", action="store_true", help="emit the raw report")
+    args = parser.parse_args()
+
+    report = run()
+    if args.json:
+        print(json.dumps(report, indent=2))
+        return
+
+    store = report["store"]
+    print(
+        f"Synapse recall latency — {store['nodes']:,} nodes, "
+        f"{store['co_activations']:,} co-activations, "
+        f"{store['mean_neighbors_per_node']} neighbors/node\n"
+    )
+    print(f"{'operation':<12}{'p50 (ms)':>12}{'p95 (ms)':>12}{'max (ms)':>12}")
+    for op in report["operations"]:
+        print(f"{op['operation']:<12}{op['p50_ms']:>12.2f}{op['p95_ms']:>12.2f}{op['max_ms']:>12.2f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/benchmark/latency.py
+++ b/tests/benchmark/latency.py
@@ -161,7 +161,9 @@ def main() -> None:
     )
     print(f"{'operation':<12}{'p50 (ms)':>12}{'p95 (ms)':>12}{'max (ms)':>12}")
     for op in report["operations"]:
-        print(f"{op['operation']:<12}{op['p50_ms']:>12.2f}{op['p95_ms']:>12.2f}{op['max_ms']:>12.2f}")
+        print(
+            f"{op['operation']:<12}{op['p50_ms']:>12.2f}{op['p95_ms']:>12.2f}{op['max_ms']:>12.2f}"
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_docs_claims.py
+++ b/tests/test_docs_claims.py
@@ -111,6 +111,91 @@ FORBIDDEN = [
 ]
 
 
+# Point estimates that must never come back as bare claims.
+#
+# The synapse-recall and faithfulness A/Bs run against a ~500-line fixture
+# behind a ChromaDB HNSW index, so their deltas jitter between runs — CI
+# averages the onboarding lift over three runs for exactly that reason, and
+# gates both A/Bs on *direction* (on >= off, delta >= 0), never on a magnitude.
+# Published as fixed figures, they go stale within days: the synapse lift was
+# written as +12 pts (2026-08-06), +6.1 pts (2026-08-11, in a commit whose own
+# message reported +14 from its fresh run), and measured +3.5 pts in CI on
+# 2026-08-18. The onboarding lift simultaneously read +11.6, +6.5, and +0.9 pts
+# on three different surfaces, two of them in the same README.
+#
+# So these patterns match the *bare point-estimate* form only. Quoting the
+# observed band ("+0.013 to +0.143 across runs") is the correct phrasing and
+# deliberately still passes.
+SUPERSEDED_FIGURES = [
+    (
+        re.compile(r"\+?6\.1\s*(pts|points|pt)\b", re.IGNORECASE),
+        (
+            "The synapse-recall lift is run-dependent (+3.5 to +14 pts observed). "
+            "Quote the CI gate — recall-on >= recall-off — and the observed band."
+        ),
+    ),
+    (
+        re.compile(r"77\.2\s*%\s*(→|->|to)\s*83\.3\s*%"),
+        (
+            "These hit-rate levels are one run's output, not a stable result. "
+            "Quote the gate and the band instead."
+        ),
+    ),
+    (
+        re.compile(r"faithfulness\s*\+0\.143", re.IGNORECASE),
+        (
+            "The faithfulness delta is run-dependent (+0.013 to +0.143 observed) "
+            "and CI gates it at >= 0, not at a magnitude."
+        ),
+    ),
+    (
+        re.compile(r"\+?11\.6\s*(pts|points)\b|\+?6\.5\s*points\b", re.IGNORECASE),
+        (
+            "The onboarding lift is run-dependent (+0.9 to +11.6 pts observed) and "
+            "was simultaneously published as three different values."
+        ),
+    ),
+]
+
+# The public benchmark's mean is 93.75% and its per-repo floor is 0.79. A bare
+# "100% gold-file recall" shipped in the README for weeks while the same file's
+# later section correctly reported the range.
+PERFECT_RECALL_RE = re.compile(
+    r"100\s*%[^.\n]{0,40}?gold-file\s+recall|gold-file\s+recall[^.\n]{0,40}?100\s*%",
+    re.IGNORECASE,
+)
+
+# A figure quoted as one end of a band ("+0.9 to +11.6 pts", "79-100%") is the
+# correct phrasing, not the defect. Blank those spans before matching so the
+# guards catch bare point estimates only.
+_RANGE_RES = (
+    re.compile(
+        r"\+?\d+(?:\.\d+)?\s*(?:to|–|—|-|&ndash;|&mdash;)\s*\+?\d+(?:\.\d+)?\s*(?:pts|points|%)?",
+        re.IGNORECASE,
+    ),
+)
+
+
+# "100% gold-file recall" is accurate for the disclosed, off-by-default
+# competitor eval, which runs on `requests`/`click` only. The defect is
+# attaching it to the 4-repo public benchmark, whose mean is 93.75%. Lines that
+# name the competitor comparison within a short window are making the narrower,
+# true claim.
+COMPETITOR_SCOPE_RE = re.compile(r"codebase-memory-mcp|competitor", re.IGNORECASE)
+_SCOPE_WINDOW = 3
+
+
+def _scoped_to_competitor_eval(lines: list[str], index: int) -> bool:
+    window = lines[max(0, index - _SCOPE_WINDOW) : index + _SCOPE_WINDOW + 1]
+    return any(COMPETITOR_SCOPE_RE.search(line) for line in window)
+
+
+def _without_ranges(line: str) -> str:
+    for pattern in _RANGE_RES:
+        line = pattern.sub(" ", line)
+    return line
+
+
 def _published_paths() -> list[Path]:
     paths: list[Path] = []
     for rel in PUBLISHED_FILES:
@@ -143,3 +228,75 @@ def test_guard_actually_matches_a_known_bad_phrase() -> None:
     # refactor can't neuter it into a silent no-op.
     bad = "100% local — your code never leaves your machine."
     assert any(p.search(bad) for p, _ in FORBIDDEN)
+
+
+def test_published_surfaces_do_not_quote_superseded_point_estimates() -> None:
+    violations: list[str] = []
+    for path in _published_paths():
+        text = path.read_text(encoding="utf-8", errors="replace")
+        for lineno, raw in enumerate(text.splitlines(), start=1):
+            line = _without_ranges(raw)
+            for pattern, reason in SUPERSEDED_FIGURES:
+                m = pattern.search(line)
+                if m:
+                    rel = path.relative_to(REPO_ROOT)
+                    violations.append(f"{rel}:{lineno}: {m.group(0)!r} — {reason}")
+    assert not violations, (
+        "A run-dependent A/B magnitude is published as a fixed figure. CI gates "
+        "these on direction, not size — quote the gate and the observed band:\n  "
+        + "\n  ".join(violations)
+    )
+
+
+def test_published_surfaces_do_not_claim_perfect_gold_file_recall() -> None:
+    violations: list[str] = []
+    for path in _published_paths():
+        text = path.read_text(encoding="utf-8", errors="replace")
+        lines = text.splitlines()
+        for index, raw in enumerate(lines):
+            if not PERFECT_RECALL_RE.search(_without_ranges(raw)):
+                continue
+            if _scoped_to_competitor_eval(lines, index):
+                continue
+            rel = path.relative_to(REPO_ROOT)
+            violations.append(f"{rel}:{index + 1}: {raw.strip()[:110]}")
+    assert not violations, (
+        "A published surface claims 100% gold-file recall. The public benchmark "
+        "reports 93.75% mean across 40 queries (0.96 / 0.79 / 0.95 / 1.00) and "
+        "publishes every miss:\n  " + "\n  ".join(violations)
+    )
+
+
+def test_superseded_figure_guards_trip_on_the_copy_that_shipped() -> None:
+    # Each pattern must fire on the exact text that was live, and must NOT fire
+    # on the band phrasing that replaced it — otherwise the guard either rots
+    # into a no-op or blocks the correct wording.
+    bad = [
+        "hit-rate **+6.1 points (77.2%→83.3%), budget-neutral**",
+        "faithfulness +0.143, grounding 1.00",
+        "| **Onboarding lift** | — | — | **+11.6 pts** |",
+        "- **Onboarding lift:** +6.5 points top-k module hit-rate",
+    ]
+    for line in bad:
+        assert any(p.search(line) for p, _ in SUPERSEDED_FIGURES), line
+
+    good = [
+        "recall-on >= recall-off, at a neutral token budget | **+3.5 to +14 pts**",
+        "delta **>= 0** | **+0.013 to +0.143**",
+        "lift **>= 0**, averaged over 3 runs | **+0.9 to +11.6 pts** across runs",
+    ]
+    for line in good:
+        stripped = _without_ranges(line)
+        assert not any(p.search(stripped) for p, _ in SUPERSEDED_FIGURES), line
+
+    assert PERFECT_RECALL_RE.search("**100% gold-file recall, MRR 0.96** on the public benchmark")
+    assert not PERFECT_RECALL_RE.search(
+        _without_ranges("**79-100% gold-file recall (93.75% mean)**")
+    )
+    assert not PERFECT_RECALL_RE.search(_without_ranges("79–100% gold-file recall"))
+    assert not PERFECT_RECALL_RE.search(_without_ranges("79&ndash;100% gold-file recall"))
+    # The narrower competitor-eval claim is true and stays allowed; the same
+    # sentence without that scope is the defect.
+    scoped = ["100% gold-file recall, MRR 0.96", "beats codebase-memory-mcp 0.96 vs 0.23"]
+    assert _scoped_to_competitor_eval(scoped, 0)
+    assert not _scoped_to_competitor_eval(["100% gold-file recall on the public benchmark"], 0)

--- a/tests/test_docs_claims.py
+++ b/tests/test_docs_claims.py
@@ -91,7 +91,9 @@ FORBIDDEN = [
         ),
     ),
     (
-        re.compile(r"\b(zero|no)\s+(data\s+)?egress\b", re.IGNORECASE),
+        # Any qualifier — "zero data egress", "zero code egress", "no egress" —
+        # makes the same inaccurate absolute about the whole agent workflow.
+        re.compile(r"\b(zero|no)\s+(\w+\s+)?egress\b", re.IGNORECASE),
         "Absolute egress claim. NeuralMind minimizes egress, doesn't eliminate it.",
     ),
     (

--- a/tests/test_site_claims.py
+++ b/tests/test_site_claims.py
@@ -71,7 +71,9 @@ SINGLE_RE = re.compile(r"(\d+(?:\.\d+)?)\s*×")
 
 # "100% recall" in any word order within a short window. The public
 # benchmark's mean is 93.75% and its per-repo floor is 0.79.
-PERFECT_RECALL_RE = re.compile(r"100\s*%[^.<>{}]{0,40}?recall|recall[^.<>{}]{0,40}?100\s*%", re.IGNORECASE)
+PERFECT_RECALL_RE = re.compile(
+    r"100\s*%[^.<>{}]{0,40}?recall|recall[^.<>{}]{0,40}?100\s*%", re.IGNORECASE
+)
 
 
 def _claims() -> dict:

--- a/tests/test_site_claims.py
+++ b/tests/test_site_claims.py
@@ -1,0 +1,200 @@
+"""Guard the marketing site's numeric claims against drift.
+
+``tests/test_docs_claims.py`` scans the README, the docs site, and the
+security guides — but **not** ``site/``, which is the surface most people
+actually read. That gap let four different classes of drift ship at once:
+
+- the same token-reduction figure attributed to three different repo sizes
+  (241 nodes in one component, "1,486-node" in two others, neither of which
+  is where the number came from),
+- a transcription error of that figure (``63.6×`` for ``65.6×``) sitting one
+  card away from the original,
+- a query-latency number with no measurement behind it anywhere in the repo,
+- a ``100%`` gold-file recall claim the current public benchmark contradicts
+  (93.75% mean; ``click`` is 0.79), and the real name of a private client
+  whose field report every doc deliberately anonymizes.
+
+So this module enforces three rules:
+
+1. **Ratio provenance** — every ``N×`` performance ratio on the high-traffic
+   surfaces must be listed in ``site/claims.json`` with a source and a
+   reproduction command. Small multipliers (< 2×) are exempt: those are decay
+   coefficients and worked examples in the publications, not claims.
+2. **No private names** — names on the manifest's ``private_names_never_publish``
+   list must not appear anywhere under ``site/``.
+3. **No absolute privacy claims** — the same ``FORBIDDEN`` patterns the docs
+   guard uses, applied to the site too.
+
+Stdlib-only, like the docs guard, so it runs without the full dep set.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+from tests.test_docs_claims import FORBIDDEN
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SITE_ROOT = REPO_ROOT / "site" / "src"
+CLAIMS_FILE = REPO_ROOT / "site" / "claims.json"
+
+# Surfaces where a bare ratio reads as a headline product claim. The
+# publications and field-report pages carry their own inline provenance
+# (and worked arithmetic), so they are checked for names and absolutes but
+# not for ratio provenance.
+RATIO_GATED = (
+    "components/sections/*.tsx",
+    "app/page.tsx",
+    "app/layout.tsx",
+)
+
+# Ratios below this are never performance claims — they're decay weights,
+# merge coefficients, and other worked math in the publications.
+MIN_CLAIM_RATIO = 2.0
+
+# className="..." holds Tailwind tokens, not prose. Strip it before scanning
+# so `w-[100%]` and friends can't masquerade as claims.
+CLASSNAME_RE = re.compile(r"className=(?:\"[^\"]*\"|'[^']*'|\{[^}]*\})", re.DOTALL)
+
+# A page may legitimately *quote* a forbidden phrase in order to disown it —
+# the effectiveness page lists "Zero code egress" under what NeuralMind does
+# not claim. Mark those lines (or the line above) so the guard stays useful
+# instead of being switched off wholesale.
+ALLOW_MARKER = "claims-guard:allow"
+
+# Any number immediately preceding a multiplication sign, including both
+# endpoints of a range ("45–257×" yields 45 and 257).
+RANGE_RE = re.compile(r"(\d+(?:\.\d+)?)\s*[–—-]\s*(\d+(?:\.\d+)?)\s*×")
+SINGLE_RE = re.compile(r"(\d+(?:\.\d+)?)\s*×")
+
+# "100% recall" in any word order within a short window. The public
+# benchmark's mean is 93.75% and its per-repo floor is 0.79.
+PERFECT_RECALL_RE = re.compile(r"100\s*%[^.<>{}]{0,40}?recall|recall[^.<>{}]{0,40}?100\s*%", re.IGNORECASE)
+
+
+def _claims() -> dict:
+    return json.loads(CLAIMS_FILE.read_text(encoding="utf-8"))
+
+
+def _allowed_ratios() -> set[float]:
+    return {float(entry["value"]) for entry in _claims()["ratios"]}
+
+
+def _site_files(patterns: tuple[str, ...] | None = None) -> list[Path]:
+    if patterns is None:
+        return sorted(SITE_ROOT.rglob("*.tsx")) + sorted(SITE_ROOT.rglob("*.ts"))
+    files: list[Path] = []
+    for pattern in patterns:
+        files.extend(sorted(SITE_ROOT.glob(pattern)))
+    return files
+
+
+def _prose(path: Path) -> str:
+    """File text with className attributes blanked, line numbering preserved."""
+    text = path.read_text(encoding="utf-8", errors="replace")
+    return CLASSNAME_RE.sub(lambda m: "\n" * m.group(0).count("\n"), text)
+
+
+def _exempt(lines: list[str], index: int) -> bool:
+    """True if this line, or the one above it, carries the opt-out marker."""
+    window = lines[max(0, index - 1) : index + 1]
+    return any(ALLOW_MARKER in line for line in window)
+
+
+def _ratios_in(text: str) -> list[tuple[int, float]]:
+    """Return (lineno, ratio) for every ratio claim in *text*."""
+    found: list[tuple[int, float]] = []
+    for lineno, line in enumerate(text.splitlines(), start=1):
+        consumed = line
+        for m in RANGE_RE.finditer(line):
+            found.append((lineno, float(m.group(1))))
+            found.append((lineno, float(m.group(2))))
+            consumed = consumed.replace(m.group(0), " ")
+        for m in SINGLE_RE.finditer(consumed):
+            found.append((lineno, float(m.group(1))))
+    return found
+
+
+def test_every_site_ratio_has_provenance() -> None:
+    allowed = _allowed_ratios()
+    violations: list[str] = []
+    for path in _site_files(RATIO_GATED):
+        for lineno, ratio in _ratios_in(_prose(path)):
+            if ratio < MIN_CLAIM_RATIO or ratio in allowed:
+                continue
+            rel = path.relative_to(REPO_ROOT)
+            violations.append(f"{rel}:{lineno}: {ratio:g}× is not in site/claims.json")
+    assert not violations, (
+        "Unsourced performance ratio(s) on the marketing site. Every ratio the "
+        "site quotes needs an entry in site/claims.json naming where it was "
+        "measured and how to reproduce it — add the measurement first, then the "
+        "claim:\n  " + "\n  ".join(violations)
+    )
+
+
+def test_site_does_not_name_private_projects() -> None:
+    names = _claims()["private_names_never_publish"]
+    violations: list[str] = []
+    for path in _site_files():
+        text = path.read_text(encoding="utf-8", errors="replace")
+        for lineno, line in enumerate(text.splitlines(), start=1):
+            for name in names:
+                if name.lower() in line.lower():
+                    rel = path.relative_to(REPO_ROOT)
+                    violations.append(f"{rel}:{lineno}: names private project {name!r}")
+    assert not violations, (
+        "The marketing site names a private project. Field reports are "
+        "anonymized in docs/ and in docs/community-benchmarks.json; the public "
+        "site must match:\n  " + "\n  ".join(violations)
+    )
+
+
+def test_site_does_not_claim_perfect_gold_file_recall() -> None:
+    violations: list[str] = []
+    for path in _site_files():
+        lines = _prose(path).splitlines()
+        for index, line in enumerate(lines):
+            lineno = index + 1
+            if PERFECT_RECALL_RE.search(line) and not _exempt(lines, index):
+                rel = path.relative_to(REPO_ROOT)
+                violations.append(f"{rel}:{lineno}: {line.strip()[:110]}")
+    assert not violations, (
+        "The site claims 100% gold-file recall. The public benchmark reports "
+        "93.75% mean across 40 queries (0.96 requests / 0.79 click / 0.95 flask "
+        "/ 1.00 rich) and publishes every miss — quote the mean and the range:\n  "
+        + "\n  ".join(violations)
+    )
+
+
+def test_site_has_no_forbidden_absolute_claims() -> None:
+    violations: list[str] = []
+    for path in _site_files():
+        lines = _prose(path).splitlines()
+        for index, line in enumerate(lines):
+            lineno = index + 1
+            for pattern, reason in FORBIDDEN:
+                m = pattern.search(line)
+                if m and not _exempt(lines, index):
+                    rel = path.relative_to(REPO_ROOT)
+                    violations.append(f"{rel}:{lineno}: {m.group(0)!r} — {reason}")
+    assert not violations, (
+        "Forbidden absolute claim(s) on the marketing site (NeuralMind "
+        "minimizes egress, it does not eliminate it):\n  " + "\n  ".join(violations)
+    )
+
+
+def test_guards_actually_trip_on_known_bad_copy() -> None:
+    # Sanity: each rule must fire on the copy that shipped, so a future
+    # refactor can't quietly neuter it.
+    assert _ratios_in("value: '63.6×',") == [(1, 63.6)]
+    assert 63.6 not in _allowed_ratios()
+    assert _ratios_in("'45–257× fewer tokens'") == [(1, 45.0), (1, 257.0)]
+    assert PERFECT_RECALL_RE.search("{ metric: 'Gold-File Recall', value: '100%' }")
+    assert PERFECT_RECALL_RE.search("100% gold-file recall on the public benchmark")
+    assert any(p.search("100% local with zero code egress") for p, _ in FORBIDDEN)
+    # ...and the opt-out must only cover the line it annotates and the next one.
+    marked = [f"// {ALLOW_MARKER}", "title: 'Zero code egress',", "unmarked line"]
+    assert _exempt(marked, 1)
+    assert not _exempt(marked, 2)

--- a/tests/test_synapse_latency.py
+++ b/tests/test_synapse_latency.py
@@ -1,0 +1,67 @@
+"""Regression gate for synapse recall latency.
+
+The claim this protects is "instant codebase recall" — the promise that
+recovering context after a switch costs a lookup, not a round trip. That claim
+needs a number behind it, and a number nobody rechecks is a number that rots,
+so the benchmark that produces it runs here on every PR.
+
+The ceilings are deliberately loose. They are not a performance target; they
+are a tripwire for the failure that actually happens — an index dropped, a
+lookup quietly turned into a table scan — which costs orders of magnitude, not
+percent. A tight bound on a shared CI runner would only teach people to ignore
+a flaky test.
+
+Stdlib-only, like the rest of the synapse layer's tests.
+"""
+
+from __future__ import annotations
+
+from tests.benchmark.latency import run
+
+# Small store: the regressions this catches are algorithmic, and they show at
+# any size. Keeps the gate at a couple of seconds.
+NODES = 600
+CO_ACTIVATIONS = 400
+SAMPLES = 40
+
+# Order-of-magnitude tripwires, not targets. Reference run on a 4,000-node
+# store (python -m tests.benchmark.latency): neighbors p95 ~6 ms, spread
+# p95 ~61 ms — so these sit roughly 20× above observed.
+CEILINGS_MS = {
+    "neighbors": 150.0,
+    "spread": 750.0,
+    "reinforce": 150.0,
+}
+
+
+def _report() -> dict:
+    return run(node_count=NODES, co_activations=CO_ACTIVATIONS, samples=SAMPLES)
+
+
+def test_synapse_recall_stays_within_latency_tripwires() -> None:
+    report = _report()
+    breaches = [
+        f"{op['operation']}: p95 {op['p95_ms']:.1f} ms exceeds {CEILINGS_MS[op['operation']]:.0f} ms"
+        for op in report["operations"]
+        if op["p95_ms"] > CEILINGS_MS[op["operation"]]
+    ]
+    assert not breaches, (
+        "Synapse recall latency regressed by an order of magnitude — check for a "
+        "dropped index or a lookup that became a scan:\n  " + "\n  ".join(breaches)
+    )
+
+
+def test_benchmark_reports_every_operation_it_claims_to_measure() -> None:
+    # The gate is only as good as its coverage: if an operation silently drops
+    # out of the report, the loop above trivially passes on what's left.
+    report = _report()
+    measured = {op["operation"] for op in report["operations"]}
+    assert measured == set(CEILINGS_MS)
+    assert all(op["samples"] > 0 for op in report["operations"])
+
+
+def test_store_actually_has_edges_to_traverse() -> None:
+    # A store with no edges would make every lookup trivially fast and the
+    # latency gate meaningless.
+    report = _report()
+    assert report["store"]["mean_neighbors_per_node"] > 0

--- a/tests/test_synapse_latency.py
+++ b/tests/test_synapse_latency.py
@@ -26,11 +26,20 @@ SAMPLES = 40
 
 # Order-of-magnitude tripwires, not targets. Reference run on a 4,000-node
 # store (python -m tests.benchmark.latency): neighbors p95 ~6 ms, spread
-# p95 ~61 ms — so these sit roughly 20× above observed.
+# p95 ~61 ms, reinforce p95 ~3 ms.
+#
+# The read and write paths need very different headroom, and calibrating both
+# off the same local timings was wrong: `reinforce` commits durably, so its
+# p95 is dominated by the host's fsync cost, not by anything this repo
+# controls. A Windows CI runner measured 167 ms for the write path while the
+# reads stayed fast — a 50× spread on storage alone. Reads never fsync, so
+# they keep a tight-ish bound; the write path gets a ceiling that only an
+# algorithmic blowup (a scan per write, an unbounded rewrite) can reach.
+# The real numbers come from the benchmark, not from these bounds.
 CEILINGS_MS = {
     "neighbors": 150.0,
     "spread": 750.0,
-    "reinforce": 150.0,
+    "reinforce": 2_000.0,
 }
 
 
@@ -48,6 +57,32 @@ def test_synapse_recall_stays_within_latency_tripwires() -> None:
     assert not breaches, (
         "Synapse recall latency regressed by an order of magnitude — check for a "
         "dropped index or a lookup that became a scan:\n  " + "\n  ".join(breaches)
+    )
+
+
+def test_write_cost_does_not_scale_with_store_size() -> None:
+    """The write path's real invariant, stated in a host-independent way.
+
+    An absolute millisecond bound on `reinforce` mostly measures the host's
+    fsync cost — which is why a Windows runner can be 50× a local disk without
+    anything having regressed. What must hold on *any* host is that the cost of
+    one co-activation doesn't grow with the size of the store: reinforcement is
+    an indexed upsert of a handful of edges, not a pass over the graph. Compare
+    the two on the same machine and the storage cost cancels out.
+    """
+    small = _report()
+    large = run(node_count=NODES * 4, co_activations=CO_ACTIVATIONS * 4, samples=SAMPLES)
+
+    def write_p50(report: dict) -> float:
+        return next(op["p50_ms"] for op in report["operations"] if op["operation"] == "reinforce")
+
+    small_ms, large_ms = write_p50(small), write_p50(large)
+    # Observed ratio is ~1.1 for a 4× store. Allow 4× to absorb a noisy runner
+    # while still catching a write that started scanning what it should index.
+    assert large_ms <= max(small_ms * 4.0, 1.0), (
+        f"Reinforce cost grew with store size: {small_ms:.2f} ms at {NODES} nodes → "
+        f"{large_ms:.2f} ms at {NODES * 4}. A co-activation write should be an indexed "
+        "upsert of a few edges, independent of how much the store already holds."
     )
 
 


### PR DESCRIPTION
## Description

Validating a proposed marketing metrics set against the repo turned up that the **live site had already drifted** from the evidence base, on the highest-traffic surface, with nothing in CI watching it.

What shipped on `neuralmind.uk`:

| Claim on the site | What the repo actually says |
|---|---|
| `65.6×` on a **1,486-node** production codebase (`layout.tsx`, `ProveIt`) | 65.6× is a **241-node** community submission. No dataset has a 1,486-node repo; the 1,626-node one measured 46.0×. |
| `63.6×` (`Benchmarks` card + `Features` badge) | Transcription error of 65.6×, one card away from the original. |
| `0.81s` query latency (×4, incl. JSON-LD `featureList`) | **Nothing in this repo produces this number.** |
| `100%` gold-file recall "on the public benchmark (requests, click)" | 93.75% mean / 79–100% per repo. requests 0.96, click 0.79 — and `docs/benchmarks/public.md` publishes every miss. |
| Named the private client behind the field report | `docs/` and `docs/community-benchmarks.json` anonymize it deliberately. |
| "Every number is produced by CI on every commit" | The public benchmark is `workflow_dispatch` only; the field report is explicitly *not* CI-gated. |

`tests/test_docs_claims.py` exists to stop precisely this, but its scan list never included `site/`. So six absolute privacy claims were live there too — "nothing leaves your machine" (×3), "fully air-gapped", "zero code egress" — plus two in `README.md` that a narrow `(zero|no)\s+(data\s+)?egress` pattern missed.

Fixes the copy, then closes the gap so it can't reopen.

**`site/claims.json`** — canon for site numbers, same contract as `commercial-terms.json` (change the JSON first, then the copy). Every ratio carries its source, its reproduction command, and what *kind* of evidence it is: `ci-gated` / `reproducible` / `field-report` / `community`. It also records the four unsourced figures under `unsourced_do_not_use` with why, so nobody reintroduces them from a cached page.

**`tests/test_site_claims.py`** — stdlib-only gate: ratio provenance on the headline surfaces, no private project names anywhere under `site/`, no perfect-recall claim, and the docs guard's absolutes now applied to the site. A page that quotes a forbidden phrase *in order to disown it* (the effectiveness page's overclaim list) marks the line `claims-guard:allow`, so the guard stays on rather than being switched off wholesale.

**`tests/benchmark/latency.py` + `tests/test_synapse_latency.py`** — the speed claim now has a measurement instead of an invented one. p50/p95/max for synapse `neighbors`, `spread`, and `reinforce`, with order-of-magnitude tripwires in CI (tuned to catch a dropped index, not to police percent-level noise on a shared runner). Reference run at 4,000 nodes / 3,000 co-activations: **neighbors p95 ~6 ms, spread p95 ~61 ms**.

**Repositioned copy.** Recall leads and token reduction supports it; speed is stated as a mechanism ("a local index lookup, not another model call") rather than a number nothing measures. The CFO bullet that modelled `~$310/mo` at 65.6× now notes the figure is insensitive to the ratio — 48.8× and 65.6× differ by under 1% of the saving, since both already remove ~98% of the tokens.

Fixes # N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🧪 Test update

## How Has This Been Tested?

- [x] Unit tests
- [x] Manual testing

* **Python version**: 3.13
* **Operating System**: Linux
* **Test command**: `pytest tests/test_site_claims.py tests/test_docs_claims.py tests/test_synapse_latency.py tests/test_synapses.py tests/test_synapse_memory.py -q` → **all pass**

Also verified:

- `npm ci && npm run build` in `site/` — static export builds clean, all 16 routes prerendered.
- `python scripts/check_commercial_terms.py` — passes.
- `black --check` / `ruff check` on all touched Python — clean.
- Each new guard has a self-test asserting it trips on the copy that actually shipped (`63.6×`, `'100%'` recall, `zero code egress`), so a later refactor can't quietly neuter it into a no-op.

## Documentation & discoverability

- [x] Docs answer *"what does the user/agent now see?"* — `CLAUDE.md` gains a "`site/claims.json` is canon for site numbers" section under the marketing-site rules: no number without a measurement, say which kind of evidence it is, quote the mean and the range and publish the misses.
- [x] `README.md` updated — two "zero code egress" phrasings corrected to what NeuralMind itself does.
- [ ] `docs/index.html` + `docs/about.html` — N/A, no version-facing change
- [ ] `docs/wiki/*.md` — N/A, no new command or env var
- [ ] Use-case walkthrough — N/A
- [ ] SEO refreshed — the `layout.tsx` title/description/JSON-LD are rewritten around gold-file recall, and `sub-second code retrieval` is replaced with `gold-file recall` + `local code retrieval` in keywords. No new sitemap URLs.
- [x] I did **not** edit `CHANGELOG.md` or hand-bump the `pyproject.toml` version

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

## Code Quality

- [x] I have run `black .` for formatting
- [x] I have run `ruff check .` for linting
- [x] Type hints are added for new functions/methods
- [x] Docstrings are added/updated for public APIs

## Additional Notes

Two things this PR deliberately does **not** do, both worth a follow-up decision:

1. **The benchmark suite is 40 pre-registered queries on 4 repos, not 100.** The proposed ≥0.9 recall target is already met at n=40 (93.75%), so expanding the corpus is about tightening the confidence interval and covering more languages, not about clearing the bar.
2. **"Wrong-turn reduction" (file edits per task) has no instrumentation.** The Edit/Write `PostToolUse` hooks and the reuse-vs-rewrite signal are the raw material, but nothing groups edits into a task or defines a wrong turn — and there is no before/after baseline, so it can't be claimed yet.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FtsAd1SqfK91QSdo6f2QQS)_