### PR TITLE
docs: reposition graphify as a tracked competitor, not a complementary backend

### DIFF
--- a/docs/comparisons/README.md
+++ b/docs/comparisons/README.md
@@ -23,6 +23,7 @@ Each page follows the same structure:
 | [Long context windows](./vs-long-context.md) | "Claude has 1M context / Gemini has 2M — why compress?" |
 | [Generic RAG over a codebase](./vs-rag.md) | "Isn't this just RAG with extra steps?" |
 | [Tree-sitter / ctags / grep](./vs-treesitter-ctags.md) | "Why do I need embeddings at all?" |
+| [graphify](./vs-graphify.md) | "Isn't graphify's knowledge graph the same thing, and now with a review/governance tier too?" |
 | [Headroom](./vs-headroom.md) | "Isn't a compression layer between my agent and the LLM enough?" |
 | [Context Engineering Stack (NeuralMind + Ponytail + Headroom)](./context-engineering-stack.md) | "How do I deploy all three tools together as an end-to-end pipeline?" |
 

--- a/docs/comparisons/vs-graphify.md
+++ b/docs/comparisons/vs-graphify.md
@@ -1,0 +1,131 @@
+---
+title: "NeuralMind vs. graphify — code-context retrieval or a general knowledge-graph engine with a code-review layer?"
+description: "Honest comparison of NeuralMind and Graphify-Labs' graphify for AI coding agents: purpose-built retrieval + learned team memory vs. a general corpus-to-knowledge-graph engine now shipping an enterprise code-review/governance tier. When to pick which."
+---
+
+# NeuralMind vs. graphify
+
+> **TL;DR** — graphify started as a general "turn any corpus into a
+> knowledge graph" tool and NeuralMind's built-in backend was designed to
+> read its `graph.json` output as an optional richer alternative to our
+> own tree-sitter graph. As of August 2026 that relationship is one-sided:
+> graphify (now built by **Graphify-Labs**, a YC S26 company) has grown
+> into a large, actively-shipped project with its own enterprise tier —
+> merge-gate verification, graph-aware code review, engineering digest,
+> self-hosted deployment — that overlaps NeuralMind's positioning
+> directly, and its own docs no longer reference NeuralMind. We still
+> treat it as interoperable at the file-format level (a graphify-produced
+> `graph.json` is read automatically when present), but it is a
+> **competitor for the AI-coding-agent context/governance niche**, not
+> merely an optional backend. Assessed August 2026 — Graphify-Labs ships
+> daily; re-check before relying on specifics.
+
+## What graphify is
+
+[graphify](https://github.com/Graphify-Labs/graphify) (Apache 2.0,
+`pip install graphifyy`) turns a corpus — code, docs, papers, images,
+video — into a knowledge graph with community detection, an audit trail
+(EXTRACTED / INFERRED / AMBIGUOUS edge tagging), and exports to
+Obsidian, Neo4j, GraphML, and SVG. Its extraction pipeline combines a
+free, deterministic AST pass for code with an LLM-driven semantic pass
+for everything else (and for code relationships an AST pass alone can't
+see), which is what gives it broader-than-code reach that NeuralMind
+doesn't attempt.
+
+Originally a solo project (`github.com/safishamsi/graphify`), it now
+lives under the **Graphify-Labs** GitHub organization — a Y Combinator
+S26 company pitching *"on-device knowledge graph engine for
+enterprises."* The OSS core stayed free and relicensed from MIT to
+Apache 2.0. `graphify.com` lists a paid **Enterprise (Early Access)**
+tier — no public price — adding merge-gate verification, graph-aware
+code review, an engineering digest, and self-hosted deployment. As of
+this writing it reports 100K+ GitHub stars and a daily release cadence
+(v0.9.44 → v0.9.48 in less than a week); we flag the star count as
+large enough to warrant skepticism about organic growth rather than
+treat it as settled fact, while the fork count (10K+, harder to
+inflate) still points to real adoption.
+
+## How NeuralMind differs
+
+The two tools now answer overlapping but distinct questions:
+
+- **graphify:** "build a knowledge graph of *anything* I point it at,
+  with a human-auditable trail of what's certain vs. inferred" — and,
+  increasingly, "gate merges and reviews on that graph."
+- **NeuralMind:** "give an AI coding agent the least possible context to
+  answer a code question correctly, and remember what it learns about
+  *this* codebase across sessions and across every agent you use."
+
+NeuralMind's scope is deliberately narrower — code only, retrieval and
+compression only — in exchange for things graphify's general-purpose
+design doesn't do: a learned Hebbian synapse layer that strengthens
+associations from actual usage (not just extraction-time inference),
+PostToolUse hooks that compress `Read`/`Bash`/`Grep` output in-session,
+and git-portable team memory that any MCP-compatible agent can read, not
+just the ones graphify's own CLI targets.
+
+| Dimension | graphify | NeuralMind |
+|---|---|---|
+| Corpus scope | Code, docs, papers, images, video — anything | Code only |
+| Extraction | AST (free) + LLM semantic pass (costs tokens, requires a model) | Tree-sitter, deterministic, no LLM required to build the index |
+| Edge provenance | EXTRACTED / INFERRED / AMBIGUOUS audit trail | Not tracked the same way — retrieval scores, not edge-confidence tags |
+| Learned/usage-based memory | No — graph reflects extraction time, not usage | Yes — Hebbian synapse layer strengthens from real query/edit activity, with decay |
+| Cross-session team memory | No | Yes — git-portable `.neuralmind-team-memory.json`, importable by any teammate's agent |
+| Tool-output compression | No | Yes — PostToolUse hooks (`Read`/`Bash`/`Grep`) |
+| Agent integration | Own CLI/MCP server, exports to Obsidian/Neo4j/etc. | MCP server + Claude Code hooks; any MCP-compatible agent |
+| Paid tier | Enterprise (Early Access) — merge-gate verification, graph-aware review, engineering digest, self-hosted; no public price | Team ($29/user/mo) — seats beyond one, priority support, annual invoice; every feature runs free at 1 seat |
+| Backing | Y Combinator (S26), organizational | Bootstrapped, solo maintainer |
+| License | Apache 2.0 | MIT (core); source-available commercial modules for the Team tier |
+
+## When to pick which
+
+**Pick graphify if:**
+
+- Your corpus is broader than code — research papers, meeting notes,
+  screenshots, a personal knowledge base — and you want one graph across
+  all of it.
+- You want a visual, exportable graph (Obsidian vault, Neo4j, GraphML)
+  as a first-class deliverable, not just an internal retrieval index.
+- You're evaluating merge-gate or graph-aware-review tooling and want to
+  see what a funded, actively-shipping team is building in that space.
+
+**Pick NeuralMind if:**
+
+- Your problem is specifically "an AI coding agent needs less context,
+  cheaper, and should get smarter about this codebase the more it's
+  used" — not general corpus-to-graph.
+- You run multiple agents (Claude Code, Cursor, Cline, Codex) against
+  the same repo and want one memory they all reinforce, portable via
+  git rather than tied to one tool's cloud or local state.
+- You want every feature evaluable free at one seat, with a published,
+  CI-gated reduction benchmark rather than an early-access enterprise
+  tier with no public terms yet.
+
+**They're still interoperable at the file level** — a graphify-produced
+`graph.json` is read automatically by NeuralMind's built-in backend when
+present and takes priority over ours. That plumbing predates graphify's
+pivot and, as far as we've verified, still works; it just no longer
+implies any relationship on graphify's side, and their own docs make no
+mention of NeuralMind.
+
+## The honest caveats
+
+- We have not built or run a reproducible retrieval benchmark against
+  graphify (see [`evals/public/COMPETITORS.md`](../../evals/public/COMPETITORS.md)
+  for why: its extraction pipeline calls an LLM for the semantic pass,
+  which makes a single pinned, reproducible run harder to define fairly
+  than a static binary like `codebase-memory-mcp`). Everything above is
+  a capability comparison, not a scored head-to-head.
+- graphify's Enterprise tier has no public price and is labeled "early
+  access" — we don't know if it converts to real revenue any better than
+  NeuralMind's Team tier does. Treat "funded and shipping" as a
+  distribution/attention signal, not proof of a working business model.
+- The star count is unusually large for the repo's age; we flag rather
+  than certify it. Don't cite it as settled evidence of user count.
+
+## See also
+
+- [vs. Tree-sitter / ctags / grep](./vs-treesitter-ctags.md) — the
+  deterministic-extraction end of this comparison
+- [vs. Generic RAG](./vs-rag.md) — retrieval-side alternatives
+- [All comparisons](./README.md)

