### PR TITLE
feat(drift): commit-time pattern-drift detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ together, what you usually touch next — and remembers it across sessions.
 > - Receives PostToolUse compression automatically (Bash output → errors + signals)
 > - Queries your codebase in ~800 tokens instead of ~50,000
 > - Gets health checks, synapse pruning, audit queries, and code/doc type filtering (v3.1.4+)
+> - Gets a `pre-commit` warning when a change skips a pattern its own peers share — the eleventh handler that forgot the auth check the other ten have (v3.2.0+)
 >
 > **Works with every IDE your team already uses.**
 
@@ -119,6 +120,7 @@ At a *matched* token budget, NeuralMind's selected context carries more of the g
 |-----------|------|
 | Cut AI inference costs on code Q&A | [Cost optimization](docs/use-cases/cost-optimization.md) |
 | Set up Claude Code hooks | [Claude Code walkthrough](docs/use-cases/claude-code.md) |
+| Catch code that drifts from its own patterns before it ships | [Review before push](docs/use-cases/review-before-push.md) |
 | Measure savings on my own repo | [Benchmark your repo](docs/use-cases/benchmark-your-repo.md) |
 | Always-on synapse learning (24/7) | [Always-on](docs/use-cases/always-on.md) |
 | Run across multiple codebases | [Multi-project scoping](docs/wiki/Multi-Project-Scoping.md) |
@@ -251,6 +253,11 @@ neuralmind benchmark .
 - **Team memory.** `neuralmind memory publish` commits a learned-weights
   bundle (no source code) that teammates' agents inherit on their next
   session — a fresh clone starts with the team's earned intuition.
+- **Commit-time drift guard.** `neuralmind drift` reads your staged diff,
+  maps changed lines to graph symbols, and flags one that skips a pattern a
+  strong majority of its siblings share — before it ships, not after a
+  query happens to surface the cluster. `neuralmind init-hook` wires it into
+  `pre-commit` automatically (warn by default; `--strict` to block).
 - **MCP server for any agent.** Claude Code, Codex, Cursor, Cline, Continue,
   or anything MCP-compatible: `neuralmind install-mcp --all`.
 - **Graph view.** `neuralmind serve` renders the index as a force-directed,

--- a/docs/about.html
+++ b/docs/about.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="How NeuralMind works: a Hebbian synapse layer that learns your codebase from real usage, a structural code graph that answers what calls a symbol and what a change touches (blast radius), decision provenance that recalls why code is the way it is from git history, progressive context disclosure for 12-50× token savings, and a 100% local ten-language code graph.">
-    <meta name="keywords" content="NeuralMind, AI coding agent memory, doc-evolver, jsdoc-optimization, Hebbian learning, synapse layer, semantic code search, structural code search, call graph, blast radius, decision provenance, commit rationale, code rationale, context compression, token optimization, MCP server, Claude Code, tree-sitter code graph, team memory, branch-isolated memory, local-first, open source">
+    <meta name="description" content="How NeuralMind works: a Hebbian synapse layer that learns your codebase from real usage, a structural code graph that answers what calls a symbol and what a change touches (blast radius), a commit-time drift check that flags code diverging from its own patterns, decision provenance that recalls why code is the way it is from git history, progressive context disclosure for 12-50× token savings, and a 100% local ten-language code graph.">
+    <meta name="keywords" content="NeuralMind, AI coding agent memory, code drift detection, pattern drift, agentic drift, doc-evolver, jsdoc-optimization, Hebbian learning, synapse layer, semantic code search, structural code search, call graph, blast radius, decision provenance, commit rationale, code rationale, context compression, token optimization, MCP server, Claude Code, tree-sitter code graph, team memory, branch-isolated memory, local-first, open source">
     <title>About NeuralMind - Semantic Code Intelligence with Brain-like Memory</title>
     <link rel="canonical" href="https://docs.neuralmind.uk/about.html">
     <meta property="og:type" content="article">
@@ -196,6 +196,21 @@
                 </tbody>
             </table>
             <p>For enterprise-scale agentic fleets, the full stack delivers maximum token efficiency, 100% local privacy, and a traceable technical debt ledger. <a href="https://github.com/dfrostar/neuralmind/blob/main/docs/comparisons/context-engineering-stack.md">Read the full comparative guide →</a></p>
+        </div>
+    </section>
+
+    <section>
+        <div class="container" id="whats-new-v320">
+            <h2>What's New in v3.2.0 — Drift, caught at commit time</h2>
+            <p><strong>The cohesion outlier check moves from query time to commit time.</strong> <code>neuralmind drift</code> reads your staged diff, maps changed lines onto the code graph, and flags a changed symbol that skips a pattern a strong majority of its siblings share — before the commit lands, not after a query happens to surface the cluster.</p>
+            <h3>What's new</h3>
+            <ul>
+                <li><strong><code>neuralmind drift</code></strong> — commit-time pattern-drift check over a git diff, warn-only by default</li>
+                <li><strong><code>init-hook</code> pre-commit guard</strong> — installs the drift check automatically alongside the existing post-commit index rebuild</li>
+                <li><strong><code>--strict</code></strong> — opt in to blocking the commit instead of warning</li>
+            </ul>
+            <p>Only symbols actually touched by the diff are ever reported — pre-existing outliers elsewhere in the graph are silently ignored, so the check never blames a commit for drift it didn't introduce.</p>
+            <p>Full details: <a href="https://github.com/dfrostar/neuralmind/blob/main/docs/releases/RELEASE_NOTES_v3.2.0.md">v3.2.0 release notes</a></p>
         </div>
     </section>
 

--- a/docs/releases/RELEASE_NOTES_v3.2.0.md
+++ b/docs/releases/RELEASE_NOTES_v3.2.0.md
@@ -1,0 +1,108 @@
+# NeuralMind v3.2.0 — drift, caught at commit time
+
+v0.44.0 gave the graph a way to spot the *odd one out* — the cluster member
+that skips a pattern its peers share — but only at **query time**, over
+whatever a prompt happened to surface. v3.2.0 moves that same consensus
+check to the one moment it matters most for an agent-written codebase: the
+commit that's about to ship.
+
+## What's in this release
+
+| Feature | Surfaces the… | Surface |
+|---------|---------------|---------|
+| **`neuralmind drift`** | *pattern drift* — a changed symbol that skips an association a strong majority of its siblings make | `neuralmind drift`, `pre-commit` hook |
+| **`init-hook` pre-commit guard** | the same check, wired in automatically | `.git/hooks/pre-commit` |
+
+Both are additive. `drift` warns and exits 0 by default — nothing about a
+plain `neuralmind init-hook` can block a commit unless you ask it to with
+`--strict`.
+
+## 1. `neuralmind drift` — pattern drift, caught before it ships
+
+Ten endpoint handlers all call `verify_session()`. An agent writes an
+eleventh, tests pass, review skims it, and the missing auth check ships —
+because the eleventh handler *looks* exactly like the other ten to anyone
+scanning the diff. That's the shape `NEURALMIND_SYNAPSE_OUTLIERS` already
+catches for a query-time cluster; `drift` catches it for a diff.
+
+```bash
+$ neuralmind drift . --staged
+
+## NeuralMind drift check (warning) — 1 finding(s)
+
+- api/routes.py:67 — `delete_me_endpoint()` skips `verify_session()`, which
+  3 of its 9 peers (33%) use. Confirm this is deliberate.
+
+Warning only — the commit proceeds. Use --strict to block on drift.
+```
+
+It reads the diff (`--staged`, a ref via `--diff`, or the working tree by
+default), maps the changed lines back onto graph symbols, groups each one
+with its siblings in the same file or class, and asks whether the changed
+symbol omits an association its peer group otherwise agrees on. **Only
+symbols actually touched by the diff are ever reported** — the graph is
+full of pre-existing odd-ones-out, and blaming a commit for those trains
+people to ignore the check. Tune what counts as consensus with
+`--cohesion` (default `0.6`) and `--min-peers` (default `3`); cap findings
+with `--max-findings`.
+
+Stdlib-only, like the rest of the synapse/structural layer — no ChromaDB,
+no tree-sitter required to run the check itself. When tree-sitter *is*
+installed (the `graphgen` extra), changed files are transparently
+re-parsed before judging, so a brand-new function in the diff is visible
+even though the persisted index predates it (`--no-refresh` or
+`NEURALMIND_DRIFT_REFRESH=0` to skip that and judge against the graph
+exactly as last built).
+
+## 2. `init-hook` installs the guard automatically
+
+`neuralmind init-hook` now installs **two** hooks instead of one:
+
+- `post-commit` — rebuilds the index (unchanged from prior releases).
+- `pre-commit` — runs `neuralmind drift . --staged`.
+
+```bash
+neuralmind init-hook .            # both hooks; drift warns, never blocks
+neuralmind init-hook . --strict   # drift blocks the commit
+neuralmind init-hook . --no-drift # post-commit rebuild only, no drift guard
+```
+
+Both hooks are idempotent and append to (rather than clobber) any existing
+hook script, so `init-hook` composes with hooks another tool already
+installed.
+
+## What the agent actually sees post-install
+
+| Agent | What changes | How to use it |
+|-------|--------------|---------------|
+| **Claude Code** | A staged commit that drifts from its peers prints a warning in the terminal (or blocks, under `--strict`) before the commit lands | Run `neuralmind init-hook .` once per repo; adjust `--cohesion`/`--min-peers` if it's too chatty or too quiet for your codebase |
+| **Cursor / Cline** | Same — the hook is a plain git `pre-commit` script, provider-agnostic | Nothing agent-specific to configure |
+| **Generic MCP / CLI** | `neuralmind drift [path] [--staged\|--diff BASE] [--strict] [--json]` | Call directly, or wire into any CI job with `--diff origin/main --strict --json` |
+
+## Configuration
+
+| Env var | Default | Effect |
+|---------|---------|--------|
+| `NEURALMIND_DRIFT_REFRESH` | `1` | `0` → skip the transparent re-parse of changed files; judge strictly against the last-built graph. Already a no-op without tree-sitter installed. |
+
+## Honest scope
+
+- **`drift`** needs a built graph (`neuralmind build .`); on a cold graph it
+  reports "No code graph found" and exits 0 — it never fails a commit for a
+  missing index.
+- Peer groups come from the graph's `contains` hierarchy (same file or
+  class) narrowed by a shared naming role (`create_*`, `*_endpoint`); a
+  symbol with fewer than `--min-peers` siblings, or no strong majority
+  among them, is judged as having nothing to say — quiet by design, not a
+  false negative to fix.
+- This is a heuristic over structural edges (`calls`, `inherits`), not a
+  type checker or a security scanner: it flags "this looks different from
+  its peers," not "this is wrong." Findings are a prompt to confirm intent,
+  not a verdict.
+
+## Upgrade
+
+```
+pip install --upgrade neuralmind
+neuralmind init-hook .   # re-run to pick up the new pre-commit guard
+```

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -8,7 +8,7 @@
   </url>
   <url>
     <loc>https://docs.neuralmind.uk/about.html</loc>
