### PR TITLE
fix(tests): bind site ratios to their repo and evidence level, not just value

### DIFF
--- a/site/claims.json
+++ b/site/claims.json
@@ -68,21 +68,24 @@
       "context": "Field report: anonymized ~9,300-node private TypeScript SaaS platform. Never name the client — the docs and the community-benchmark entry are both anonymized on purpose.",
       "source": "docs/use-cases/measure-memory-across-a-refactor.md",
       "reproduce": "neuralmind benchmark <your repo>",
-      "evidence": "field-report"
+      "evidence": "field-report",
+      "nodes": 9293
     },
     {
       "value": 65.6,
       "context": "Community-submitted: project-alpha, JavaScript, 241 nodes. NOT a 1,486-node repo — that attribution was invented on the site and matches nothing in the data.",
       "source": "docs/community-benchmarks.json",
       "reproduce": "neuralmind benchmark . --json",
-      "evidence": "community"
+      "evidence": "community",
+      "nodes": 241
     },
     {
       "value": 46,
       "context": "Community-submitted: project-beta, Python, 1,626 nodes.",
       "source": "docs/community-benchmarks.json",
       "reproduce": "neuralmind benchmark . --json",
-      "evidence": "community"
+      "evidence": "community",
+      "nodes": 1626
     },
     {
       "value": 6.2,
@@ -181,5 +184,6 @@
   "private_names_never_publish": [
     "Level2Logic",
     "cmmc20"
-  ]
+  ],
+  "_attribution_rule": "A ratio is only correct together with the repo it was measured on and the evidence level it carries. The original defect was not a wrong number — 65.6 is a real measurement — it was that number bolted to a '1,486-node production codebase' that appears in no dataset. So entries that were measured on a specific repo declare `nodes`, and tests/test_site_claims.py checks the (ratio, node-count) pair and the claimed evidence level wherever the site states them, not just the numeric value."
 }

--- a/tests/test_site_claims.py
+++ b/tests/test_site_claims.py
@@ -76,12 +76,49 @@ PERFECT_RECALL_RE = re.compile(
 )
 
 
+# A ratio is only right in company with the repo it was measured on and the
+# evidence level it carries. The shipped defect was not a wrong number — 65.6 is
+# a real community submission — it was that number bolted to a "1,486-node
+# production codebase" that appears in no dataset. Checking membership in a set
+# of floats would have passed it, so these two patterns bind each occurrence to
+# its context.
+NODE_ATTR_RE = re.compile(r"([\d,]+)\s*-\s*node", re.IGNORECASE)
+CI_GATED_RE = re.compile(
+    r"CI[-\s]gated|gated in CI|recomputed by CI|produced by CI|asserted on every",
+    re.IGNORECASE,
+)
+# "method reproducible, not CI-gated" is the copy doing its job — disclosing the
+# evidence level rather than inflating it. A guard that fires on correct copy is
+# worse than no guard, so a negated mention doesn't count as a claim.
+NEGATION_RE = re.compile(r"\b(not|never|isn't|is not|rather than)\s*$", re.IGNORECASE)
+# The site rounds ("~9,300-node" for a 9,293-node repo); a mis-attribution is
+# off by orders of magnitude, never by a rounding step.
+NODE_TOLERANCE = 0.02
+
+
 def _claims() -> dict:
     return json.loads(CLAIMS_FILE.read_text(encoding="utf-8"))
 
 
 def _allowed_ratios() -> set[float]:
     return {float(entry["value"]) for entry in _claims()["ratios"]}