--- a/evals/public/COMPETITORS.md
+++ b/evals/public/COMPETITORS.md
@@ -1,7 +1,8 @@
 # Competitor benchmarks — what's reproducibly scorable, and what isn't
 
 The recurring critique asks for scored head-to-heads vs Bloop, Sourcegraph Cody,
-Continue/Cline, and Tejas Headroom. We run exactly one **live, scored** competitor
+Continue/Cline, Tejas Headroom, and (as of August 2026) graphify. We run exactly
+one **live, scored** competitor
 today (`codebase-memory-mcp`) and we're honest about why the others aren't here yet:
 a fair, *reproducible* retrieval benchmark needs a competitor that can be driven
 **headless, on a pinned repo, with no account**, and that returns ranked files we
@@ -20,6 +21,7 @@ exact blocker is named so a contributor knows what it would take.
 | **Sourcegraph Cody** | ✗ **account-gated** | Server-hosted, org-wide code context | Cody's context API requires a Sourcegraph instance + auth token; results depend on server-side indexing we can't pin per-commit. Not reproducible without an account, so any number would be unauditable. |
 | **Continue / Cline** | ✗ **no headless retrieval** | IDE agent runtimes (VS Code / JetBrains extensions) | These are *agent runtimes* that consume a context layer; they expose no headless "retrieve files for this query" CLI to score in isolation. The honest comparison is architectural (see [`docs/comparisons/vs-continue-cline.md`](../../docs/comparisons/vs-continue-cline.md)), not a retrieval head-to-head. |
 | **Tejas Headroom** | ✗ **wrong axis** | Universal context **compression** proxy | Headroom compresses what flows to the model; it is not a code *retriever* and returns no ranked file list, so gold-file recall doesn't apply. The right comparison is **compression ratio at fixed fidelity**, a different benchmark — tracked separately. See [`docs/comparisons/vs-headroom.md`](../../docs/comparisons/vs-headroom.md). |