-    <lastmod>2026-07-19</lastmod>
+    <lastmod>2026-08-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
@@ -176,13 +176,13 @@
   </url>
   <url>
     <loc>https://docs.neuralmind.uk/use-cases/claude-code.html</loc>
-    <lastmod>2026-06-29</lastmod>
+    <lastmod>2026-08-18</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://docs.neuralmind.uk/use-cases/review-before-push.html</loc>
-    <lastmod>2026-06-29</lastmod>
+    <lastmod>2026-08-18</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -248,7 +248,7 @@
   </url>
   <url>
     <loc>https://docs.neuralmind.uk/wiki/CLI-Reference.html</loc>
-    <lastmod>2026-07-13</lastmod>
+    <lastmod>2026-08-18</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>

--- a/docs/use-cases/claude-code.md
+++ b/docs/use-cases/claude-code.md
@@ -51,6 +51,7 @@ Returns the function list, rationales, call graph, and cross-file edges — ~88%
 | `npm test` dumps 800 lines into the agent | Hook keeps errors + last 3 lines (~91% smaller) |
 | `grep -r "foo"` floods with 200 matches | Capped at 25 with "N more hidden" pointer |
 | Every commit drifts the index | `post-commit` hook rebuilds incrementally |
+| An eleventh handler quietly skips the auth check the other ten share *(v3.2.0+)* | `pre-commit` drift guard flags it before the commit lands |
 | "What should I open next?" is guesswork *(v0.11.0+)* | `neuralmind next . path/to/file.py` returns the files most often edited after this one, ranked by probability |
 
 ## Predict the next file *(v0.11.0+)*
@@ -130,6 +131,32 @@ Co-break candidates for 3 changed files:
 ```
 
 Same data via the `neuralmind_review` MCP tool — Claude Code can call it automatically after editing a file, before a commit or push.
+
+## Flag a commit that drifts from its own patterns *(v3.2.0+)*
+
+`review` (above) answers "what else might this change break?" It says
+nothing about whether the change itself fits the pattern its siblings
+follow. `neuralmind drift` closes that gap: it reads the diff, maps
+changed lines to graph symbols, and flags a symbol that skips an
+association a strong majority of its peer group shares.
+
+```bash
+neuralmind drift . --staged
+```
+
+```
+## NeuralMind drift check (warning) — 1 finding(s)
+
+- api/routes.py:67 — `delete_me_endpoint()` skips `verify_session()`, which
+  3 of its 9 peers (33%) use. Confirm this is deliberate.
+
+Warning only — the commit proceeds. Use --strict to block on drift.
+```
+
+Only symbols the diff actually touched are ever reported — a pre-existing
+outlier elsewhere in the graph never gets blamed on your commit.
+`neuralmind init-hook .` installs this as a `pre-commit` hook automatically
+(warn-only; pass `--strict` to `init-hook` to make it block instead).
 
 ## Track cumulative savings *(v0.39.0+, requires NEURALMIND_MEMORY=1)*
 

--- a/docs/use-cases/review-before-push.md
+++ b/docs/use-cases/review-before-push.md
@@ -71,9 +71,26 @@ The agent can call this automatically after editing a file, get the co-break can
 
 > **Want the static side of this?** `neuralmind review` ranks co-break candidates by *learned association* (what you edit together). For the *structural* answer — the exact callers, importers, and subclasses a change would touch, straight from the code graph and available with no editing history — run [`neuralmind structural <symbol> --blast-radius`](blast-radius-before-a-rename.md) (v0.42.0+). Structure says what *can* break; synapses say what *usually* co-changes. Use both before a risky refactor.
 
+> **Want to know if the change itself is off, not just what it touches?** `neuralmind review` and `--blast-radius` both answer "what else does this affect?" — they say nothing about whether the change you made is internally consistent with its own siblings. For that, [`neuralmind drift`](claude-code.md#flag-a-commit-that-drifts-from-its-own-patterns-v320) (v3.2.0+) reads the same diff and flags a changed symbol that skips an association a strong majority of its peers share — the eleventh handler that quietly forgot the auth check the other ten all have. Run it alongside `review`: one tells you what a change might break elsewhere, the other tells you if the change is drifting from the pattern it's supposed to follow.
+
+## As a pre-commit hook
+
+Both `review` and `drift` are diff-aware, so both fit naturally into a git hook instead of a manual pre-push habit:
+
+```bash
+neuralmind init-hook .   # installs post-commit rebuild + pre-commit drift guard
+```
+
+`init-hook` wires `neuralmind drift . --staged` into `pre-commit` (warn-only
+by default, `--strict` to block). `review` isn't installed automatically —
+its co-break candidates are advisory judgment calls, better suited to a
+manual check before opening a PR than a hook every commit runs through.
+
 ## See also
 
 - [Blast radius before a rename](blast-radius-before-a-rename.md) — the static-graph complement: every caller/importer/subclass a change would touch (v0.42.0+)
+- [`neuralmind drift`](claude-code.md#flag-a-commit-that-drifts-from-its-own-patterns-v320) — flag a changed symbol that breaks a pattern its peers share, at commit time (v3.2.0+)
 - [`neuralmind query --explain`](claude-code.md#understand-why-a-retrieval-answered-the-way-it-did-v0400) — understand why a specific retrieval answered the way it did
 - [`neuralmind savings`](claude-code.md#track-cumulative-savings-v0400-requires-neuralmind_memory1) — track cumulative token savings across sessions
 - [Full v0.39.0 release notes](https://github.com/dfrostar/neuralmind/blob/main/docs/releases/RELEASE_NOTES_v0.39.0.md)
+- [Full v3.2.0 release notes](https://github.com/dfrostar/neuralmind/blob/main/docs/releases/RELEASE_NOTES_v3.2.0.md)

--- a/docs/wiki/CLI-Reference.md
+++ b/docs/wiki/CLI-Reference.md
@@ -27,6 +27,7 @@ Complete command-line interface documentation for NeuralMind.
   - [last](#last-v0100)
   - [install-hooks](#install-hooks)
   - [init-hook](#init-hook)
+  - [drift](#drift-v320)
   - [watch](#watch-v040)
   - [serve](#serve-v054-live-feed-v060)
   - [daemon](#daemon-v0230)
@@ -1635,10 +1636,16 @@ then exposes NeuralMind's MCP tools (`wakeup`, `query`, `search`, `skeleton`,
 
 ### init-hook
 
-Install (or update) a Git post-commit hook that rebuilds the neural index automatically after every commit. Safe and idempotent — re-running only updates the NeuralMind block without touching other hooks.
+Install (or update) two Git hooks, both idempotent and both appended to any
+existing hook script rather than overwriting it:
+
+- **`post-commit`** rebuilds the neural index automatically after every commit.
+- **`pre-commit`** *(v3.2.0+)* runs `neuralmind drift . --staged` over the
+  staged diff — the commit-time drift guard described under
+  [`drift`](#drift-v320) below.
 
 ```bash
-neuralmind init-hook [project_path]
+neuralmind init-hook [project_path] [--no-drift] [--strict]
 ```
 
 #### Arguments
@@ -1646,16 +1653,89 @@ neuralmind init-hook [project_path]
 | Argument | Required | Description |
 |----------|----------|-------------|
 | `project_path` | No | Project root (default: current directory) |
+| `--no-drift` | No | Skip installing the pre-commit drift guard; post-commit rebuild only |
+| `--strict` | No | Make the installed drift guard block commits instead of warning |
 
 #### Examples
 
 ```bash
-# Install hook in current project
+# Install both hooks (drift guard warns, never blocks)
 neuralmind init-hook .
 
