### PR TITLE
fix: correct graphify attribution — moved to Graphify-Labs org, relicensed Apache-2.0

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -7,8 +7,11 @@ the NeuralMind Commercial Modules License — see LICENSING.md.
 Third-party acknowledgements
 ----------------------------
 
-graphify (https://github.com/safishamsi/graphify)
-  MIT License, Copyright (c) 2026 Safi Shamsi.
+graphify (https://github.com/Graphify-Labs/graphify)
+  Apache License 2.0. Originally authored by Safi Shamsi; the project
+  moved to the Graphify-Labs organization and relicensed from MIT to
+  Apache-2.0 as of v0.9.x (checked 2026-08-21 — verify current terms at
+  the link above before relying on this line).
   NeuralMind's built-in tree-sitter backend (neuralmind/graphgen.py)
   emits a graph.json compatible with the format graphify pioneered, and
   a graphify-generated graph is supported as an optional richer backend.

--- a/docs/HONEST-ASSESSMENT.md
+++ b/docs/HONEST-ASSESSMENT.md
@@ -55,7 +55,7 @@ You'll likely see real benefit if **all** of these are true:
   ~30 min of setup.
 - You use an **AI agent** (Claude Code, Cursor, Cline, Continue) for
   multi-step code work — not just inline completions.
-- Your codebase is in a language the **built-in tree-sitter backend** parses well (Python, TypeScript, Go, Rust, Java, C, C++, C#, Ruby, PHP) — coverage drops outside that set. [graphify](https://github.com/safishamsi/graphify) is optional and takes priority where present.
+- Your codebase is in a language the **built-in tree-sitter backend** parses well (Python, TypeScript, Go, Rust, Java, C, C++, C#, Ruby, PHP) — coverage drops outside that set. [graphify](https://github.com/Graphify-Labs/graphify) is optional and takes priority where present.
 
 If you check 3 of 5, marginal. If you check 4–5, run
 `bash scripts/demo.sh` and then `neuralmind benchmark .` on your repo.

--- a/docs/comparisons/context-engineering-stack.md
+++ b/docs/comparisons/context-engineering-stack.md
@@ -25,7 +25,7 @@ NeuralMind functions as a local-first semantic memory engine designed to model a
 
 ### Core Mechanism: AST Parsing and the Hebbian Synapse Layer
 
-NeuralMind employs Abstract Syntax Tree (AST) parsing natively for **Python, TypeScript, and Go** via its built-in tree-sitter backend. Additional language support is available through the optional [graphify](https://github.com/safishamsi/graphify) backend — any language graphify supports feeds the same retrieval pipeline. Relationships are stored in an offline ChromaDB instance (or the dependency-free turbovec backend), providing a secure, local-first processing boundary: NeuralMind itself makes no external calls, so it adds no network calls of its own to your agent's workflow.
+NeuralMind employs Abstract Syntax Tree (AST) parsing natively for **Python, TypeScript, and Go** via its built-in tree-sitter backend. Additional language support is available through the optional [graphify](https://github.com/Graphify-Labs/graphify) backend — any language graphify supports feeds the same retrieval pipeline. Relationships are stored in an offline ChromaDB instance (or the dependency-free turbovec backend), providing a secure, local-first processing boundary: NeuralMind itself makes no external calls, so it adds no network calls of its own to your agent's workflow.
 
 The system's primary learning signal is the **Hebbian Synapse Layer**. This layer continuously records user queries and file edits, allowing active associations to strengthen while unused connections naturally decay. In the v0.25.0 release, the previous co-occurrence reranker was deprecated and removed; internal benchmarks confirmed it was "runtime-inert on the warm path," adding 0.0 points to accuracy while increasing complexity.
 

--- a/docs/comparisons/vs-treesitter-ctags.md
+++ b/docs/comparisons/vs-treesitter-ctags.md
@@ -25,7 +25,7 @@ They are complementary. NeuralMind's `search` command gives you ranked semantic 
 
 ## The heuristic-only alternative
 
-If you want NeuralMind's output *shape* (skeletons, clusters) without embeddings, the [graphify](https://github.com/safishamsi/graphify) knowledge graph (MIT, by Safi Shamsi) alone already provides ~33x token reduction with zero ML dependencies. NeuralMind adds semantic retrieval on top, trading a ChromaDB dependency for stronger recall on paraphrased queries.
+If you want NeuralMind's output *shape* (skeletons, clusters) without embeddings, the [graphify](https://github.com/Graphify-Labs/graphify) knowledge graph (Apache-2.0) alone already provides ~33x token reduction with zero ML dependencies. NeuralMind adds semantic retrieval on top, trading a ChromaDB dependency for stronger recall on paraphrased queries.
 
 ---
 

--- a/docs/wiki/Installation.md
+++ b/docs/wiki/Installation.md
@@ -66,7 +66,7 @@ The sections below remain the deep reference — system requirements, dependency
 1. **Python 3.10+**: Download from [python.org](https://www.python.org/downloads/)
 2. **pip** (or [pipx](https://pipx.pypa.io/) / [uv](https://docs.astral.sh/uv/)): Usually included with Python
 3. **git** (optional): For source installation
-4. **graphify** (optional): since v0.15.0 NeuralMind generates the code graph itself with a built-in tree-sitter backend (Python, TypeScript, Go). Install [graphify](https://github.com/safishamsi/graphify) (`pip install graphifyy`) only if you want its richer graph — it takes priority automatically when present.
+4. **graphify** (optional): since v0.15.0 NeuralMind generates the code graph itself with a built-in tree-sitter backend (Python, TypeScript, Go). Install [graphify](https://github.com/Graphify-Labs/graphify) (`pip install graphifyy`) only if you want its richer graph — it takes priority automatically when present.
 
 ---
 

--- a/docs/wiki/Integration-Guide.md
+++ b/docs/wiki/Integration-Guide.md
@@ -90,7 +90,7 @@ processes.
 
 ## Graphify Integration
 
-NeuralMind generates its own code graph — `neuralmind build` uses the built-in tree-sitter backend (ten languages), so no external install is required. [graphify](https://github.com/safishamsi/graphify) (MIT, by Safi Shamsi) is an optional alternative graph producer: it analyzes a corpus (code, docs, papers, images) into a richer structured graph, and where a graphify-generated `graph.json` is present it takes priority automatically.
+NeuralMind generates its own code graph — `neuralmind build` uses the built-in tree-sitter backend (ten languages), so no external install is required. [graphify](https://github.com/Graphify-Labs/graphify) (Apache-2.0; originally by Safi Shamsi, now under the Graphify-Labs org) is an optional alternative graph producer: it analyzes a corpus (code, docs, papers, images) into a richer structured graph, and where a graphify-generated `graph.json` is present it takes priority automatically.
 
 ### Installing Graphify
 

--- a/docs/wiki/Scheduling-Guide.md
+++ b/docs/wiki/Scheduling-Guide.md
@@ -355,7 +355,7 @@ jobs:
       - name: Install NeuralMind and graphify
         run: |
           pip install neuralmind
-          git clone https://github.com/safishamsi/graphify.git
+          git clone https://github.com/Graphify-Labs/graphify.git
           cd graphify && pip install -e .
       
       - name: Generate code graph
@@ -417,7 +417,7 @@ jobs:
       - name: Install NeuralMind and graphify
         run: |
           pip install neuralmind
-          git clone https://github.com/safishamsi/graphify.git
+          git clone https://github.com/Graphify-Labs/graphify.git
           cd graphify && pip install -e .
       
       - name: Generate graph and index for ${{ matrix.project.name }}

--- a/docs/wiki/Setup-Guide.md
+++ b/docs/wiki/Setup-Guide.md
@@ -301,7 +301,7 @@ fails, `neuralmind doctor` will tell you which piece is missing.
 
 NeuralMind's built-in tree-sitter backend covers Python, TypeScript,
 and Go standalone, proven at parity with graphify by a CI gate. If you
-prefer [graphify](https://github.com/safishamsi/graphify)'s richer
+prefer [graphify](https://github.com/Graphify-Labs/graphify)'s richer
 graph, install it and it takes priority automatically:
 
 ```bash

--- a/requirements-pinned.txt
+++ b/requirements-pinned.txt
@@ -35,7 +35,7 @@ ruff==0.16.1
 mypy==1.20.2
 
 # External tools (required separately)
-# graphify - install from: git clone https://github.com/safishamsi/graphify.git && cd graphify && pip install -e .
+# graphify - install from: git clone https://github.com/Graphify-Labs/graphify.git && cd graphify && pip install -e .
 
 # Documentation
 # sphinx==7.2.6


### PR DESCRIPTION
## What

Pure factual correction, verified live 2026-08-21: \`github.com/safishamsi/graphify\` now 301-redirects to \`github.com/Graphify-Labs/graphify\` (GitHub API confirms \`owner.type: Organization\`), and the project relicensed from MIT to Apache-2.0 as of v0.9.x — both the repo's \`license\` field and the \`graphifyy\` PyPI package's \`license_expression\` now read Apache-2.0. Every doc naming the old individual account or asserting MIT was wrong.

Fixed: NOTICE, HONEST-ASSESSMENT.md, Integration-Guide.md, Installation.md, Setup-Guide.md, Scheduling-Guide.md, context-engineering-stack.md, vs-treesitter-ctags.md, requirements-pinned.txt. Same interop story throughout (optional richer backend, no graphify code vendored) — only the owner/license attribution changed.

## Deliberately out of scope

Whether graphify should now be described as a competitor rather than a complement (its own site lists an enterprise tier — merge-gate verification, graph-aware review, self-hosted — that overlaps NeuralMind's positioning) is a strategic call, not an accuracy fix. \`evals/public/COMPETITORS.md\` and \`docs/comparisons/README.md\` are untouched pending that discussion.

## Verification

\`git grep safishamsi\` → 0 hits outside \`.neuralmind/\` (local index); \`scripts/check_commercial_terms.py\` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)