### PR TITLE
fix(tests): extend the claims guard to docs/social and add an allow marker

### DIFF
--- a/docs/social/2026-08-19-claims-integrity-linkedin.md
+++ b/docs/social/2026-08-19-claims-integrity-linkedin.md
@@ -50,6 +50,7 @@ Before: "12–50x Average Token Reduction."
 After: 12–50x token reduction on real repos — the low and high end of a range, not an average.
 Why: 12 and 50 are real, field-reported numbers. Calling them an "average" implied a calculation that was never done.
 
+<!-- claims-guard:allow — quoting the retracted claim to correct it -->
 Before: "Zero telemetry or code egress — your IP never leaves your machine."
 After: No telemetry. No calls home. NeuralMind itself makes no network calls of its own.
 Why: Your agent still sends its chosen context to its model — that hasn't changed. The absolute claim overstated what we actually control.
@@ -64,4 +65,4 @@ The same audit that caught these produced the CI gate in this week's post: every
 |---|---|
 | 0.81s → "local index lookup, not another model call" | `site/claims.json`, `unsourced_do_not_use`: "No measurement anywhere in the repo produces this number... Speed claims must be mechanism-based." The replacement phrase is quoted directly from that entry. |
 | "Average" 12-50x → "range, low/high end, not an average" | `site/claims.json` `ratios`, entries `value: 12` / `value: 50`, `evidence: "field-report"`, "Directional, not a guarantee." |
-| "Never leaves your machine / zero code egress" → "no network calls of its own" | `tests/test_docs_claims.py` FORBIDDEN patterns (`egress`, `never leaves... machine`) and its prescribed replacement phrasing; `site/src/app/effectiveness/page.tsx`'s own "honesty gate" disclaims "zero code egress" as an overclaim. |
+| "Never leaves your machine / zero code egress" → "no network calls of its own" | `tests/test_docs_claims.py` FORBIDDEN patterns (`egress`, `never leaves... machine`) and its prescribed replacement phrasing; `site/src/app/effectiveness/page.tsx`'s own "honesty gate" disclaims "zero code egress" as an overclaim. | <!-- claims-guard:allow — row quotes the retracted claim it corrects -->

--- a/tests/test_docs_claims.py
+++ b/tests/test_docs_claims.py
@@ -54,7 +54,28 @@ PUBLISHED_GLOBS = (
     # likewise unscanned.
     "docs/benchmarks/*.md",
     "docs/benchmarks/*.html",
+    # Social copy (LinkedIn posts + their image prompts) is the surface class
+    # where the worst historical overclaims shipped: one infographic carried an
+    # unsourced latency figure and a "never leaves your machine" absolute at
+    # once. Posts are drafted in-repo precisely so this guard vets them BEFORE
+    # they're pasted somewhere no CI can reach.
+    "docs/social/*.md",
 )
+
+# A post may legitimately *quote* a forbidden phrase in order to correct it —
+# the correction post renders the old claim as "Before:" beside its fix. Same
+# mechanism as tests/test_site_claims.py: mark the line (or the line above it)
+# with the marker and the guards skip that line only. The marker is an audit
+# trail, not an off switch — an unmarked reappearance still fails the build.
+ALLOW_MARKER = "claims-guard:allow"
+
+
+def _allowed(lines: list[str], index: int) -> bool:
+    """True when ``lines[index]`` (0-based) carries or follows the allow marker."""
+    if ALLOW_MARKER in lines[index]:
+        return True
+    return index > 0 and ALLOW_MARKER in lines[index - 1]
+
 
 # Each entry: (compiled pattern, why it's forbidden / what to say instead).
 # Patterns target whole misleading phrases, case-insensitive.
@@ -222,12 +243,17 @@ def test_published_surfaces_have_no_forbidden_absolute_claims() -> None:
     violations: list[str] = []
     for path in _published_paths():
         text = path.read_text(encoding="utf-8", errors="replace")
-        for lineno, line in enumerate(text.splitlines(), start=1):
+        lines = text.splitlines()
+        for index, line in enumerate(lines):
+            if _allowed(lines, index):
+                continue
             for pattern, reason in FORBIDDEN:
                 m = pattern.search(line)
                 if m:
                     rel = path.relative_to(REPO_ROOT)