-# Install hook for a specific project
-neuralmind init-hook /path/to/project
+# Install both hooks, with drift blocking the commit
+neuralmind init-hook . --strict
+
+# Install only the post-commit rebuild, no drift guard
+neuralmind init-hook . --no-drift
 ```
+
+---
+
+### drift *(v3.2.0+)*
+
+Flag changed symbols that skip a pattern their peers share — the commit-time
+half of the cohesion outlier check (`NEURALMIND_SYNAPSE_OUTLIERS`, see
+[Environment Variables](#environment-variables)), which runs the same
+consensus math at query time instead of diff time. Reads a git diff, maps the changed lines onto graph symbols, groups each
+changed symbol with its siblings in the same file or class, and asks whether
+the symbol you just touched omits an association a strong majority of that
+group makes (e.g. nine of ten `*_endpoint` handlers call `verify_session()`
+and the tenth doesn't).
+
+Only symbols **in the diff** are ever reported — pre-existing outliers
+elsewhere in the graph are silently ignored, so the check never blames a
+commit for drift it didn't introduce. Warn-only and exit-0 by default so it
+is safe to wire into `pre-commit`; `--strict` makes it exit non-zero.
+
+```bash
+neuralmind drift [project_path] [--staged] [--diff BASE] [--strict]
+                  [--cohesion N] [--min-peers N] [--max-findings N]
+                  [--no-refresh] [--json]
+```
+
+#### Arguments
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `project_path` | No | Project root (default: current directory) |
+| `--staged` | No | Check staged changes against `HEAD` — what `pre-commit` sees |
+| `--diff BASE` | No | Diff the working tree against `BASE` instead of `HEAD` |
+| `--strict` | No | Exit non-zero when drift is found (default: warn only) |
+| `--cohesion N` | No | Fraction of a peer group that must share an association before a dissenter is flagged (default: `0.6`) |
+| `--min-peers N` | No | Minimum peers required for a peer group to be judged (default: `3`) |
+| `--max-findings N` | No | Cap on reported findings (default: `10`) |
+| `--no-refresh` | No | Skip re-parsing changed files; judge against the graph exactly as last built |
+| `--json` | No | Output JSON |
+
+#### Examples
+
+```bash
+# What a pre-commit hook runs
+neuralmind drift . --staged
+
+# Check everything since a branch diverged from main
+neuralmind drift . --diff main
+
+# Be stricter about what counts as consensus, and block on it
+neuralmind drift . --staged --cohesion 0.75 --strict
+```
+
+```
+## NeuralMind drift check (warning) — 1 finding(s)
+
+- api/routes.py:67 — `delete_me_endpoint()` skips `verify_session()`, which 3 of its 9 peers (33%) use. Confirm this is deliberate.
+
+Warning only — the commit proceeds. Use --strict to block on drift.
+```
+
+Requires a built graph (`neuralmind build .`) — without one, `drift` reports
+"No code graph found" and exits 0 rather than failing the commit. When
+tree-sitter is installed (the `graphgen` optional extra), the graph is
+transparently refreshed for just the changed files before judging, so a
+brand-new function in the diff is visible even though the persisted index
+predates it; pass `--no-refresh` to skip that and judge against the index
+exactly as it was last built. Stdlib-only otherwise, same as
+`neuralmind/cohesion.py` — no ChromaDB or embedder work.
 
 ---
 
@@ -2334,6 +2414,7 @@ Run without --dry-run to evolve JSDoc for these methods.
 | `NEURALMIND_STRUCTURAL_RECALL` | `0` | *(v0.42.0+)* Opt-in (`== "1"`). Fold a query hit's structural neighbors (callers/callees/base classes) into L3 retrieval, budget-neutrally (displacement, not addition). **Off by default** because the structural signal can saturate top-k recall and crowd out the learned synapse reranker on some graphs; the always-on structural **query tools** carry the value with zero effect on the tuned retrieval stack. |
 | `NEURALMIND_STRUCTURAL_MIN_CONFIDENCE` | `0.0` | *(v0.42.0+)* Drop structural edges whose `confidence_score` is below this value when building the index. Raise toward `1.0` to trust only compiler-accurate edges (pair with `NEURALMIND_PRECISION`). |
 | `NEURALMIND_STRUCTURAL_HUB_DEGREE` | `50` | *(v0.42.0+)* Per-relation degree cap for structural recall and blast-radius. Above the cap, an over-connected utility's neighbors are down-weighted (recall) or truncated (blast-radius) so one hub can't dominate. |
+| `NEURALMIND_DRIFT_REFRESH` | `1` | *(v3.2.0+)* Set to `0` to make `neuralmind drift` judge strictly against the last-built graph, skipping the transparent re-parse of changed files (same effect as `--no-refresh`). The re-parse needs tree-sitter (the `graphgen` extra); without it this is already a no-op. |
 
 ---
 

--- a/neuralmind/cli.py
+++ b/neuralmind/cli.py
@@ -15,8 +15,10 @@ from neuralmind import __version__, memory
 from neuralmind.audit import AuditTrail
 from neuralmind.cli_feedback_status import cmd_feedback_bad, cmd_feedback_good, cmd_status
 from neuralmind.cli_health import cmd_health
+from neuralmind.cohesion import DEFAULT_COHESION, DEFAULT_MIN_PEERS
 from neuralmind.core import GraphNotBuiltError, NeuralMind, create_mind
 from neuralmind.doc_evolver import BlindSpot, DocEvolver
+from neuralmind.drift import DEFAULT_MAX_FINDINGS
 from neuralmind.metrics_pipeline import MetricsCollector
 from neuralmind.onboarding import cmd_onboarding
 from neuralmind.tier2.config import TIER2_CONFIG_DIR
@@ -3710,6 +3712,52 @@ def _cmd_gaps_structural(args):
         print(format_structural_gaps(gaps))
 
 
+def cmd_drift(args):
+    """Flag changed symbols that break a pattern their peers share.
+
+    The commit-time half of the cohesion check: instead of judging
+    whatever cluster a query surfaced, it reads the diff, maps the
+    changed lines onto graph symbols, and asks whether anything you just
+    touched skips an association a strong majority of its siblings make.
+
+    Warn-only by default so it can sit in a ``pre-commit`` hook without
+    ever standing between a developer and their commit; ``--strict``
+    turns findings into a non-zero exit.
+    """
+    from .drift import check_project, format_drift
+
+    project_path = getattr(args, "project_path", ".")
+    strict = getattr(args, "strict", False)
+
+    result = check_project(
+        project_path,
+        base=getattr(args, "diff", None),
+        staged=getattr(args, "staged", False),
+        cohesion=args.cohesion,
+        min_peers=args.min_peers,
+        max_findings=args.max_findings,
+        refresh=not getattr(args, "no_refresh", False),
+    )
+    findings = result.pop("_findings", [])
+
+    if args.json:
+        print(json.dumps(result, indent=2))
+    elif not result["changed_files"]:
+        print("No changes to check. (Nothing staged, or an empty diff.)")
+    elif result["graph"] == "missing":
+        print("No code graph found. Run `neuralmind build .` first — drift needs the graph.")
+    elif not findings:
+        print(
+            f"✓ No drift. Checked {result['symbols_checked']} changed "
+            f"symbol(s) across {len(result['changed_files'])} file(s)."
+        )
+    else:
+        print(format_drift(findings, strict=strict))
+
+    if findings and strict:
+        sys.exit(1)
+
+
 def cmd_gaps(args):
     """Find endpoints tested only in mock mode — the coverage that lies.
 
@@ -3783,14 +3831,61 @@ def cmd_why(args):
     print(format_decisions(hits))
 
 
-def cmd_init_hook(args):
-    """Initialize Git post-commit hook for automatic updates.
+def _splice_hook_block(existing: str, block: str) -> tuple[str, str]:
+    """Merge a neuralmind block into an existing hook script.
 
-    Safe: appends to an existing post-commit hook rather than overwriting
-    it, and is idempotent — re-running only updates the neuralmind block.
+    Returns ``(new_content, action)``. The block is delimited by sentinels
+    so re-runs replace it in place and coexist with other tools' hook
+    contributions (e.g. ``graphify hook install``) instead of clobbering
+    them.
     """
+    if "# neuralmind-hook-start" in existing and "# neuralmind-hook-end" in existing:
+        # Idempotent replacement of just our block.
+        pre, _, rest = existing.partition("# neuralmind-hook-start")
+        _, _, post = rest.partition("# neuralmind-hook-end")
+        return pre.rstrip("\n") + "\n\n" + block + post.lstrip("\n"), "updated"
+    if existing.strip():
+        # Append to an existing hook without clobbering it.
+        if not existing.endswith("\n"):
+            existing += "\n"
+        return existing + "\n" + block, "appended to"
+    return "#!/bin/sh\n" + block, "created"
+
+
+def _write_hook(hook_path: str, block: str) -> str:
+    """Write a hook file with the block spliced in; return the action taken."""
     import os
     import stat
+
+    existing = ""
+    if os.path.exists(hook_path):
+        with open(hook_path) as f:
+            existing = f.read()
+    new_content, action = _splice_hook_block(existing, block)
+    with open(hook_path, "w") as f:
+        f.write(new_content)
+    # Make executable (no-op on Windows but harmless).
+    current_mode = os.stat(hook_path).st_mode
+    os.chmod(hook_path, current_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    return action
+
+
+def cmd_init_hook(args):
+    """Initialize the Git hooks that keep the index fresh and the code honest.
+
+    Installs two hooks, both idempotent and both appended to any existing
+    script rather than overwriting it:
+
+    - ``post-commit`` rebuilds the index so it never drifts stale;
+    - ``pre-commit`` runs the drift check over the staged diff, so a
+      symbol that skips a pattern its peers share gets flagged while the
+      change is still in your hands.
+
+    The pre-commit guard warns and exits 0 by default — a check that
+    blocks commits on a heuristic loses its welcome fast. ``--strict``
+    makes it blocking; ``--no-drift`` skips it entirely.
+    """
+    import os
     import sys
 
     project_path = getattr(args, "project_path", ".")
@@ -3823,40 +3918,45 @@ fi
 # neuralmind-hook-end
 """
 
-    existing = ""
-    if os.path.exists(hook_path):
-        with open(hook_path) as f:
-            existing = f.read()
-
-    if "# neuralmind-hook-start" in existing and "# neuralmind-hook-end" in existing:
-        # Idempotent replacement of just our block
-        pre, _, rest = existing.partition("# neuralmind-hook-start")
-        _, _, post = rest.partition("# neuralmind-hook-end")
-        # post starts right after the sentinel; strip the trailing newline
-        # from our pre-slice if it produced one, then splice
-        new_content = pre.rstrip("\n") + "\n\n" + nm_block + post.lstrip("\n")
-        action = "updated"
-    elif existing.strip():
-        # Append to existing hook without clobbering
-        if not existing.endswith("\n"):
-            existing += "\n"
-        new_content = existing + "\n" + nm_block
-        action = "appended to"
-    else:
-        # Fresh hook
-        new_content = "#!/bin/sh\n" + nm_block
-        action = "created"
-
     try:
-        with open(hook_path, "w") as f:
-            f.write(new_content)
-        # Make executable (no-op on Windows but harmless)
-        current_mode = os.stat(hook_path).st_mode
-        os.chmod(hook_path, current_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+        action = _write_hook(hook_path, nm_block)
         print(f"✓ NeuralMind post-commit hook {action} at {hook_path}")
         print("  The index will rebuild automatically after every commit.")
     except Exception as e:
         print(f"Error installing hook: {e}")
+        sys.exit(1)
+
+    if getattr(args, "no_drift", False):
+        print("  Drift guard skipped (--no-drift).")
+        return
+
+    # The pre-commit guard reads the staged diff and the last-built graph.
+    # `|| true` in warn mode is deliberate belt-and-braces: `drift` already
+    # exits 0 without --strict, but a hook that can never block a commit by
+    # accident is one people leave installed.
+    strict = getattr(args, "strict", False)
+    drift_cmd = "neuralmind drift . --staged" + (" --strict" if strict else "")
+    tail = "" if strict else " || true"
+    drift_block = f"""# neuralmind-hook-start
+# Flag staged changes that drift from a pattern their peers share.
+# Managed by `neuralmind init-hook`.
+if command -v neuralmind >/dev/null 2>&1; then
+    {drift_cmd}{tail}
+fi
+# neuralmind-hook-end
+"""
+
+    pre_commit_path = os.path.join(git_hooks_dir, "pre-commit")
+    try:
+        action = _write_hook(pre_commit_path, drift_block)
+        print(f"✓ NeuralMind pre-commit drift guard {action} at {pre_commit_path}")
+        if strict:
+            print("  Commits are BLOCKED when a staged change drifts from its peers.")
+        else:
+            print("  Drift is reported as a warning; commits are never blocked.")
+            print("  Re-run with --strict to make it blocking.")
+    except Exception as e:
+        print(f"Error installing pre-commit hook: {e}")
         sys.exit(1)
 
 
@@ -4556,9 +4656,66 @@ def main():
     )
     ingest_cmmc_p.set_defaults(func=cmd_ingest_cmmc)
 
+    # Drift command — commit-time pattern-drift guard
+    drift_p = subparsers.add_parser(
+        "drift",
+        help="Flag changed symbols that skip a pattern their peers share",
+    )
+    drift_p.add_argument(
+        "project_path",
+        nargs="?",
+        default=".",
+        help="Project root to check (default: current directory)",
+    )
+    drift_p.add_argument(
+        "--staged",
+        action="store_true",
+        help="Check staged changes against HEAD (what a pre-commit hook sees)",
+    )
+    drift_p.add_argument(
+        "--diff",
+        metavar="BASE",
+        default=None,
+        help="Git ref to diff the working tree against (default: HEAD)",
+    )
+    drift_p.add_argument(
+        "--strict",
+        action="store_true",
+        help="Exit non-zero when drift is found (default: warn only)",
+    )
+    drift_p.add_argument(
+        "--cohesion",
+        type=float,
+        default=DEFAULT_COHESION,
+        help=(
+            "Fraction of a peer group that must share an association before a "
+            f"dissenter is flagged (default: {DEFAULT_COHESION})"
+        ),
+    )
+    drift_p.add_argument(
+        "--min-peers",
+        type=int,
+        default=DEFAULT_MIN_PEERS,
+        help=f"Minimum peers that must agree (default: {DEFAULT_MIN_PEERS})",
+    )
+    drift_p.add_argument(
+        "--max-findings",
+        type=int,
+        default=DEFAULT_MAX_FINDINGS,
+        help=f"Cap on reported findings (default: {DEFAULT_MAX_FINDINGS})",
+    )
+    drift_p.add_argument(
+        "--no-refresh",
+        action="store_true",
+        help="Skip re-parsing changed files; use the graph exactly as last built",
+    )
+    drift_p.add_argument("--json", action="store_true", help="Output JSON")
+    drift_p.set_defaults(func=cmd_drift)
+
     # Init-hook command
     init_parser = subparsers.add_parser(
-        "init-hook", help="Initialize Git post-commit hook for auto-updates"
+        "init-hook",
+        help="Install Git hooks: post-commit index rebuild + pre-commit drift guard",
     )
     init_parser.add_argument(
         "project_path",
@@ -4566,6 +4723,16 @@ def main():
         nargs="?",
         default=".",
         help="Path to the project (defaults to current directory)",
+    )
+    init_parser.add_argument(
+        "--no-drift",
+        action="store_true",
+        help="Skip the pre-commit drift guard; install the post-commit rebuild only",
+    )
+    init_parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Make the pre-commit drift guard block the commit instead of warning",
     )
     init_parser.set_defaults(func=cmd_init_hook)
 

--- a/neuralmind/drift.py
+++ b/neuralmind/drift.py
@@ -150,9 +150,7 @@ def parse_diff_hunks(diff_text: str) -> dict[str, list[tuple[int, int]]]:
     return dict(ranges)
 
 
-def diff_text(
-    project_path: str | Path, *, base: str | None = None, staged: bool = False
-) -> str:
+def diff_text(project_path: str | Path, *, base: str | None = None, staged: bool = False) -> str:
     """Return unified diff text for the requested comparison, or ``""``.
 
     ``staged=True`` diffs the index against ``HEAD`` — what a
@@ -172,9 +170,7 @@ def diff_text(
     if base is not None:
         cmd.append(base)
     try:
-        return subprocess.check_output(
-            cmd, stderr=subprocess.DEVNULL, text=True, errors="replace"
-        )
+        return subprocess.check_output(cmd, stderr=subprocess.DEVNULL, text=True, errors="replace")
     except (subprocess.CalledProcessError, OSError):
         return ""
 
@@ -507,11 +503,7 @@ def refresh_graph(project_path: str | Path, graph: dict, paths: list[str]) -> di
             return graph
         root = Path(project_path).resolve()
         indexable = graphgen.SUPPORTED_SUFFIXES | graphgen._DOC_SUFFIXES
-        changed = [
-            rel
-            for rel in paths
-            if Path(rel).suffix in indexable and (root / rel).is_file()
-        ]
+        changed = [rel for rel in paths if Path(rel).suffix in indexable and (root / rel).is_file()]
         if not changed:
             return graph
         refreshed, _ = graphgen.update_files(project_path, copy.deepcopy(graph), changed, [])

--- a/neuralmind/drift.py
+++ b/neuralmind/drift.py
@@ -1,0 +1,568 @@
+"""
+drift.py — Commit-time pattern-drift detection over the code graph.
+
+The synapse layer answers "what is related to this?" and
+:mod:`neuralmind.cohesion` turns a surfaced cluster into "which member
+breaks the cluster's shared pattern?". Both run at *recall* time, over
+whatever the agent happened to ask about. Neither of them looks at the
+one artifact that always knows what actually changed: the diff.
+
+This module closes that loop. Given a git diff, it maps the changed
+lines back onto graph nodes, builds each changed symbol's *peer group*
+— its siblings in the same file or class, narrowed to the ones that
+share its naming role — and asks the cohesion primitive whether the
+symbol you just touched skips an association a strong majority of its
+peers share.
+
+That is "code drift" in the sense that matters for an agent-written
+codebase: not a lint violation and not a broken test, but handler #11
+quietly not doing what handlers #1-#10 all do. Tests pass, review skims
+it, and the codebase erodes one plausible-looking function at a time.
+
+Design:
+- Stdlib-only (no ChromaDB, no tree-sitter, no embedder), matching the
+  synapse/structural layers, so ``tests/test_drift.py`` runs without the
+  full dependency set and the pre-commit hook costs a JSON load rather
+  than a model load.
+- Reuses :func:`neuralmind.cohesion.find_outliers` for the consensus
+  math and :class:`neuralmind.structural.StructuralIndex` for adjacency
+  instead of restating either — a drift detector that drifted from the
+  primitives it was built on would be a poor advertisement.
+- Reports only symbols *in the diff*. The graph is full of pre-existing
+  odd-ones-out; blaming a commit for those trains people to ignore the
+  check.
+- Fails quiet, never loud: an unparseable diff, a cold graph, or a
+  symbol the graph has never seen yields no findings rather than a
+  false accusation.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+from collections import defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+
+from .cohesion import DEFAULT_COHESION, DEFAULT_MIN_PEERS, find_outliers
+from .structural import StructuralIndex
+
+# Relations whose *forward* view defines "what this symbol reaches out to".
+# Calls dominate (a skipped call is the classic drift), and inheritance
+# catches the sibling class that forgot its base.
+DRIFT_RELATIONS: tuple[str, ...] = ("calls", "inherits")
+DRIFT_VIEWS: tuple[str, ...] = ("callees", "bases")
+
+# A peer group needs at least this many members before consensus means
+# anything; below it, "the majority" is one or two symbols.
+DEFAULT_MAX_FINDINGS = 10
+
+# Name tokens shorter than this are too generic to define a role group
+# (``_``, ``b``, ``id``), so they never narrow a sibling set.
+MIN_ROLE_TOKEN = 3
+
+# Refs flow in from a CLI argument and a git hook, so they reach
+# ``subprocess`` as data. Same allowlist the compliance CI check uses.
+_SAFE_REF = re.compile(r"^[A-Za-z0-9_./^\-~@]+$")
+
+# ``@@ -12,3 +14,9 @@`` — we only care about the new-side range, since a
+# deleted line has no symbol left to blame.
+_HUNK = re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@")
+
+
+@dataclass(frozen=True)
+class DriftFinding:
+    """One changed symbol that skips a pattern its peers share.
+
+    ``node`` was touched by the diff and does *not* reach ``associate``,
+    while ``peers`` of the ``group_size`` symbols in its peer group do.
+    ``share`` is the strength of that consensus in ``[0, 1]``.
+    """
+
+    node: str
+    label: str
+    source_file: str
+    line: int
+    associate: str
+    associate_label: str
+    peers: int
+    group_size: int
+
+    @property
+    def share(self) -> float:
+        others = self.group_size - 1
+        return self.peers / others if others else 0.0
+
+    def to_dict(self) -> dict:
+        return {
+            "node": self.node,
+            "label": self.label,
+            "file": self.source_file,
+            "line": self.line,
+            "skips": self.associate,
+            "skips_label": self.associate_label,
+            "peers": self.peers,
+            "group_size": self.group_size,
+            "share": round(self.share, 3),
+        }
+
+
+# --------------------------------------------------------------------- #
+# Diff → changed line ranges
+# --------------------------------------------------------------------- #
+
+
+def parse_diff_hunks(diff_text: str) -> dict[str, list[tuple[int, int]]]:
+    """Map ``path -> [(start_line, end_line), ...]`` from unified diff text.
+
+    Reads the ``+++ b/path`` headers and the new-side range of each
+    ``@@`` hunk, so the ranges index the *post-change* file — the same
+    coordinate space the graph's ``source_location`` uses. Pure-deleted
+    hunks (new-side count of 0) are skipped: there is no resulting line
+    to attribute to a symbol. ``/dev/null`` targets (file deletions) are
+    dropped for the same reason.
+    """
+    ranges: dict[str, list[tuple[int, int]]] = defaultdict(list)
+    current: str | None = None
+    for line in (diff_text or "").splitlines():
+        if line.startswith("+++ "):
+            target = line[4:].strip()
+            # git writes `+++ b/path`; `--no-prefix` or /dev/null vary it.
+            if target == "/dev/null":
+                current = None
+                continue
+            if target.startswith("b/"):
+                target = target[2:]
+            current = target or None
+            continue
+        if current is None or not line.startswith("@@"):
+            continue
+        match = _HUNK.match(line)
+        if not match:
+            continue
+        start = int(match.group(1))
+        count = int(match.group(2)) if match.group(2) is not None else 1
+        if count <= 0:
+            continue
+        ranges[current].append((start, start + count - 1))
+    return dict(ranges)
+
+
+def diff_text(
+    project_path: str | Path, *, base: str | None = None, staged: bool = False
+) -> str:
+    """Return unified diff text for the requested comparison, or ``""``.
+
+    ``staged=True`` diffs the index against ``HEAD`` — what a
+    ``pre-commit`` hook is about to let through. Otherwise the working
+    tree is compared against ``base`` (default ``HEAD``). Zero context
+    lines keep the hunk ranges tight around what actually changed, so a
+    one-line edit does not implicate its neighbors.
+
+    Any git failure returns ``""``; the caller reports "nothing to
+    check" rather than treating a missing repo as a violation.
+    """
+    if base is not None and not _SAFE_REF.match(base):
+        return ""
+    cmd = ["git", "-C", str(project_path), "diff", "--unified=0", "--no-color"]
+    if staged:
+        cmd.append("--cached")
+    if base is not None:
+        cmd.append(base)
+    try:
+        return subprocess.check_output(
+            cmd, stderr=subprocess.DEVNULL, text=True, errors="replace"
+        )
+    except (subprocess.CalledProcessError, OSError):
+        return ""
+
+
+# --------------------------------------------------------------------- #
+# Graph view — containers, members, and line→symbol mapping
+# --------------------------------------------------------------------- #
+
+
+def _location_line(node: dict) -> int:
+    """Parse graphify's ``source_location`` (``"L23"``) to an int line."""
+    raw = str(node.get("source_location", "") or "")
+    match = re.search(r"(\d+)", raw)
+    return int(match.group(1)) if match else 0
+
+
+class GraphView:
+    """Read-only helpers over a loaded ``graph.json`` dict.
+
+    Holds the three things drift detection needs and nothing else: the
+    ``contains`` hierarchy (to find a symbol's siblings), a per-file
+    ordering of code symbols (to map a diff line to the symbol that owns
+    it), and a :class:`~neuralmind.structural.StructuralIndex` for the
+    outward edges the consensus is computed over.
+    """
+
+    def __init__(self, graph: dict) -> None:
+        nodes = graph.get("nodes") or []
+        links = graph.get("links") or graph.get("edges") or []
+        self.nodes: dict[str, dict] = {
+            str(n["id"]): n for n in nodes if isinstance(n, dict) and n.get("id")
+        }
+        # container -> members, and the reverse, from `contains` edges.
+        self.members: dict[str, list[str]] = defaultdict(list)
+        self.container_of: dict[str, str] = {}
+        for link in links:
+            if not isinstance(link, dict):
+                continue
+            if link.get("relation") != "contains":
+                continue
+            src = str(link.get("source", link.get("_src", "")) or "")
+            tgt = str(link.get("target", link.get("_tgt", "")) or "")
+            if not src or not tgt or src == tgt:
+                continue
+            self.members[src].append(tgt)
+            # A node contained by two parents is a graph anomaly; first wins.
+            self.container_of.setdefault(tgt, src)
+        # Every node that owns members is a container (a file or a class),
+        # never a leaf symbol we would blame for a change.
+        self.containers: frozenset[str] = frozenset(self.members)
+
+        # file path -> code symbols in that file, ordered by start line.
+        by_file: dict[str, list[tuple[int, str]]] = defaultdict(list)
+        for node_id, node in self.nodes.items():
+            if node.get("file_type") != "code" or node_id in self.containers:
+                continue
+            source_file = str(node.get("source_file", "") or "")
+            if not source_file:
+                continue
+            by_file[source_file].append((_location_line(node), node_id))
+        self.file_symbols: dict[str, list[tuple[int, str]]] = {
+            path: sorted(entries) for path, entries in by_file.items()
+        }
+
+        self.structural = StructuralIndex().build_from_edges(links)
+
+    def label(self, node_id: str) -> str:
+        """Human label for a node id, falling back to the id itself."""
+        node = self.nodes.get(node_id)
+        return str(node.get("label", node_id)) if node else node_id
+
+    def associates(self, node_id: str) -> list[tuple[str, float]]:
+        """Outward structural edges of ``node_id`` as ``(id, weight)``.
+
+        The shape :func:`~neuralmind.cohesion.find_outliers` expects. Only
+        the forward views in :data:`DRIFT_VIEWS` count: "my peers all call
+        X and I don't" is a pattern the author controls, whereas "my peers
+        are all called by X" is a fact about the rest of the codebase.
+        """
+        views = self.structural.neighbors(node_id, DRIFT_RELATIONS)
+        out: list[tuple[str, float]] = []
+        for view in DRIFT_VIEWS:
+            out.extend((other, 1.0) for other in views.get(view, ()))
+        return out
+
+    def symbols_for_ranges(self, ranges: dict[str, list[tuple[int, int]]]) -> list[str]:
+        """Map changed line ranges to the code symbols that own them.
+
+        Within a file, symbols are ordered by start line and a changed
+        line is attributed to the last symbol starting at or before it —
+        graphify records a start line but no end line, so this is the
+        closest containment the graph supports. Lines above the first
+        symbol (imports, module docstrings) belong to no symbol and are
+        dropped rather than blamed on the file node.
+
+        Returns node ids in a stable order, de-duplicated.
+        """
+        hits: list[str] = []
+        for path, spans in ranges.items():
+            entries = self.file_symbols.get(path)
+            if not entries:
+                continue
+            for start, end in spans:
+                for index, (line, node_id) in enumerate(entries):
+                    if line > end:
+                        break
+                    # Owns the change if the next symbol starts after it.
+                    next_line = entries[index + 1][0] if index + 1 < len(entries) else None
+                    if next_line is not None and next_line <= start:
+                        continue
+                    if line <= end:
+                        hits.append(node_id)
+        return list(dict.fromkeys(hits))
+
+
+# --------------------------------------------------------------------- #
+# Peer groups
+# --------------------------------------------------------------------- #
+
+
+def _role_tokens(label: str) -> tuple[str, str]:
+    """Split a symbol label into its ``(first, last)`` role tokens.
+
+    ``create_user()`` → ``("create", "user")``; ``_on_charge_failed()`` →
+    ``("on", "failed")``. Trailing ``()`` (the built-in backend's marker
+    for a callable) and leading underscores are stripped so a private
+    helper groups with its public siblings. Tokens below
+    :data:`MIN_ROLE_TOKEN` characters are dropped — they are too generic
+    to name a role.
+    """
+    name = label.strip()
+    if name.endswith("()"):
+        name = name[:-2]
+    parts = [p for p in name.strip("_").split("_") if len(p) >= MIN_ROLE_TOKEN]
+    if not parts:
+        return ("", "")
+    return (parts[0].lower(), parts[-1].lower())
+
+
+def peer_group(view: GraphView, node_id: str, *, min_peers: int = DEFAULT_MIN_PEERS) -> list[str]:
+    """Return the symbols ``node_id`` should be consistent with.
+
+    Starts from its siblings — the other code symbols in the same
+    container (file or class) — then narrows to the ones sharing its
+    naming role when such a subgroup is both large enough to carry a
+    majority and strictly smaller than the full sibling set. So
+    ``refund_endpoint`` is judged against the other ``*_endpoint``
+    handlers rather than against every exception class in the module,
+    which is what makes a consensus meaningful instead of merely
+    arithmetic.
+
+    Returns ``[]`` when the group would be too small to have both a
+    majority and a dissenter, which is the common, quiet case.
+    """
+    container = view.container_of.get(node_id)
+    if not container:
+        return []
+    siblings = [
+        member
+        for member in view.members.get(container, ())
+        if member in view.nodes
+        and view.nodes[member].get("file_type") == "code"
+        and member not in view.containers
+    ]
+    if len(siblings) < min_peers + 1:
+        return []
+
+    first, last = _role_tokens(view.label(node_id))
+    best: list[str] | None = None
+    for position, token in ((1, last), (0, first)):
+        if not token:
+            continue
+        group = [s for s in siblings if _role_tokens(view.label(s))[position] == token]
+        if len(group) < min_peers + 1 or len(group) >= len(siblings):
+            # Too small to judge, or it is just the sibling set again.
+            continue
+        if best is None or len(group) < len(best):
+            best = group
+    return best if best is not None else siblings
+
+
+# --------------------------------------------------------------------- #
+# Detection
+# --------------------------------------------------------------------- #
+
+
+def find_drift(
+    graph: dict,
+    changed_ranges: dict[str, list[tuple[int, int]]],
+    *,
+    cohesion: float = DEFAULT_COHESION,
+    min_peers: int = DEFAULT_MIN_PEERS,
+    max_findings: int = DEFAULT_MAX_FINDINGS,
+) -> list[DriftFinding]:
+    """Find changed symbols that break their peer group's shared pattern.
+
+    Maps ``changed_ranges`` (from :func:`parse_diff_hunks`) onto graph
+    symbols, and for each one runs :func:`~neuralmind.cohesion.find_outliers`
+    over its :func:`peer_group`, keeping only the findings that name the
+    changed symbol itself. Ranked by consensus strength, strongest first.
+
+    Empty whenever the graph is cold, the diff touches nothing the graph
+    knows, or every changed symbol agrees with its peers.
+    """
+    view = GraphView(graph)
+    changed = view.symbols_for_ranges(changed_ranges)
+    if not changed:
+        return []
+
+    findings: list[DriftFinding] = []
+    seen: set[tuple[str, str]] = set()
+    for node_id in changed:
+        group = peer_group(view, node_id, min_peers=min_peers)
+        if not group or node_id not in group:
+            continue
+        try:
+            outliers = find_outliers(
+                group,
+                view.associates,
+                cohesion=cohesion,
+                min_peers=min_peers,
+                max_findings=max_findings,
+            )
+        except Exception:
+            # A malformed graph must not break a commit.
+            continue
+        node = view.nodes.get(node_id, {})
+        for outlier in outliers:
+            if outlier.node != node_id:
+                # A pre-existing odd-one-out this commit did not touch.
+                continue
+            key = (node_id, outlier.associate)
+            if key in seen:
+                continue
+            seen.add(key)
+            findings.append(
+                DriftFinding(
+                    node=node_id,
+                    label=view.label(node_id),
+                    source_file=str(node.get("source_file", "") or ""),
+                    line=_location_line(node),
+                    associate=outlier.associate,
+                    associate_label=view.label(outlier.associate),
+                    peers=outlier.peers,
+                    group_size=outlier.cluster_size,
+                )
+            )
+
+    findings.sort(key=lambda f: (f.share, f.peers), reverse=True)
+    return findings[:max_findings]
+
+
+def format_drift(findings: list[DriftFinding], *, strict: bool = False) -> str:
+    """Render findings as a compact block for a terminal or a hook.
+
+    Empty string when there is nothing to report, so a caller can print
+    it unconditionally without emitting a dangling header.
+    """
+    if not findings:
+        return ""
+    verb = "blocked" if strict else "warning"
+    lines = [f"## NeuralMind drift check ({verb}) — {len(findings)} finding(s)", ""]
+    for finding in findings:
+        location = f"{finding.source_file}:{finding.line}" if finding.source_file else finding.node
+        pct = round(finding.share * 100)
+        lines.append(
+            f"- {location} — `{finding.label}` skips `{finding.associate_label}`, "
+            f"which {finding.peers} of its {finding.group_size - 1} peers ({pct}%) use. "
+            "Confirm this is deliberate."
+        )
+    lines.append("")
+    if strict:
+        lines.append("Commit blocked. Fix the drift, or re-run without --strict to warn only.")
+    else:
+        lines.append("Warning only — the commit proceeds. Use --strict to block on drift.")
+    return "\n".join(lines)
+
+
+# --------------------------------------------------------------------- #
+# Project-level entry point
+# --------------------------------------------------------------------- #
+
+
+def load_graph(project_path: str | Path) -> dict:
+    """Load a project's ``graph.json``, or ``{}`` when there is none.
+
+    Goes through :func:`neuralmind.ir.project_artifact` so a project root
+    arriving from a CLI argument or a hook cannot escape its own tree.
+    """
+    from . import ir as ir_mod
+
+    try:
+        path = ir_mod.project_artifact(project_path, "graphify-out", "graph.json")
+    except ValueError:
+        return {}
+    try:
+        with open(path, encoding="utf-8") as handle:
+            graph = json.load(handle)
+    except (OSError, ValueError):
+        return {}
+    return graph if isinstance(graph, dict) else {}
+
+
+def refresh_graph(project_path: str | Path, graph: dict, paths: list[str]) -> dict:
+    """Re-parse ``paths`` into a copy of ``graph`` so new symbols are visible.
+
+    The persisted graph is only as fresh as the last build, and the
+    ``post-commit`` hook rebuilds *after* the commit — so at ``pre-commit``
+    time a brand-new function, the single most common shape of agent
+    drift, would be invisible. Splicing just the changed files back in
+    costs a tree-sitter parse of those files and no embedder work.
+
+    Deep-copies first: ``graphgen.update_files`` splices in place, and a
+    check must never mutate the index it reads. Returns ``graph``
+    unchanged when tree-sitter is unavailable, the graph came from
+    graphify, or anything at all goes wrong — a stale graph yields
+    weaker findings, while a failed refresh must not fail the commit.
+    """
+    if not graph or not paths:
+        return graph
+    if "neuralmind.graphgen" not in str(graph.get("generated_by", "")):
+        # A real graphify build is graphify's to update.
+        return graph
+    try:
+        import copy
+
+        from . import graphgen
+
+        if not graphgen.is_available():
+            return graph
+        root = Path(project_path).resolve()
+        indexable = graphgen.SUPPORTED_SUFFIXES | graphgen._DOC_SUFFIXES
+        changed = [
+            rel
+            for rel in paths
+            if Path(rel).suffix in indexable and (root / rel).is_file()
+        ]
+        if not changed:
+            return graph
+        refreshed, _ = graphgen.update_files(project_path, copy.deepcopy(graph), changed, [])
+        return refreshed if isinstance(refreshed, dict) else graph
+    except Exception:
+        return graph
+
+
+def check_project(
+    project_path: str | Path,
+    *,
+    base: str | None = None,
+    staged: bool = False,
+    cohesion: float = DEFAULT_COHESION,
+    min_peers: int = DEFAULT_MIN_PEERS,
+    max_findings: int = DEFAULT_MAX_FINDINGS,
+    refresh: bool = True,
+) -> dict:
+    """Run the whole drift check for a project and return a result dict.
+
+    ``{"findings": [...], "changed_files": [...], "symbols_checked": int,
+    "graph": "loaded"|"missing"}``. The single entry point the CLI, the
+    git hook, and any future MCP tool share, so all three report the
+    same thing.
+    """
+    ranges = parse_diff_hunks(diff_text(project_path, base=base, staged=staged))
+    result: dict = {
+        "findings": [],
+        "changed_files": sorted(ranges),
+        "symbols_checked": 0,
+        "graph": "missing",
+    }
+    if not ranges:
+        return result
+
+    graph = load_graph(project_path)
+    if not graph.get("nodes"):
+        return result
+    result["graph"] = "loaded"
+    if refresh and os.environ.get("NEURALMIND_DRIFT_REFRESH") != "0":
+        graph = refresh_graph(project_path, graph, sorted(ranges))
+
+    view = GraphView(graph)
+    result["symbols_checked"] = len(view.symbols_for_ranges(ranges))
+    findings = find_drift(
+        graph,
+        ranges,
+        cohesion=cohesion,
+        min_peers=min_peers,
+        max_findings=max_findings,
+    )
+    result["findings"] = [f.to_dict() for f in findings]
+    result["_findings"] = findings
+    return result

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,9 @@ keywords = [
     "developer-tools",
     "team-memory",
     "impact-analysis",
+    "code-drift-detection",
+    "pre-commit-hook",
+    "pattern-consistency",
 ]
 classifiers = [
     "Development Status :: 5 - Production/Stable",

--- a/tests/test_drift.py
+++ b/tests/test_drift.py
@@ -1,0 +1,269 @@
+"""Tests for commit-time pattern-drift detection (neuralmind/drift.py).
+
+Stdlib-only, matching the rest of the synapse/structural/cohesion layer:
+these operate on plain graph dicts and diff text, no ChromaDB or
+tree-sitter required.
+"""
+
+from __future__ import annotations
+
+from neuralmind.drift import (
+    DriftFinding,
+    GraphView,
+    check_project,
+    find_drift,
+    format_drift,
+    parse_diff_hunks,
+    peer_group,
+)
+
+# --------------------------------------------------------------------- #
+# Fixture: ten endpoint handlers that all verify a session, plus one
+# that doesn't — the same "handler #11" shape cohesion.py's own tests
+# use, but built as a graph.json rather than a bare neighbor dict.
+# --------------------------------------------------------------------- #
+
+
+def _handler_graph(*, drop_verify_from: str | None = "handler_10"):
+    nodes = [{"id": "routes.py", "label": "routes.py", "file_type": "file"}]
+    links = []
+    for i in range(1, 11):
+        name = f"handler_{i}"
+        nodes.append(
+            {
+                "id": name,
+                "label": f"{name}()",
+                "file_type": "code",
+                "source_file": "routes.py",
+                "source_location": f"L{i * 10}",
+            }
+        )
+        links.append({"source": "routes.py", "target": name, "relation": "contains"})
+        if name != drop_verify_from:
+            links.append({"source": name, "target": "verify_session", "relation": "calls"})
+    nodes.append({"id": "verify_session", "label": "verify_session()", "file_type": "code"})
+    return {"nodes": nodes, "links": links, "generated_by": "test-fixture"}
+
+
+def _ranges_for_line(line: int, path: str = "routes.py"):
+    return {path: [(line, line)]}
+
+
+class TestParseDiffHunks:
+    def test_single_hunk(self):
+        diff = (
+            "diff --git a/routes.py b/routes.py\n"
+            "index abc..def 100644\n"
+            "--- a/routes.py\n"
+            "+++ b/routes.py\n"
+            "@@ -10,0 +10,3 @@\n"
+            "+def handler_10():\n"
+            "+    pass\n"
+        )
+        ranges = parse_diff_hunks(diff)
+        assert ranges == {"routes.py": [(10, 12)]}
+
+    def test_deleted_file_is_skipped(self):
+        diff = "diff --git a/gone.py b/gone.py\n--- a/gone.py\n+++ /dev/null\n@@ -1,3 +0,0 @@\n"
+        assert parse_diff_hunks(diff) == {}
+
+    def test_pure_deletion_hunk_is_skipped(self):
+        # New-side count of 0: nothing added, nothing to attribute.
+        diff = "--- a/f.py\n+++ b/f.py\n@@ -5,3 +5,0 @@\n"
+        assert parse_diff_hunks(diff) == {}
+
+    def test_multiple_files(self):
+        diff = (
+            "--- a/a.py\n+++ b/a.py\n@@ -1,0 +1,2 @@\n"
+            "--- a/b.py\n+++ b/b.py\n@@ -20 +20 @@\n"
+        )
+        ranges = parse_diff_hunks(diff)
+        assert ranges == {"a.py": [(1, 2)], "b.py": [(20, 20)]}
+
+    def test_empty_diff(self):
+        assert parse_diff_hunks("") == {}
+
+
+class TestGraphView:
+    def test_symbols_for_ranges_maps_line_to_owning_symbol(self):
+        view = GraphView(_handler_graph())
+        hits = view.symbols_for_ranges(_ranges_for_line(100))
+        assert hits == ["handler_10"]
+
+    def test_line_before_first_symbol_maps_to_nothing(self):
+        view = GraphView(_handler_graph())
+        assert view.symbols_for_ranges(_ranges_for_line(1)) == []
+
+    def test_unknown_file_maps_to_nothing(self):
+        view = GraphView(_handler_graph())
+        assert view.symbols_for_ranges({"nope.py": [(1, 5)]}) == []
+
+    def test_associates_uses_forward_calls_view(self):
+        view = GraphView(_handler_graph())
+        assert view.associates("handler_1") == [("verify_session", 1.0)]
+        # verify_session is only ever a callee, never a caller in this graph.
+        assert view.associates("verify_session") == []
+
+
+class TestPeerGroup:
+    def test_groups_by_shared_container(self):
+        view = GraphView(_handler_graph())
+        group = peer_group(view, "handler_10")
+        assert set(group) == {f"handler_{i}" for i in range(1, 11)}
+
+    def test_no_container_is_empty(self):
+        view = GraphView(_handler_graph())
+        assert peer_group(view, "verify_session") == []
+
+    def test_too_few_siblings_is_empty(self):
+        graph = {
+            "nodes": [
+                {"id": "f.py", "label": "f.py", "file_type": "file"},
+                {
+                    "id": "only_one",
+                    "label": "only_one()",
+                    "file_type": "code",
+                    "source_file": "f.py",
+                    "source_location": "L1",
+                },
+            ],
+            "links": [{"source": "f.py", "target": "only_one", "relation": "contains"}],
+        }
+        view = GraphView(graph)
+        assert peer_group(view, "only_one") == []
+
+    def test_role_token_narrows_group(self):
+        # create_endpoint / update_endpoint / delete_endpoint share "endpoint";
+        # a stray helper() in the same file must not join their peer group.
+        nodes = [{"id": "f.py", "label": "f.py", "file_type": "file"}]
+        links = []
+        names = ["create_endpoint", "update_endpoint", "delete_endpoint", "read_endpoint", "helper"]
+        for i, name in enumerate(names):
+            nodes.append(
+                {
+                    "id": name,
+                    "label": f"{name}()",
+                    "file_type": "code",
+                    "source_file": "f.py",
+                    "source_location": f"L{i * 10 + 1}",
+                }
+            )
+            links.append({"source": "f.py", "target": name, "relation": "contains"})
+        view = GraphView({"nodes": nodes, "links": links})
+        group = peer_group(view, "create_endpoint", min_peers=3)
+        assert set(group) == {"create_endpoint", "update_endpoint", "delete_endpoint", "read_endpoint"}
+        assert "helper" not in group
+
+
+class TestFindDrift:
+    def test_flags_the_handler_that_skips_verify_session(self):
+        graph = _handler_graph(drop_verify_from="handler_10")
+        findings = find_drift(graph, _ranges_for_line(100), cohesion=0.6, min_peers=3)
+        assert len(findings) == 1
+        finding = findings[0]
+        assert finding.node == "handler_10"
+        assert finding.associate == "verify_session"
+        assert finding.peers == 9
+        assert finding.group_size == 10
+
+    def test_consistent_change_is_quiet(self):
+        # handler_10 keeps its call to verify_session — nothing to flag.
+        graph = _handler_graph(drop_verify_from=None)
+        findings = find_drift(graph, _ranges_for_line(100))
+        assert findings == []
+
+    def test_only_reports_symbols_actually_in_the_diff(self):
+        # handler_10 is the pre-existing outlier, but the diff only touches
+        # handler_5 — a compliant handler. Nothing should be blamed.
+        graph = _handler_graph(drop_verify_from="handler_10")
+        findings = find_drift(graph, _ranges_for_line(50))
+        assert findings == []
+
+    def test_empty_ranges_yields_no_findings(self):
+        graph = _handler_graph(drop_verify_from="handler_10")
+        assert find_drift(graph, {}) == []
+
+    def test_cold_graph_yields_no_findings(self):
+        assert find_drift({"nodes": [], "links": []}, _ranges_for_line(10)) == []
+
+    def test_max_findings_caps_output(self):
+        graph = _handler_graph(drop_verify_from="handler_10")
+        ranges = _ranges_for_line(100)
+        findings = find_drift(graph, ranges, max_findings=0)
+        assert findings == []
+
+
+class TestFormatDrift:
+    def test_empty_findings_render_empty_string(self):
+        assert format_drift([]) == ""
+
+    def test_warn_mode_mentions_proceeding(self):
+        finding = DriftFinding(
+            node="handler_10",
+            label="handler_10()",
+            source_file="routes.py",
+            line=100,
+            associate="verify_session",
+            associate_label="verify_session()",
+            peers=9,
+            group_size=10,
+        )
+        text = format_drift([finding], strict=False)
+        assert "routes.py:100" in text
+        assert "handler_10()" in text
+        assert "verify_session()" in text
+        assert "proceeds" in text
+
+    def test_strict_mode_mentions_blocked(self):
+        finding = DriftFinding(
+            node="handler_10",
+            label="handler_10()",
+            source_file="routes.py",
+            line=100,
+            associate="verify_session",
+            associate_label="verify_session()",
+            peers=9,
+            group_size=10,
+        )
+        text = format_drift([finding], strict=True)
+        assert "blocked" in text.lower()
+
+    def test_share_property(self):
+        finding = DriftFinding(
+            node="n", label="n", source_file="f.py", line=1,
+            associate="a", associate_label="a", peers=9, group_size=10,
+        )
+        assert finding.share == 1.0  # 9 of 9 *other* members
+
+    def test_to_dict_roundtrip(self):
+        finding = DriftFinding(
+            node="n", label="n()", source_file="f.py", line=5,
+            associate="a", associate_label="a()", peers=3, group_size=4,
+        )
+        d = finding.to_dict()
+        assert d["node"] == "n"
+        assert d["skips"] == "a"
+        assert d["share"] == 1.0
+
+
+class TestCheckProject:
+    def test_no_git_repo_yields_empty_result(self, tmp_path):
+        result = check_project(str(tmp_path))
+        assert result["findings"] == []
+        assert result["changed_files"] == []
+
+    def test_missing_graph_is_reported(self, tmp_path):
+        import subprocess
+
+        subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True)
+        subprocess.run(
+            ["git", "-c", "user.email=t@t.com", "-c", "user.name=t", "commit", "--allow-empty", "-m", "init"],
+            cwd=tmp_path,
+            check=True,
+            capture_output=True,
+        )
+        (tmp_path / "a.py").write_text("x = 1\n")
+        subprocess.run(["git", "add", "a.py"], cwd=tmp_path, check=True, capture_output=True)
+        result = check_project(str(tmp_path), staged=True, refresh=False)
+        assert result["graph"] == "missing"
+        assert result["changed_files"] == ["a.py"]

--- a/tests/test_drift.py
+++ b/tests/test_drift.py
@@ -73,10 +73,7 @@ class TestParseDiffHunks:
         assert parse_diff_hunks(diff) == {}
 
     def test_multiple_files(self):
-        diff = (
-            "--- a/a.py\n+++ b/a.py\n@@ -1,0 +1,2 @@\n"
-            "--- a/b.py\n+++ b/b.py\n@@ -20 +20 @@\n"
-        )
+        diff = "--- a/a.py\n+++ b/a.py\n@@ -1,0 +1,2 @@\n--- a/b.py\n+++ b/b.py\n@@ -20 +20 @@\n"
         ranges = parse_diff_hunks(diff)
         assert ranges == {"a.py": [(1, 2)], "b.py": [(20, 20)]}
 
@@ -151,7 +148,12 @@ class TestPeerGroup:
             links.append({"source": "f.py", "target": name, "relation": "contains"})
         view = GraphView({"nodes": nodes, "links": links})
         group = peer_group(view, "create_endpoint", min_peers=3)
-        assert set(group) == {"create_endpoint", "update_endpoint", "delete_endpoint", "read_endpoint"}
+        assert set(group) == {
+            "create_endpoint",
+            "update_endpoint",
+            "delete_endpoint",
+            "read_endpoint",
+        }
         assert "helper" not in group
 
 
@@ -230,15 +232,27 @@ class TestFormatDrift:
 
     def test_share_property(self):
         finding = DriftFinding(
-            node="n", label="n", source_file="f.py", line=1,
-            associate="a", associate_label="a", peers=9, group_size=10,
+            node="n",
+            label="n",
+            source_file="f.py",
+            line=1,
+            associate="a",
+            associate_label="a",
+            peers=9,
+            group_size=10,
         )
         assert finding.share == 1.0  # 9 of 9 *other* members
 
     def test_to_dict_roundtrip(self):
         finding = DriftFinding(
-            node="n", label="n()", source_file="f.py", line=5,
-            associate="a", associate_label="a()", peers=3, group_size=4,
+            node="n",
+            label="n()",
+            source_file="f.py",
+            line=5,
+            associate="a",
+            associate_label="a()",
+            peers=3,
+            group_size=4,
         )
         d = finding.to_dict()
         assert d["node"] == "n"
@@ -257,7 +271,17 @@ class TestCheckProject:
 
         subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True)
         subprocess.run(
-            ["git", "-c", "user.email=t@t.com", "-c", "user.name=t", "commit", "--allow-empty", "-m", "init"],
+            [
+                "git",
+                "-c",
+                "user.email=t@t.com",
+                "-c",
+                "user.name=t",
+                "commit",
+                "--allow-empty",
+                "-m",
+                "init",
+            ],
             cwd=tmp_path,
             check=True,
             capture_output=True,


### PR DESCRIPTION
## Description

Adds `neuralmind drift`, a local, commit-time guard against pattern drift — the shape where an agent (or a person) writes a new function that quietly skips something a strong majority of its siblings do (the "eleventh handler" that forgot the auth check the other ten have). This is the diff-aware, commit-time counterpart to the existing `NEURALMIND_SYNAPSE_OUTLIERS` query-time cohesion check (`neuralmind/cohesion.py`) — same consensus math, reused rather than restated, now applied to a git diff instead of a spreading-activation cluster.

Requested as: "we're looking to have the local version using neuralmind to prevent code drift."

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)

## How it works

`neuralmind drift` reads a git diff (`--staged`, a ref via `--diff`, or the working tree by default), maps the changed lines onto graph symbols (`neuralmind/drift.py: GraphView.symbols_for_ranges`), groups each changed symbol with its siblings in the same file/class (`peer_group`, narrowed by shared naming role when that's a meaningful subset), and asks whether the changed symbol skips an association a strong majority of its peer group makes (`cohesion.find_outliers`, reused as-is).

**Only symbols actually touched by the diff are ever reported** — pre-existing outliers elsewhere in the graph are silently ignored, so the check never blames a commit for drift it didn't introduce. Warn-only and exit-0 by default; `--strict` blocks.

`neuralmind init-hook` now installs this as a `pre-commit` hook automatically (alongside the existing `post-commit` index rebuild), `--no-drift` to skip it, `--strict` to make it block.

```
$ neuralmind drift . --staged