+
+
+def _claims_ci_gating(line: str) -> bool:
+    """True if the line asserts CI gating, rather than disclaiming it."""
+    return any(
+        not NEGATION_RE.search(line[max(0, m.start() - 12) : m.start()])
+        for m in CI_GATED_RE.finditer(line)
+    )
+
+
+def _entries_for(value: float) -> list[dict]:
+    return [e for e in _claims()["ratios"] if float(e["value"]) == value]
+
+
+def _nodes_in(line: str) -> list[int]:
+    """Node counts the copy attributes on this line ("1,486-node" -> 1486)."""
+    return [int(m.group(1).replace(",", "")) for m in NODE_ATTR_RE.finditer(line)]
 
 
 def _site_files(patterns: tuple[str, ...] | None = None) -> list[Path]:
@@ -200,3 +237,96 @@ def test_guards_actually_trip_on_known_bad_copy() -> None:
     marked = [f"// {ALLOW_MARKER}", "title: 'Zero code egress',", "unmarked line"]
     assert _exempt(marked, 1)
     assert not _exempt(marked, 2)
+
+
+def test_site_ratios_are_attributed_to_the_repo_they_were_measured_on() -> None:
+    """A ratio quoted next to the wrong repo size is the defect, not the value.
+
+    `65.6× ... on a 1,486-node production codebase` shipped for weeks and would
+    pass a value-only check, because 65.6 is a real number — measured on a
+    241-node repo. Where the copy states both a ratio and a node count, the pair
+    must exist in the manifest.
+    """
+    violations: list[str] = []
+    for path in _site_files(RATIO_GATED):
+        for lineno, line in enumerate(_prose(path).splitlines(), start=1):
+            claimed_nodes = _nodes_in(line)
+            if not claimed_nodes:
+                continue
+            for _, ratio in _ratios_in(line):
+                if ratio < MIN_CLAIM_RATIO:
+                    continue
+                declared = [e["nodes"] for e in _entries_for(ratio) if "nodes" in e]
+                if not declared:
+                    continue
+                if any(
+                    abs(claimed - d) <= NODE_TOLERANCE * d
+                    for claimed in claimed_nodes
+                    for d in declared
+                ):
+                    continue
+                rel = path.relative_to(REPO_ROOT)
+                violations.append(
+                    f"{rel}:{lineno}: {ratio:g}× attributed to "
+                    f"{claimed_nodes} nodes; measured on {declared}"
+                )
+    assert not violations, (
+        "A ratio is quoted against a repo size it was not measured on. This is the "
+        "original defect: the number is real, the attribution is invented:\n  "
+        + "\n  ".join(violations)
+    )
+
+
+def test_site_does_not_upgrade_a_ratios_evidence_level() -> None:
+    """Calling a field report or community submission 'CI-gated' is drift too.
+
+    Evidence level is part of the claim: `48.8×` is one maintainer's field
+    report, and presenting it as recomputed-by-CI overstates it exactly as
+    surely as changing the digits would.
+    """
+    violations: list[str] = []
+    for path in _site_files(RATIO_GATED):
+        for lineno, line in enumerate(_prose(path).splitlines(), start=1):
+            if not _claims_ci_gating(line):
+                continue
+            for _, ratio in _ratios_in(line):
+                if ratio < MIN_CLAIM_RATIO:
+                    continue
+                entries = _entries_for(ratio)
+                if not entries or any(e["evidence"] == "ci-gated" for e in entries):
+                    continue
+                rel = path.relative_to(REPO_ROOT)
+                levels = sorted({e["evidence"] for e in entries})
+                violations.append(
+                    f"{rel}:{lineno}: {ratio:g}× presented as CI-gated; it is {levels}"
+                )
+    assert not violations, (
+        "A ratio is presented as CI-gated when its manifest evidence level says "
+        "otherwise. Say which kind of evidence it actually is:\n  " + "\n  ".join(violations)
+    )
+
+
+def test_attribution_guards_trip_on_the_copy_that_shipped() -> None:
+    # The exact line that was live, which the value-only check passed.
+    shipped = "desc: '65.6× compression measured on a 1,486-node production codebase.',"
+    assert _nodes_in(shipped) == [1486]
+    ratios = [r for _, r in _ratios_in(shipped)]
+    assert ratios == [65.6]
+    declared = [e["nodes"] for e in _entries_for(65.6) if "nodes" in e]
+    assert declared and all(
+        abs(1486 - d) > NODE_TOLERANCE * d for d in declared
+    ), "the 1,486-node attribution must not match the repo 65.6× came from"
+
+    # ...and the correct attribution, including the site's rounded form, passes.
+    assert any(abs(241 - d) <= NODE_TOLERANCE * d for d in declared)
+    field = [e["nodes"] for e in _entries_for(48.8) if "nodes" in e]
+    assert any(abs(9300 - d) <= NODE_TOLERANCE * d for d in field), "~9,300 ≈ 9,293"
+
+    # Evidence-level upgrade: 48.8× is a field report, not a CI gate.
+    assert _claims_ci_gating("a CI-gated 48.8× on a ~9,300-node codebase")
+    assert all(e["evidence"] != "ci-gated" for e in _entries_for(48.8))
+    # ...but disclosing the level honestly must keep passing. This exact line is
+    # live on the site and an earlier draft of this guard failed it.
+    assert not _claims_ci_gating(
+        "'48.8×', detail: '~9,300-node codebase — method reproducible, not CI-gated'"
+    )