+| **graphify** (Graphify-Labs) | ◐ **not yet integrated** | General corpus→knowledge-graph engine (Apache 2.0), now with an unpriced enterprise merge-gate/code-review tier | Its extraction pipeline runs an LLM in the loop for the semantic pass (per its own docs), not just a static headless binary — pinning a single fair, reproducible run needs more care than `codebase-memory-mcp`'s single-invocation binary and hasn't been attempted yet. Capability comparison only for now: [`docs/comparisons/vs-graphify.md`](../../docs/comparisons/vs-graphify.md). Contribution-ready if someone works out a reproducible invocation. |
 
 ## The fairness contract (any new competitor must meet it)
 


### PR DESCRIPTION
## What

Follow-up to #449 (pure factual correction: graphify moved to the Graphify-Labs org, relicensed MIT → Apache-2.0). This PR makes the strategic call that correction surfaced: Graphify-Labs (YC S26) ships an unpriced **Enterprise (Early Access)** tier — merge-gate verification, graph-aware code review, engineering digest, self-hosted — that overlaps NeuralMind's own governance-layer positioning directly, and graphify's own docs no longer reference NeuralMind at all. The "optional complementary backend" framing undersold how much the two now compete for the same evaluator attention.

Gives graphify the same treatment already given Cody/Bloop/Continue/Headroom:

- **New:** `docs/comparisons/vs-graphify.md` — full comparison page. Explicit about what's verified (Apache-2.0 relicense, YC batch/pitch, enterprise feature list, fork count) vs. flagged-not-verified (the 108K-star count's authenticity — that growth rate over ~4.5 months warrants skepticism even though it's API-confirmed and not a scraping artifact; whether "early access" ever converts to real revenue).
- `docs/comparisons/README.md` — indexed alongside the other 14 pages.
- `evals/public/COMPETITORS.md` — added as a **tracked, currently-unscored** row. Its extraction pipeline runs an LLM in the loop for the semantic pass (per graphify's own docs), which needs more careful reproducible-invocation design than a static binary like `codebase-memory-mcp` before it can be scored fairly under the fairness contract — flagged as a real blocker and contribution-ready, not an excuse.

File-format interop (an optional graphify-produced `graph.json` is still read and prioritized when present) is unchanged — only the competitive framing changed.

## Why now

This came out of a competitor/monetization reassessment (2026-08-21) that found graphify had pivoted from a solo MIT side-tool to a funded org running the identical open-core-into-governance-tier motion NeuralMind uses, in the same lane. User call: reposition now rather than wait for a public price or a head-to-head benchmark.

## Verification

`scripts/check_commercial_terms.py` passes; both new cross-links resolve; `vs-graphify.md` intentionally not added to the site sitemap, matching every other `vs-*.md` comparison page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)