### PR TITLE
ci: allow manual dispatch of PR-gating workflows for the release branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,11 @@ on:
     branches: [main, develop]
   pull_request:
     branches: [main, develop]
+  # Manual trigger for branches whose pull_request events can't fire —
+  # release-please force-pushes its release branch with GITHUB_TOKEN, and
+  # GitHub's anti-recursion guard suppresses workflow runs for those pushes,
+  # so the release PR otherwise shows these checks as never-started (#98).
+  workflow_dispatch:
 
 jobs:
   lint:

--- a/.github/workflows/commercial-terms.yml
+++ b/.github/workflows/commercial-terms.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [main]
   pull_request:
+  # Manual trigger for release-please's branch, whose GITHUB_TOKEN pushes
+  # can't fire pull_request workflows — see ci.yml (#98).
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/neuralmind-ci.yml
+++ b/.github/workflows/neuralmind-ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [main, master]
   push:
     branches: [main, master]
+  # Manual trigger for release-please's branch, whose GITHUB_TOKEN pushes
+  # can't fire pull_request workflows — see ci.yml (#98).
+  workflow_dispatch:
 
 # The composite action posts its summary as a PR comment; the default
 # GITHUB_TOKEN here is read-only, which made that step 403 and fail the


### PR DESCRIPTION
## Description

Adds `workflow_dispatch:` to the three PR-gating workflows that were missing it — `ci.yml` (Lint/Type Check/Test matrix/Fresh Install/Build), `neuralmind-ci.yml` (compliance-check), and `commercial-terms.yml`.

Why: release-please force-pushes its release branch with `GITHUB_TOKEN`, and GitHub's anti-recursion guard suppresses workflow runs for pushes made with that token. The release PR (#439 today) therefore shows those checks as never-started after every refresh. `ci-benchmark.yml` already carries `workflow_dispatch:` for exactly this reason; this extends the same escape hatch to the rest of the PR-gating set, so the full check suite can be run by hand against `release-please--branches--main` (checks attach to the branch head SHA, so they surface on the release PR).

Issue #98 tracks the token-side fix (`RELEASE_PLEASE_TOKEN` secret, already wired in `release-please.yml`); this PR is the no-secret fallback.

Fixes # (see #98 — related, not closed by this)

## Type of Change

- [x] 🔧 Configuration change

## How Has This Been Tested?

- [x] Manual testing

- YAML validity + presence of the new trigger verified for all three files with `yaml.safe_load` (all parse; each `on:` block now contains `workflow_dispatch`).
- The mechanism itself is already proven in-repo: `ci-benchmark.yml` has the identical trigger and was successfully dispatched against `release-please--branches--main` today, with its checks attaching to the release PR's head SHA.
- Trigger-only change: no job, step, permission, or matrix was modified, so scheduled/push/PR behavior is byte-identical.

### Test Configuration

* **Python version**: 3.11.15
* **Operating System**: Linux
* **Test command**: `python -c "import yaml; ..."` (YAML parse + trigger assertion)

## Documentation & discoverability

- [x] N/A — internal-only change, no user-facing surface (CI plumbing; no command, hook, env var, or agent-visible behavior changed)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas (each new trigger carries a comment explaining the GITHUB_TOKEN suppression rationale and points at #98)
- [x] My changes generate no new warnings

## Code Quality

- [x] N/A — YAML workflow triggers only; no Python code changed

## Screenshots (if applicable)

N/A

## Additional Notes

Companion manual step (repo admin only, not doable from a PR): create a fine-grained PAT scoped to this repo with **Contents: Read/Write** and **Pull requests: Read/Write**, and store it as the `RELEASE_PLEASE_TOKEN` Actions secret. `release-please.yml` already reads it (`token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}`); once set, the release branch's refreshes trigger PR CI natively and this dispatch path becomes a backstop only.

---
_Generated by [Claude Code](https://claude.ai/code/session_019xKfheP2FfmzwZzWim1qC2)_