### PR DESCRIPTION
## Description

Follow-up to #437, which merged before its review feedback was addressed. The Codex review on that PR found that the provenance guard it shipped checks only membership in a set of floats — so it passes the exact defect it was written to prevent:

```
desc: '65.6× compression measured on a 1,486-node production codebase.'
```

`65.6` is a real number: a community submission measured on a **241-node** repo. The drift was never the digits, it was the attribution bolted to them. I verified the merged guard against that string before changing anything — it reports clean.

Both halves of the review are addressed.

**Attribution.** Ratios measured on a specific repo now declare `nodes` in `site/claims.json` (65.6→241, 46→1626, 48.8→9293). Where the copy states a ratio and a node count together, the *pair* must exist in the manifest. Tolerance is 2%, so the site's rounded "~9,300-node" for a 9,293-node repo keeps passing while a 1,486-vs-241 mismatch cannot.

**Evidence level.** Presenting a `field-report` or `community` ratio as CI-gated overstates it as surely as changing the digits would, so that is flagged too.

### A false positive, found and fixed

The first draft of the evidence check failed on live copy reading `method reproducible, not CI-gated` — the site disclosing its evidence level *correctly*, which the regex read as a claim. Negation is now handled and that exact line is a regression test.

A guard that fires on correct copy is worse than no guard: it trains people to route around it. Same reasoning as the Windows latency fix in #437 — the gate has to measure the thing it claims to measure.

Fixes # N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🧪 Test update

## How Has This Been Tested?

- [x] Unit tests

* **Python version**: 3.13
* **Operating System**: Linux
* **Test command**: `pytest tests/test_site_claims.py tests/test_docs_claims.py tests/test_synapse_latency.py -q` → **17 passed**

Self-tests assert both new guards trip on the string that actually shipped (`65.6× ... 1,486-node`) and stay quiet on the correct attribution, including the rounded `~9,300-node` form — so a later refactor can't quietly neuter them into no-ops. `black --check` and `ruff check` clean.

## Documentation & discoverability

- [x] N/A — internal test/guard change, no user-facing surface. `site/claims.json` gains an `_attribution_rule` note recording why a ratio is only correct together with its repo and evidence level.
- [x] I did **not** edit `CHANGELOG.md` or hand-bump the `pyproject.toml` version

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

## Code Quality

- [x] I have run `black .` for formatting
- [x] I have run `ruff check .` for linting
- [x] Type hints are added for new functions/methods
- [x] Docstrings are added/updated for public APIs

---
_Generated by [Claude Code](https://claude.ai/code/session_01FtsAd1SqfK91QSdo6f2QQS)_