## NeuralMind drift check (warning) — 1 finding(s)

- api/routes.py:67 — `delete_me_endpoint()` skips `verify_session()`, which 3 of its 9 peers (33%) use. Confirm this is deliberate.

Warning only — the commit proceeds. Use --strict to block on drift.
```

Stdlib-only (no ChromaDB/tree-sitter needed to run the check), matching the rest of the synapse/structural/cohesion layer. When tree-sitter *is* available, changed files are transparently re-parsed before judging so a brand-new function in the diff is visible even though the persisted index predates it (`--no-refresh` / `NEURALMIND_DRIFT_REFRESH=0` to disable); without tree-sitter this is already a documented no-op that fails open rather than failing the commit.

## How Has This Been Tested?

- [x] Unit tests — `tests/test_drift.py`, 27 tests covering diff-hunk parsing, line→symbol mapping, peer-group construction (including naming-role narrowing), outlier detection (including the "only report symbols in the diff" guarantee), formatting, and `check_project` end-to-end on a scratch git repo.
- [x] Manual testing — installed the package in editable mode, ran `neuralmind init-hook .` against a scratch copy of the bundled demo project to confirm both hooks install correctly and are idempotent/appendable, staged a real drift-shaped edit (dropped an auth check from a handler), and confirmed `neuralmind drift . --staged` correctly warns (exit 0) and `--strict` correctly blocks (exit 1).

### Test Configuration

* **Python version**: 3.11
* **Operating System**: Linux
* **Test command**: `pytest tests/test_drift.py tests/test_cohesion.py tests/test_structural.py -v`

Note: this sandbox is missing `numpy`/`chromadb`/tree-sitter, so the full `pytest tests/` suite has pre-existing unrelated failures (confirmed present on `main` before this change too — not introduced by this PR). All stdlib-only tests (cohesion, structural, drift) pass.

## Documentation & discoverability

- [x] Docs answer *"what does the user/agent now see?"*
- [x] `README.md` updated (new hook bullet, "What You Get" entry, Use Cases table row)
- [x] `docs/index.html` + `docs/about.html` updated — new "What's New in v3.2.0" section added above v3.1.4 in `about.html`; meta description/keywords refreshed. (`docs/index.html` currently has no per-release banner block to update — none of the recent release PRs appear to touch it either.)
- [x] `docs/wiki/CLI-Reference.md` updated — new `drift` section, updated `init-hook` section, new `NEURALMIND_DRIFT_REFRESH` env var row, TOC entry
- [x] Use-case walkthrough updated — `docs/use-cases/claude-code.md` (new "Flag a commit that drifts from its own patterns" section + table row) and `docs/use-cases/review-before-push.md` (cross-linked as the "is this change internally consistent" complement to the existing co-break/blast-radius checks)
- [x] SEO refreshed — `pyproject.toml` keywords, `docs/about.html` meta, `docs/sitemap.xml` lastmod bumps for touched pages
- [x] I did **not** edit `CHANGELOG.md` or hand-bump the `pyproject.toml` version (release-please owns these). `docs/releases/RELEASE_NOTES_v3.2.0.md` is written against the next expected minor version per the established `feat:` → minor-bump pattern; happy to rename if release-please lands on a different number.

## Checklist

- [x] Self-review complete
- [x] Docstrings added for public APIs (module-level rationale + per-function docs throughout `drift.py`, matching the style of `cohesion.py`/`structural.py`)
- [x] New and existing unit tests pass locally
- [x] `ruff check` and `black --check` pass on all changed/added files

## Code Quality

- [x] `black .` run on changed files
- [x] `ruff check .` run on changed files
- [x] Type hints added for new functions/methods
- [x] Docstrings added/updated for public APIs

## Additional Notes

Scope note on `peer_group`: it groups by shared container (file/class) narrowed by a shared naming-role token (first/last `_`-separated word, e.g. `*_endpoint`), which is a heuristic, not a semantic classifier. A symbol with fewer than `--min-peers` (default 3) siblings, or no strong majority (`--cohesion`, default `0.6`) among them, is judged as having nothing to say — quiet by design. This is a heuristic over structural edges (`calls`/`inherits`), not a type checker or security scanner: findings are a prompt to confirm intent, not a verdict.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WV8ifrYnV7UBVopC4xG4Mn)_