-                    violations.append(f"{rel}:{lineno}: forbidden claim {m.group(0)!r} — {reason}")
+                    violations.append(
+                        f"{rel}:{index + 1}: forbidden claim {m.group(0)!r} — {reason}"
+                    )
     assert not violations, (
         "Forbidden absolute claim(s) found on published surfaces "
         "(NeuralMind minimizes egress, it does not eliminate it):\n  " + "\n  ".join(violations)
@@ -243,17 +269,44 @@ def test_guard_actually_matches_a_known_bad_phrase() -> None:
     assert any(p.search("100% local: no code leaves the machine") for p, _ in FORBIDDEN)
 
 
+def test_social_copy_is_scanned() -> None:
+    # docs/social/ went unscanned while it held finished LinkedIn copy — the
+    # exact surface class the 0.81s infographic shipped from. Pin the coverage
+    # so a glob refactor can't silently drop it.
+    assert any(
+        p.parts[-2:] == ("docs", "social") or "social" in p.parts for p in _published_paths()
+    )
+
+
+def test_allow_marker_exempts_quoted_disavowals_only() -> None:
+    # A correction post quotes the old claim beside its fix; the marker skips
+    # that line — and only that line. Unmarked reappearances still fail.
+    quoted = [
+        "<!-- claims-guard:allow — quoting the retracted claim to correct it -->",
+        'Before: "your IP never leaves your machine."',
+        "After: NeuralMind makes no network calls of its own.",
+    ]
+    assert _allowed(quoted, 1), "marker on the previous line must exempt the quote"
+    assert not _allowed(quoted, 2), "the line after the quote is not exempt"
+    unmarked = ['Before: "your IP never leaves your machine."']
+    assert not _allowed(unmarked, 0)
+    assert any(p.search(unmarked[0]) for p, _ in FORBIDDEN)
+
+
 def test_published_surfaces_do_not_quote_superseded_point_estimates() -> None:
     violations: list[str] = []
     for path in _published_paths():
         text = path.read_text(encoding="utf-8", errors="replace")
-        for lineno, raw in enumerate(text.splitlines(), start=1):
+        lines = text.splitlines()
+        for index, raw in enumerate(lines):
+            if _allowed(lines, index):
+                continue
             line = _without_ranges(raw)
             for pattern, reason in SUPERSEDED_FIGURES:
                 m = pattern.search(line)
                 if m:
                     rel = path.relative_to(REPO_ROOT)
-                    violations.append(f"{rel}:{lineno}: {m.group(0)!r} — {reason}")
+                    violations.append(f"{rel}:{index + 1}: {m.group(0)!r} — {reason}")
     assert not violations, (
         "A run-dependent A/B magnitude is published as a fixed figure. CI gates "
         "these on direction, not size — quote the gate and the observed band:\n  "
@@ -268,6 +321,8 @@ def test_published_surfaces_do_not_claim_perfect_gold_file_recall() -> None:
         lines = text.splitlines()
         for index, raw in enumerate(lines):
             if not PERFECT_RECALL_RE.search(_without_ranges(raw)):
+                continue
+            if _allowed(lines, index):
                 continue
             if _scoped_to_competitor_eval(lines, index):
                 continue


### PR DESCRIPTION
## Description

Closes the last claims-guard blind spot: `docs/social/` holds finished LinkedIn copy — the exact surface class the 0.81s infographic shipped from — yet neither guard scanned it.

- Adds `docs/social/*.md` to `tests/test_docs_claims.py`'s `PUBLISHED_GLOBS`, so social copy is vetted for forbidden absolutes, superseded point estimates, and perfect-recall claims **before** it's pasted somewhere no CI can reach.
- Ports the `claims-guard:allow` marker from `tests/test_site_claims.py`: a line carrying the marker (or following a marker line) is exempt — so a correction post can quote the retracted claim beside its fix without the quote itself failing the build. The marker is an audit trail, not an off switch; an unmarked reappearance still fails.
- Marks the two quoting lines in the 2026-08-19 correction post (one `Before:` line, one source-table row — the table marker is inline so rendering stays intact).
- Two new self-tests pin the mechanism: `test_social_copy_is_scanned` (a glob refactor can't silently drop coverage) and `test_allow_marker_exempts_quoted_disavowals_only` (the marker exempts exactly one line, and the quoted phrase still trips the pattern unmarked).

Verified red→green: with the glob added and no markers, the guard correctly flagged the correction post's quoted claims at their exact lines; with the markers, all 16 tests across both guard files pass.

Fixes # (n/a — follow-through on the claims-guard hardening from #437/#440/#441)

## Type of Change

- [x] 🧪 Test update

## How Has This Been Tested?

- [x] Unit tests
- [x] Manual testing

- Red run first: extending the glob without markers produced 3 expected violations in `docs/social/2026-08-19-claims-integrity-linkedin.md` (lines quoting "never leaves your machine" / "zero code egress").
- Green run: `pytest tests/test_docs_claims.py tests/test_site_claims.py` → 16 passed.
- `black` and `ruff check` clean on the changed test file.

### Test Configuration

* **Python version**: 3.11.15
* **Operating System**: Linux
* **Test command**: `pytest tests/test_docs_claims.py tests/test_site_claims.py -v`

## Documentation & discoverability

- [x] N/A — internal-only change, no user-facing product surface (guard coverage + markers in an internal social-copy archive)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Code Quality

- [x] I have run `black .` for formatting
- [x] I have run `ruff check .` for linting
- [x] Type hints are added for new functions/methods
- [x] Docstrings are added/updated for public APIs

## Screenshots (if applicable)

N/A

## Additional Notes

Stdlib-only, like the rest of the guard suite, so it runs without the full dep set.

---
_Generated by [Claude Code](https://claude.ai/code/session_019xKfheP2FfmzwZzWim1qC2)_