### PR TITLE
feat(site): rebuild the marketing site design system

### DIFF
--- a/site/src/app/effectiveness/page.tsx
+++ b/site/src/app/effectiveness/page.tsx
@@ -47,10 +47,6 @@ export default function EffectivenessPage() {
             <Navbar />
             <main>
                 <section className="relative pt-32 pb-16 md:py-40 px-4 md:px-6 overflow-hidden">
-                    <div className="absolute inset-0 -z-10">
-                        <div className="absolute top-1/4 -left-1/4 w-[600px] h-[600px] bg-electric/5 rounded-full blur-[120px]" />
-                        <div className="absolute bottom-1/4 -right-1/4 w-[600px] h-[600px] bg-proton/5 rounded-full blur-[120px]" />
-                    </div>
                     <div className="max-w-4xl mx-auto text-center">
                         <span className="text-electric text-sm font-semibold tracking-wider uppercase mb-3 block">
                             Measured, Not Marketed
@@ -66,12 +62,11 @@ export default function EffectivenessPage() {
                 </section>
 
                 <section className="relative py-16 md:py-32 px-4 md:px-6">
-                    <div className="absolute top-1/3 right-0 w-[500px] h-[500px] bg-proton/3 rounded-full blur-[200px] -z-10" />
                     <div className="max-w-5xl mx-auto">
                         <div className="grid sm:grid-cols-2 lg:grid-cols-4 gap-4">
                             {headlineStats.map((s) => (
-                                <div key={s.label} className="glow-card rounded-2xl p-6">
-                                    <p className="text-slate-500 text-xs font-semibold uppercase tracking-wider mb-2">{s.label}</p>
+                                <div key={s.label} className="card rounded-2xl p-6">
+                                    <p className="text-faint text-xs font-semibold uppercase tracking-wider mb-2">{s.label}</p>
                                     <p className={`font-display text-3xl font-bold mb-1 ${s.gradient ? 'gradient-text' : 'text-white'}`}>{s.value}</p>
                                     <p className="text-slate-400 text-sm">{s.detail}</p>
                                 </div>
@@ -81,7 +76,6 @@ export default function EffectivenessPage() {
                 </section>
 
                 <section className="relative py-16 md:py-32 px-4 md:px-6">
-                    <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[600px] h-[600px] bg-electric/3 rounded-full blur-[200px] -z-10" />
                     <div className="max-w-5xl mx-auto">
                         <div className="text-center mb-12 md:mb-16">
                             <span className="text-electric text-sm font-semibold tracking-wider uppercase mb-3 block">Before / After</span>
@@ -90,7 +84,7 @@ export default function EffectivenessPage() {
                                 Full rebuild on a real production CRM codebase
                             </p>
                         </div>
-                        <div className="glow-card rounded-2xl p-6 md:p-8 overflow-hidden">
+                        <div className="card rounded-2xl p-6 md:p-8 overflow-hidden">
                             <table className="w-full text-sm">
                                 <thead>
                                     <tr className="border-b border-carbon-border">
@@ -104,7 +98,7 @@ export default function EffectivenessPage() {
                                     {beforeAfter.map((row, i) => (
                                         <tr key={row.metric} className={i < beforeAfter.length - 1 ? 'border-b border-carbon-border/50' : ''}>
                                             <td className="py-3 px-4">{row.metric}</td>
-                                            <td className="py-3 px-4 text-right font-mono text-slate-500">{row.before}</td>
+                                            <td className="py-3 px-4 text-right font-mono text-faint">{row.before}</td>
                                             <td className="py-3 px-4 text-right font-mono">{row.after}</td>
                                             <td className="py-3 px-4 text-right font-mono text-electric-bright">{row.change}</td>
                                         </tr>
@@ -124,13 +118,13 @@ export default function EffectivenessPage() {
                             </h2>
                         </div>
                         <div className="grid md:grid-cols-2 gap-4">
-                            <div className="glow-card rounded-2xl p-6">
-                                <p className="text-slate-500 text-xs font-semibold uppercase tracking-wider mb-2">Full Rebuild</p>
+                            <div className="card rounded-2xl p-6">
+                                <p className="text-faint text-xs font-semibold uppercase tracking-wider mb-2">Full Rebuild</p>
                                 <p className="font-display text-3xl font-bold text-white mb-1">326s</p>
                                 <p className="text-slate-400 text-sm">All nodes, edges, embeddings</p>
                             </div>
-                            <div className="glow-card rounded-2xl p-6">
-                                <p className="text-slate-500 text-xs font-semibold uppercase tracking-wider mb-2">Incremental (after)</p>
+                            <div className="card rounded-2xl p-6">
+                                <p className="text-faint text-xs font-semibold uppercase tracking-wider mb-2">Incremental (after)</p>
                                 <p className="font-display text-3xl font-bold text-white mb-1">~30s</p>
                                 <p className="text-slate-400 text-sm">Changed files + dependents only</p>
                             </div>
@@ -148,7 +142,7 @@ export default function EffectivenessPage() {
                         </div>
                         <div className="space-y-3">
                             {honestyGate.map((item) => (
-                                <div key={item.title} className="glow-card rounded-2xl p-6">
+                                <div key={item.title} className="card rounded-2xl p-6">
                                     <h3 className="font-display text-xl font-bold text-white mb-2">{item.title}</h3>
                                     <p className="text-slate-400 text-sm">{item.body}</p>
                                 </div>
@@ -159,7 +153,7 @@ export default function EffectivenessPage() {
 
                 <section className="relative py-16 md:py-32 px-4 md:px-6">
                     <div className="max-w-5xl mx-auto">
-                        <div className="glow-card rounded-2xl p-6 md:p-8 flex flex-col md:flex-row items-center justify-between gap-6">
+                        <div className="card rounded-2xl p-6 md:p-8 flex flex-col md:flex-row items-center justify-between gap-6">
                             <div>
                                 <h3 className="font-display text-2xl font-bold text-white mb-2">See it in 30 seconds</h3>
                                 <p className="text-slate-400 text-sm">

--- a/site/src/app/field-reports/measure-memory-across-a-refactor/page.tsx
+++ b/site/src/app/field-reports/measure-memory-across-a-refactor/page.tsx
@@ -146,7 +146,7 @@ export default function FieldReportPage() {
                 <header className="mb-12 pb-8 border-b border-carbon-border">
                     <div className="flex items-center gap-3 mb-4 flex-wrap">
                         <span className="px-3 py-1 rounded-lg bg-proton/10 text-proton text-xs font-mono">Field Report — not CI-gated</span>
-                        <span className="text-slate-500 text-sm">July 20, 2026</span>
+                        <span className="text-faint text-sm">July 20, 2026</span>
                     </div>
                     <h1 className="font-display text-3xl md:text-4xl font-bold text-white mb-4 leading-tight">
                         Measuring AI agent memory across a major refactor
@@ -173,18 +173,18 @@ export default function FieldReportPage() {
                 {/* Headline stats */}
                 <section className="mb-10">
                     <div className="grid sm:grid-cols-3 gap-4">
-                        <div className="glow-card rounded-2xl p-6">
-                            <p className="text-slate-500 text-xs font-semibold uppercase tracking-wider mb-2">Avg token reduction</p>
+                        <div className="card rounded-2xl p-6">
+                            <p className="text-faint text-xs font-semibold uppercase tracking-wider mb-2">Avg token reduction</p>
                             <p className="font-display text-3xl font-bold text-white mb-1">48.8×</p>
                             <p className="text-slate-400 text-sm">~1,033 tokens/query vs 50K+ naive</p>
                         </div>
-                        <div className="glow-card rounded-2xl p-6">
-                            <p className="text-slate-500 text-xs font-semibold uppercase tracking-wider mb-2">Personal synapse edges</p>
+                        <div className="card rounded-2xl p-6">
+                            <p className="text-faint text-xs font-semibold uppercase tracking-wider mb-2">Personal synapse edges</p>
                             <p className="font-display text-3xl font-bold text-white mb-1">36 → 135</p>
                             <p className="text-slate-400 text-sm">the learning layer tracked the new code</p>
                         </div>
-                        <div className="glow-card rounded-2xl p-6">
-                            <p className="text-slate-500 text-xs font-semibold uppercase tracking-wider mb-2">Full rebuild</p>
+                        <div className="card rounded-2xl p-6">
+                            <p className="text-faint text-xs font-semibold uppercase tracking-wider mb-2">Full rebuild</p>
                             <p className="font-display text-3xl font-bold text-white mb-1">326 s</p>
                             <p className="text-slate-400 text-sm">then back to ~30 s incremental</p>
                         </div>
@@ -305,7 +305,7 @@ export default function FieldReportPage() {
                             <h3 className="text-lg font-semibold text-white mb-2">1. Snapshot before you start</h3>
                             <div className="bg-carbon rounded-lg p-4 font-mono text-sm text-slate-300 overflow-x-auto">
                                 <p>neuralmind stats . --json &gt; .neuralmind-before.json</p>
-                                <p>neuralmind benchmark .      <span className="text-slate-500"># baseline reduction number</span></p>
+                                <p>neuralmind benchmark .      <span className="text-faint"># baseline reduction number</span></p>
                             </div>
                         </div>
                         <div>
@@ -315,7 +315,7 @@ export default function FieldReportPage() {
                             </p>
                             <div className="bg-carbon rounded-lg p-4 font-mono text-sm text-slate-300 overflow-x-auto">
                                 <p>neuralmind install-hooks .</p>
-                                <p>neuralmind watch &amp;   <span className="text-slate-500"># optional: always-on learning from edits</span></p>
+                                <p>neuralmind watch &amp;   <span className="text-faint"># optional: always-on learning from edits</span></p>
                             </div>
                         </div>
                         <div>
@@ -328,8 +328,8 @@ export default function FieldReportPage() {
                         <div>
                             <h3 className="text-lg font-semibold text-white mb-2">4. Re-benchmark and price it</h3>
                             <div className="bg-carbon rounded-lg p-4 font-mono text-sm text-slate-300 overflow-x-auto">
-                                <p>neuralmind benchmark .   <span className="text-slate-500"># reduction on the post-refactor graph</span></p>
-                                <p>neuralmind savings .     <span className="text-slate-500"># what your logged queries cost vs naive</span></p>
+                                <p>neuralmind benchmark .   <span className="text-faint"># reduction on the post-refactor graph</span></p>
+                                <p>neuralmind savings .     <span className="text-faint"># what your logged queries cost vs naive</span></p>
                             </div>
                         </div>
                         <p className="text-slate-300 leading-relaxed">

--- a/site/src/app/globals.css
+++ b/site/src/app/globals.css
@@ -2,11 +2,26 @@
 @tailwind components;
 @tailwind utilities;
 
+/* ---------------------------------------------------------------------------
+   Palette. Mirrors tailwind.config.ts so raw CSS below and Tailwind classes
+   in components can never drift apart.
+   --------------------------------------------------------------------------- */
 :root {
-    --bg: #070b15;
-    --bg-raised: #0c1322;
-    --bg-card: #0e1626;
-    --border: #1b2740;
+    --bg: #0a0b0d;
+    --bg-raised: #0f1114;
+    --bg-card: #131518;
+    --border: #22262c;
+    --border-strong: #2e333b;
+
+    --text: #e8eaed;
+    --text-muted: #9aa3af;
+    --text-faint: #7e8794;
+
+    --accent: #5b8cff;
+    --accent-bright: #93b4ff;
+    --accent-dim: #1b2742;
+
+    --evidence: #4fd1a5;
 }
 
 * {
@@ -16,68 +31,202 @@
 
 html {
     scroll-behavior: smooth;
+    /* The fixed navbar is 65px tall; without this every in-page anchor lands
+       with its heading tucked underneath it. */
+    scroll-padding-top: 6rem;
     background: var(--bg);
-    color: #e2e8f0;
+    color: var(--text);
 }
 
 body {
-    font-family: 'Inter', system-ui, sans-serif;
+    font-family: var(--font-sans), ui-sans-serif, system-ui, sans-serif;
     background: var(--bg);
+    /* Inter's tabular figures make every measured number on the site line up
+       column-to-column instead of wobbling on the 1s. */
+    font-feature-settings: 'cv05' 1, 'ss01' 1;
 }
 
-.gradient-text {
-    background: linear-gradient(135deg, #60a5fa 0%, #a78bfa 40%, #f472b6 100%);
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
+/* ---------------------------------------------------------------------------
+   Typography
+   --------------------------------------------------------------------------- */
+
+h1, h2, h3, h4 {
+    letter-spacing: -0.03em;
+    /* Stops the last word of a headline from stranding on its own line. */
+    text-wrap: balance;
 }
 
-.glow-card {
-    background: linear-gradient(135deg, rgba(14, 22, 38, 0.9) 0%, rgba(12, 19, 34, 0.9) 100%);
-    border: 1px solid rgba(27, 39, 64, 0.6);
-    backdrop-filter: blur(12px);
-    transition: all 0.3s ease;
+h1 {
+    letter-spacing: -0.045em;
 }
 
-.glow-card:hover {
-    border-color: rgba(96, 165, 250, 0.4);
-    box-shadow: 0 0 40px rgba(96, 165, 250, 0.08);
+p {
+    text-wrap: pretty;
 }
+
+code, pre, kbd {
+    font-feature-settings: 'zero' 1;
+}
+
+::selection {
+    background: rgba(91, 140, 255, 0.28);
+    color: #ffffff;
+}
+
+/* ---------------------------------------------------------------------------
+   Focus. The previous stylesheet had no focus treatment at all, so keyboard
+   users navigated the site by the browser's default outline over a dark
+   background — effectively invisible.
+   --------------------------------------------------------------------------- */
+
+:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+    border-radius: 4px;
+}
+
+:focus:not(:focus-visible) {
+    outline: none;
+}
+
+/* ---------------------------------------------------------------------------
+   Surfaces
+
+   `.card` replaces the old `.glow-card`: no backdrop blur, no coloured drop
+   shadow, no 40px halo on hover. A hairline that brightens is enough to say
+   "this is a distinct thing", and it survives being repeated fifteen times
+   down a page, which a glow does not.
+   --------------------------------------------------------------------------- */
+
+.card {
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    transition: border-color 0.18s ease, background-color 0.18s ease;
+}
+
+.card:hover {
+    border-color: var(--border-strong);
+    background: #16191d;
+}
+
+/* Non-interactive panels: same surface, no hover affordance, because a card
+   that lights up but cannot be clicked is a lie about what it does. */
+.panel {
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+}
+
+.panel-accent {
+    background: linear-gradient(180deg, rgba(91, 140, 255, 0.07) 0%, var(--bg-card) 60%);
+    border: 1px solid var(--accent-dim);
+}
+
+/* A hairline rule that fades at both ends — used to separate major sections
+   without drawing a hard box around them. */
+.rule {
+    height: 1px;
+    background: linear-gradient(90deg, transparent, var(--border) 25%, var(--border) 75%, transparent);
+}
+
+/* ---------------------------------------------------------------------------
+   Buttons
+   --------------------------------------------------------------------------- */
 
 .btn-primary {
-    background: linear-gradient(135deg, #3b82f6 0%, #6366f1 100%);
-    color: white;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    background: var(--accent);
+    color: #05070d;
     font-weight: 600;
-    padding: 0.75rem 2rem;
-    border-radius: 0.75rem;
-    transition: all 0.2s ease;
-    box-shadow: 0 4px 20px rgba(59, 130, 246, 0.3);
+    letter-spacing: -0.01em;
+    padding: 0.625rem 1.25rem;
+    border-radius: 0.5rem;
+    border: 1px solid transparent;
+    transition: background-color 0.15s ease, color 0.15s ease;
 }
 
 .btn-primary:hover {
-    transform: translateY(-1px);
-    box-shadow: 0 6px 30px rgba(59, 130, 246, 0.5);
+    background: var(--accent-bright);
+}
+
+.btn-primary:active {
+    background: #4a7bee;
 }
 
 .btn-secondary {
-    background: rgba(255, 255, 255, 0.04);
-    color: #e2e8f0;
-    font-weight: 600;
-    padding: 0.75rem 2rem;
-    border-radius: 0.75rem;
-    border: 1px solid var(--border);
-    transition: all 0.2s ease;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    background: transparent;
+    color: var(--text);
+    font-weight: 550;
+    letter-spacing: -0.01em;
+    padding: 0.625rem 1.25rem;
+    border-radius: 0.5rem;
+    border: 1px solid var(--border-strong);
+    transition: border-color 0.15s ease, background-color 0.15s ease;
 }
 
 .btn-secondary:hover {
-    border-color: rgba(96, 165, 250, 0.4);
-    color: #ffffff;
+    background: rgba(255, 255, 255, 0.035);
+    border-color: #3a414a;
+}
+
+/* ---------------------------------------------------------------------------
+   Text emphasis
+
+   Was a blue → violet → pink clip-path gradient. That three-stop gradient is
+   the single most recognisable marker of a generated landing page, and it
+   made the site's headline numbers — the ones the whole positioning rests on
+   — look decorative rather than measured. Emphasis is now a solid colour.
+   --------------------------------------------------------------------------- */
+
+.gradient-text {
+    color: var(--accent-bright);
+}
+
+/* Numbers that were measured. Mono + tabular figures, so a table of them
+   aligns and reads as data rather than as marketing. */
+.metric {
+    font-family: var(--font-mono), ui-monospace, monospace;
+    font-variant-numeric: tabular-nums;
+    letter-spacing: -0.03em;
+}
+
+/* Small uppercase section label. */
+.eyebrow {
+    font-family: var(--font-mono), ui-monospace, monospace;
+    font-size: 0.6875rem;
+    font-weight: 500;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--text-faint);
+}
+
+/* ---------------------------------------------------------------------------
+   Texture
+
+   Replaces the six 200px-blurred blue and purple radial blobs that sat behind
+   every section. A 72px hairline grid reads as instrumentation rather than
+   atmosphere, and it does not cost a repaint on scroll.
+   --------------------------------------------------------------------------- */
+
+.grid-bg {
+    background-image:
+        linear-gradient(to right, rgba(255, 255, 255, 0.028) 1px, transparent 1px),
+        linear-gradient(to bottom, rgba(255, 255, 255, 0.028) 1px, transparent 1px);
+    background-size: 72px 72px;
+    mask-image: radial-gradient(ellipse 90% 60% at 50% 0%, #000 20%, transparent 75%);
+    -webkit-mask-image: radial-gradient(ellipse 90% 60% at 50% 0%, #000 20%, transparent 75%);
 }
 
 .section-reveal {
     opacity: 0;
-    transform: translateY(20px);
-    transition: all 0.6s ease;
+    transform: translateY(12px);
+    transition: opacity 0.5s ease, transform 0.5s cubic-bezier(0.16, 1, 0.3, 1);
 }
 
 .section-reveal.visible {
@@ -86,17 +235,22 @@ body {
 }
 
 .tag-rotate {
-    animation: tagRoll 0.5s ease-out;
     display: inline-block;
+    animation: tagRoll 0.4s cubic-bezier(0.16, 1, 0.3, 1);
 }
 
 @keyframes tagRoll {
-    0% { opacity: 0; transform: translateY(20px); }
+    0% { opacity: 0; transform: translateY(8px); }
     100% { opacity: 1; transform: translateY(0); }
 }
 
+/* ---------------------------------------------------------------------------
+   Scrollbar
+   --------------------------------------------------------------------------- */
+
 ::-webkit-scrollbar {
-    width: 8px;
+    width: 10px;
+    height: 10px;
 }
 
 ::-webkit-scrollbar-track {
@@ -105,9 +259,34 @@ body {
 
 ::-webkit-scrollbar-thumb {
     background: var(--border);
-    border-radius: 4px;
+    border: 2px solid var(--bg);
+    border-radius: 6px;
 }
 
 ::-webkit-scrollbar-thumb:hover {
-    background: rgba(96, 165, 250, 0.4);
+    background: var(--border-strong);
+}
+
+/* ---------------------------------------------------------------------------
+   Motion preferences. Previously unhandled: the hero's pulsing status dot and
+   every reveal animated regardless of the OS setting.
+   --------------------------------------------------------------------------- */
+
+@media (prefers-reduced-motion: reduce) {
+    html {
+        scroll-behavior: auto;
+    }
+
+    *,
+    *::before,
+    *::after {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+    }
+
+    .section-reveal {
+        opacity: 1;
+        transform: none;
+    }
 }

--- a/site/src/app/globals.css
+++ b/site/src/app/globals.css
@@ -31,8 +31,10 @@
 
 html {
     scroll-behavior: smooth;
-    /* The fixed navbar is 65px tall; without this every in-page anchor lands
-       with its heading tucked underneath it. */
+    /* The fixed navbar is 65px tall (h-16 plus its hairline), so without this
+       every in-page anchor lands with its heading tucked underneath it. The
+       value is deliberately larger than the bar: clearing it exactly leaves
+       the heading flush against the bar with no breathing room. */
     scroll-padding-top: 6rem;
     background: var(--bg);
     color: var(--text);

--- a/site/src/app/layout.tsx
+++ b/site/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import './globals.css';
 import { getLatestRelease } from '@/lib/release';
+import { fontVariables } from '@/lib/fonts';
 
 export const metadata = {
     title: 'NeuralMind — Code Memory for AI Coding Agents | 93.75% Gold-File Recall',
@@ -121,13 +122,13 @@ export default async function RootLayout({ children }: { children: React.ReactNo
     const rel = await getLatestRelease();
     const jsonLd = buildJsonLd(rel.tag.replace(/^v/, ''), rel.date);
     return (
-        <html lang="en">
+        <html lang="en" className={fontVariables}>
             <head>
                 <link rel="icon" href="/favicon.ico" sizes="any" />
                 <link rel="icon" href="/icon.svg" type="image/svg+xml" />
                 <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
                 <link rel="manifest" href="/site.webmanifest" />
-                <meta name="theme-color" content="#0c0c0c" />
+                <meta name="theme-color" content="#0a0b0d" />
                 {!process.env.NODE_ENV || process.env.NODE_ENV === 'production' ? (
                     <script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "97b18db165e64f6e8d1d75b5e4e16447"}'></script>
                 ) : null}
@@ -136,7 +137,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
                     dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
                 />
             </head>
-            <body className="bg-carbon text-slate-200 antialiased">{children}</body>
+            <body className="bg-carbon text-slate-200 font-sans antialiased">{children}</body>
         </html>
     );
 }

--- a/site/src/app/publications/budget-neutral-synaptic-recall/page.tsx
+++ b/site/src/app/publications/budget-neutral-synaptic-recall/page.tsx
@@ -97,7 +97,7 @@ export default function PublicationPage() {
                 <header className="mb-12 pb-8 border-b border-carbon-border">
                     <div className="flex items-center gap-3 mb-4">
                         <span className="px-3 py-1 rounded-lg bg-electric/10 text-electric text-xs font-mono">Defensive Publication</span>
-                        <span className="text-slate-500 text-sm">August 7, 2026</span>
+                        <span className="text-faint text-sm">August 7, 2026</span>
                     </div>
                     <h1 className="font-display text-3xl md:text-4xl font-bold text-white mb-4 leading-tight">
                         Budget-Neutral Synaptic Recall
@@ -203,7 +203,7 @@ export default function PublicationPage() {
                             Recall seeds energy at query-relevant nodes and propagates it outward for 2 hops. Edge weights merge across memory namespaces before propagation (active branch 1.0, personal 0.8, shared 0.5):
                         </p>
                         <div className="bg-carbon rounded-lg p-4 font-mono text-sm text-slate-300 mb-3 space-y-1 overflow-x-auto">
-                            <p>hub_factor(n) = sqrt(<span className="text-electric-bright">50</span> / degree(n))  <span className="text-slate-500">if degree(n) &gt; 50 else 1.0</span></p>
+                            <p>hub_factor(n) = sqrt(<span className="text-electric-bright">50</span> / degree(n))  <span className="text-faint">if degree(n) &gt; 50 else 1.0</span></p>
                             <p>propagated = energy × merged_weight × <span className="text-electric-bright">0.6</span> × hub_factor</p>
                         </div>
                         <p className="text-slate-300">
@@ -218,9 +218,9 @@ export default function PublicationPage() {
                             Activation energies fold into the vector result list under a hard invariant — <strong className="text-white">the result count never grows</strong>:
                         </p>
                         <div className="bg-carbon rounded-lg p-4 font-mono text-sm text-slate-300 mb-3 space-y-1 overflow-x-auto">
-                            <p><span className="text-slate-500">(a) BOOST:</span> score += <span className="text-electric-bright">0.3</span> × energy <span className="text-slate-500">for nodes already present; re-sort</span></p>
-                            <p><span className="text-slate-500">(b) DISPLACE:</span> swap ≤ <span className="text-electric-bright">2</span> absent nodes with energy ≥ <span className="text-electric-bright">0.15</span></p>
-                            <p className="ml-4"><span className="text-slate-500">in for the weakest vector hits, one-for-one; keep ≥ 1 original hit</span></p>
+                            <p><span className="text-faint">(a) BOOST:</span> score += <span className="text-electric-bright">0.3</span> × energy <span className="text-faint">for nodes already present; re-sort</span></p>
+                            <p><span className="text-faint">(b) DISPLACE:</span> swap ≤ <span className="text-electric-bright">2</span> absent nodes with energy ≥ <span className="text-electric-bright">0.15</span></p>
+                            <p className="ml-4"><span className="text-faint">in for the weakest vector hits, one-for-one; keep ≥ 1 original hit</span></p>
                         </div>
                         <p className="text-slate-300">
                             Because injection is one-for-one displacement, the context assembled downstream spends exactly the same token budget with or without the associative layer. When recall is unwired, disabled, or the graph is cold, output is <strong className="text-white">byte-identical</strong> to a build without a synapse store.
@@ -258,9 +258,9 @@ shared 0.5 × 0.5 = 0.25
                     </div>
 
                     <div className="bg-carbon rounded-lg p-4 font-mono text-sm text-slate-300 space-y-1 mb-4">
-                        <p><span className="text-slate-500">Result:</span> 8 hits in, 8 hits out — same token budget</p>
-                        <p><span className="text-slate-500">Gained:</span> <span className="text-electric-bright">config/secrets.py::load_keys</span> — lexically unrelated to &quot;auth&quot;, learned from co-use</p>
-                        <p><span className="text-slate-500">Dropped:</span> a docstring stub that matched on the word &quot;auth&quot;</p>
+                        <p><span className="text-faint">Result:</span> 8 hits in, 8 hits out — same token budget</p>
+                        <p><span className="text-faint">Gained:</span> <span className="text-electric-bright">config/secrets.py::load_keys</span> — lexically unrelated to &quot;auth&quot;, learned from co-use</p>
+                        <p><span className="text-faint">Dropped:</span> a docstring stub that matched on the word &quot;auth&quot;</p>
                     </div>
                 </section>
 
@@ -325,7 +325,7 @@ shared 0.5 × 0.5 = 0.25
 
                 {/* Footer */}
                 <footer className="mt-12 pt-8 border-t border-carbon-border text-center">
-                    <p className="text-slate-500 text-sm mb-2">
+                    <p className="text-faint text-sm mb-2">
                         This publication establishes prior art for the techniques described herein.
                     </p>
                     <a

--- a/site/src/app/publications/claude-teams-deep-dive/page.tsx
+++ b/site/src/app/publications/claude-teams-deep-dive/page.tsx
@@ -95,7 +95,7 @@ export default function PublicationPage() {
                 <header className="mb-12 pb-8 border-b border-carbon-border">
                     <div className="flex items-center gap-3 mb-4">
                         <span className="px-3 py-1 rounded-lg bg-electric/10 text-electric text-xs font-mono">Research Report</span>
-                        <span className="text-slate-500 text-sm">July 26, 2026</span>
+                        <span className="text-faint text-sm">July 26, 2026</span>
                     </div>
                     <h1 className="font-display text-3xl md:text-4xl font-bold text-white mb-4 leading-tight">
                         NeuralMind + Claude Teams
@@ -413,7 +413,7 @@ export default function PublicationPage() {
 
                 {/* Footer */}
                 <footer className="mt-12 pt-8 border-t border-carbon-border text-center">
-                    <p className="text-slate-500 text-sm mb-2">
+                    <p className="text-faint text-sm mb-2">
                         This report was verified against the live codebase and corrected by DeepSeek v4 Pro QA.
                     </p>
                     <a

--- a/site/src/app/publications/codex-setup/page.tsx
+++ b/site/src/app/publications/codex-setup/page.tsx
@@ -97,7 +97,7 @@ export default function PublicationPage() {
                 <header className="mb-12 pb-8 border-b border-carbon-border">
                     <div className="flex items-center gap-3 mb-4">
                         <span className="px-3 py-1 rounded-lg bg-electric/10 text-electric text-xs font-mono">How-To Guide</span>
-                        <span className="text-slate-500 text-sm">July 26, 2026</span>
+                        <span className="text-faint text-sm">July 26, 2026</span>
                     </div>
                     <h1 className="font-display text-3xl md:text-4xl font-bold text-white mb-4 leading-tight">
                         How to Use NeuralMind with OpenAI Codex
@@ -485,7 +485,7 @@ export default function PublicationPage() {
 
                 {/* Footer */}
                 <footer className="mt-12 pt-8 border-t border-carbon-border text-center">
-                    <p className="text-slate-500 text-sm mb-2">
+                    <p className="text-faint text-sm mb-2">
                         This guide was verified against the live codebase and corrected by DeepSeek v4 Pro QA.
                     </p>
                     <a

--- a/site/src/app/publications/page.tsx
+++ b/site/src/app/publications/page.tsx
@@ -100,7 +100,7 @@ export default function PublicationsIndex() {
                         >
                             <div className="flex items-center gap-3 mb-3">
                                 <span className="px-3 py-1 rounded-lg bg-electric/10 text-electric text-xs font-mono">{pub.type}</span>
-                                <span className="text-slate-500 text-sm">{pub.date}</span>
+                                <span className="text-faint text-sm">{pub.date}</span>
                             </div>
                             <h2 className="font-display text-xl font-bold text-white mb-2 group-hover:text-electric transition-colors">
                                 {pub.title}

--- a/site/src/app/publications/quality-weighted-merge/page.tsx
+++ b/site/src/app/publications/quality-weighted-merge/page.tsx
@@ -95,7 +95,7 @@ export default function PublicationPage() {
                 <header className="mb-12 pb-8 border-b border-carbon-border">
                     <div className="flex items-center gap-3 mb-4">
                         <span className="px-3 py-1 rounded-lg bg-electric/10 text-electric text-xs font-mono">Defensive Publication</span>
-                        <span className="text-slate-500 text-sm">July 22, 2026</span>
+                        <span className="text-faint text-sm">July 22, 2026</span>
                     </div>
                     <h1 className="font-display text-3xl md:text-4xl font-bold text-white mb-4 leading-tight">
                         Quality-Weighted Merge with Conflict-Driven Decay
@@ -205,12 +205,12 @@ export default function PublicationPage() {
                             When two bundles contain edges for the same <code className="text-electric-bright bg-carbon px-1.5 py-0.5 rounded text-sm">(source, target)</code> pair:
                         </p>
                         <div className="bg-carbon rounded-lg p-4 font-mono text-sm text-slate-300 mb-3 space-y-1 overflow-x-auto">
-                            <p><span className="text-slate-500">resolve(existing, incoming):</span></p>
-                            <p className="ml-4"><span className="text-slate-500">if</span> |existing.score − incoming.score| &lt; <span className="text-electric-bright">0.05</span> <span className="text-slate-500">AND</span> max(existing.score, incoming.score) &lt; <span className="text-electric-bright">0.30</span>:</p>
-                            <p className="ml-8"><span className="text-slate-500">return</span> CONTEST  <span className="text-slate-500">→ escalate to review</span></p>
-                            <p className="ml-4"><span className="text-slate-500">else:</span></p>
+                            <p><span className="text-faint">resolve(existing, incoming):</span></p>
+                            <p className="ml-4"><span className="text-faint">if</span> |existing.score − incoming.score| &lt; <span className="text-electric-bright">0.05</span> <span className="text-faint">AND</span> max(existing.score, incoming.score) &lt; <span className="text-electric-bright">0.30</span>:</p>
+                            <p className="ml-8"><span className="text-faint">return</span> CONTEST  <span className="text-faint">→ escalate to review</span></p>
+                            <p className="ml-4"><span className="text-faint">else:</span></p>
                             <p className="ml-8">winner = argmax(existing.score, incoming.score)</p>
-                            <p className="ml-8"><span className="text-slate-500">return</span> winner  <span className="text-slate-500">→ loser is dropped</span></p>
+                            <p className="ml-8"><span className="text-faint">return</span> winner  <span className="text-faint">→ loser is dropped</span></p>
                         </div>
                     </div>
 
@@ -252,7 +252,7 @@ export default function PublicationPage() {
                             Decay is applied as a <strong className="text-white">constant per-pass factor</strong> (not a cumulative formula):
                         </p>
                         <div className="bg-carbon rounded-lg p-4 font-mono text-sm text-slate-300 mb-3">
-                            <p><span className="text-slate-500">decay_factor</span> = 2<sup>(−fast_decay / half_life)</sup> = 2<sup>(−5/30)</sup> ≈ 0.891 <span className="text-slate-500">per pass</span></p>
+                            <p><span className="text-faint">decay_factor</span> = 2<sup>(−fast_decay / half_life)</sup> = 2<sup>(−5/30)</sup> ≈ 0.891 <span className="text-faint">per pass</span></p>
                         </div>
                         <p className="text-slate-300">
                             After 30 daily passes: <code className="text-electric-bright bg-carbon px-1.5 py-0.5 rounded text-sm">0.891³⁰ = 2<sup>−5</sup> = 1/32</code> — exactly 5× normal decay, <strong className="text-white">no compounding explosion</strong>.
@@ -291,9 +291,9 @@ export default function PublicationPage() {
                     </div>
 
                     <div className="bg-carbon rounded-lg p-4 font-mono text-sm text-slate-300 space-y-1 mb-4">
-                        <p><span className="text-slate-500">Difference:</span> 0.743 − 0.387 = 0.356 (&gt; 0.05, no contest)</p>
-                        <p><span className="text-slate-500">Winner:</span> Alice's edge (score 0.743)</p>
-                        <p><span className="text-slate-500">Result:</span> Bob's edge is excluded from the <span className="text-electric-bright">shared</span> namespace</p>
+                        <p><span className="text-faint">Difference:</span> 0.743 − 0.387 = 0.356 (&gt; 0.05, no contest)</p>
+                        <p><span className="text-faint">Winner:</span> Alice's edge (score 0.743)</p>
+                        <p><span className="text-faint">Result:</span> Bob's edge is excluded from the <span className="text-electric-bright">shared</span> namespace</p>
                     </div>
                 </section>
 
@@ -353,7 +353,7 @@ export default function PublicationPage() {
 
                 {/* Footer */}
                 <footer className="mt-12 pt-8 border-t border-carbon-border text-center">
-                    <p className="text-slate-500 text-sm mb-2">
+                    <p className="text-faint text-sm mb-2">
                         This publication establishes prior art for the techniques described herein.
                     </p>
                     <a

--- a/site/src/app/publications/synapse-learning-loop/page.tsx
+++ b/site/src/app/publications/synapse-learning-loop/page.tsx
@@ -96,7 +96,7 @@ export default function PublicationPage() {
                 <header className="mb-12 pb-8 border-b border-carbon-border">
                     <div className="flex items-center gap-3 mb-4">
                         <span className="px-3 py-1 rounded-lg bg-electric/10 text-electric text-xs font-mono">Defensive Publication</span>
-                        <span className="text-slate-500 text-sm">August 6, 2026</span>
+                        <span className="text-faint text-sm">August 6, 2026</span>
                     </div>
                     <h1 className="font-display text-3xl md:text-4xl font-bold text-white mb-4 leading-tight">
                         Hebbian Co-Activation with Long-Term Potentiation and Hub-Normalized Spreading Activation
@@ -260,7 +260,7 @@ export default function PublicationPage() {
                     </div>
                 </section>
 
-                <div className="border-t border-carbon-border pt-8 text-sm text-slate-500 italic">
+                <div className="border-t border-carbon-border pt-8 text-sm text-faint italic">
                     This publication establishes prior art for the techniques described herein. It is provided for defensive purposes and as technical documentation for the NeuralMind open-source project.
                 </div>
             </main>

--- a/site/src/app/security/page.tsx
+++ b/site/src/app/security/page.tsx
@@ -83,7 +83,7 @@ export default async function SecurityPage() {
                         </p>
                         <div className="bg-carbon rounded-lg p-4 font-mono text-xs text-slate-400 break-all overflow-x-auto">
                             <p className="mb-1">curl -sL {tarballUrl} | sha256sum</p>
-                            <p className="text-slate-500">Compare against the SHA-256 on the GitHub release page.</p>
+                            <p className="text-faint">Compare against the SHA-256 on the GitHub release page.</p>
                         </div>
                     </div>
                 </section>
@@ -146,7 +146,7 @@ export default async function SecurityPage() {
                 </section>
 
                 <div className="mt-12 pt-8 border-t border-carbon-border text-center">
-                    <p className="text-slate-500 text-sm">
+                    <p className="text-faint text-sm">
                         This page is updated quarterly, or on significant security events.
                     </p>
                     <a href={GITHUB_URL} target="_blank" rel="noopener noreferrer" className="text-electric hover:text-electric-bright text-sm transition-colors">

--- a/site/src/app/services/page.tsx
+++ b/site/src/app/services/page.tsx
@@ -205,7 +205,7 @@ export default function ServicesPage() {
                                 </li>
                             ))}
                         </ul>
-                        <p className="text-slate-500 text-xs leading-relaxed">
+                        <p className="text-faint text-xs leading-relaxed">
                             An engagement supports your evidence needs; it is not legal
                             advice, and no tool by itself makes an organization
                             compliant with any regulation.
@@ -225,7 +225,7 @@ export default function ServicesPage() {
                                     key={item}
                                     className="flex items-start gap-2 text-sm text-slate-300"
                                 >
-                                    <span className="text-slate-500 mt-0.5">✕</span>
+                                    <span className="text-faint mt-0.5">✕</span>
                                     <span>{item}</span>
                                 </li>
                             ))}
@@ -245,7 +245,7 @@ export default function ServicesPage() {
                     >
                         hello@neuralmind.uk
                     </a>
-                    <p className="text-slate-500 text-sm mt-6">
+                    <p className="text-faint text-sm mt-6">
                         Looking for self-serve? The software is free at 1 seat and the
                         Team tier is on the <a href="/pricing" className="text-electric hover:text-electric-bright">pricing page</a>.
                     </p>

--- a/site/src/app/team/page.tsx
+++ b/site/src/app/team/page.tsx
@@ -42,7 +42,7 @@ export default async function TeamPage() {
                         Shared codebase intelligence that learns how your team works —
                         with governance controls over what each developer publishes to the shared memory.
                     </p>
-                    <p className="text-slate-500 text-sm mt-3">
+                    <p className="text-faint text-sm mt-3">
                         Available in Team and Enterprise tiers •{' '}
                         <a
                             href="/pricing"
@@ -235,28 +235,28 @@ export default async function TeamPage() {
                         style={cardStyle}
                     >
                         <div className="font-mono text-sm text-slate-300 space-y-2">
-                            <p className="text-slate-500"># Add a team member</p>
+                            <p className="text-faint"># Add a team member</p>
                             <p>
                                 <span className="text-electric">$</span> neuralmind
                                 seats add --email developer@team.org --role member
                             </p>
-                            <p className="text-slate-500 mt-4"># List active seats</p>
+                            <p className="text-faint mt-4"># List active seats</p>
                             <p>
                                 <span className="text-electric">$</span> neuralmind
                                 seats list --format json
                             </p>
-                            <p className="text-slate-500 mt-4"># Remove a seat</p>
+                            <p className="text-faint mt-4"># Remove a seat</p>
                             <p>
                                 <span className="text-electric">$</span> neuralmind
                                 seats remove --email former@team.org
                             </p>
-                            <p className="text-slate-500 mt-4"># Sync signed manifest</p>
+                            <p className="text-faint mt-4"># Sync signed manifest</p>
                             <p>
                                 <span className="text-electric">$</span> neuralmind
                                 seats sync --verify-ed25519 --org acme-corp
                             </p>
                         </div>
-                        <p className="text-slate-500 text-xs mt-4">
+                        <p className="text-faint text-xs mt-4">
                             Signed manifest verification uses Ed25519 key signatures.
                             Each seat has a unique keypair; the admin&apos;s public key
                             signs the manifest that travels with shared synapses.
@@ -313,22 +313,22 @@ export default async function TeamPage() {
                                 </tr>
                                 <tr className="border-b border-carbon-border/50">
                                     <td className="py-3 px-4">Self-hosted deployment</td>
-                                    <td className="text-center py-3 px-4 text-slate-600">—</td>
+                                    <td className="text-center py-3 px-4 text-faint">—</td>
                                     <td className="text-center py-3 px-4 text-proton">✓</td>
                                 </tr>
                                 <tr className="border-b border-carbon-border/50">
                                     <td className="py-3 px-4">SSO / SAML</td>
-                                    <td className="text-center py-3 px-4 text-slate-600">—</td>
+                                    <td className="text-center py-3 px-4 text-faint">—</td>
                                     <td className="text-center py-3 px-4 text-proton">✓</td>
                                 </tr>
                                 <tr className="border-b border-carbon-border/50">
                                     <td className="py-3 px-4">Real-time cross-machine sync</td>
-                                    <td className="text-center py-3 px-4 text-slate-600">—</td>
+                                    <td className="text-center py-3 px-4 text-faint">—</td>
                                     <td className="text-center py-3 px-4 text-proton">✓</td>
                                 </tr>
                                 <tr>
                                     <td className="py-3 px-4">Custom SLA</td>
-                                    <td className="text-center py-3 px-4 text-slate-600">—</td>
+                                    <td className="text-center py-3 px-4 text-faint">—</td>
                                     <td className="text-center py-3 px-4 text-proton">✓</td>
                                 </tr>
                             </tbody>

--- a/site/src/app/terms/page.tsx
+++ b/site/src/app/terms/page.tsx
@@ -83,7 +83,7 @@ export default function Terms() {
                                 </ul>
                             )}
                             {s.emphasize && (
-                                <p className="text-electric-mono text-sm mt-2 font-semibold">{s.emphasize}</p>
+                                <p className="text-electric text-sm mt-2 font-semibold">{s.emphasize}</p>
                             )}
                         </div>
                     ))}

--- a/site/src/components/Navbar.tsx
+++ b/site/src/components/Navbar.tsx
@@ -1,117 +1,203 @@
 'use client';
 
 import Link from 'next/link';
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
+import Logo from '@/components/ui/Logo';
 
 // Root-relative so the menu works from every page, not just the homepage.
 // A bare "#benchmarks" does nothing on /security, /privacy, /terms — those
 // sections only exist on "/". "/#benchmarks" navigates home, then scrolls.
-const navLinks = [
-    { href: '/#how-it-works', label: 'How it works' },
-    { href: '/#benchmarks', label: 'Benchmarks' },
-    { href: '/effectiveness', label: 'Effectiveness' },
-    { href: '/publications', label: 'Research' },
-    { href: '/#features', label: 'Features' },
-    { href: '/pricing', label: 'Pricing' },
-    { href: '/services', label: 'Services' },
-    { href: '/team', label: 'Teams' },
-    { href: '/#assessment', label: 'Assessment' },
-    { href: '/#faq', label: 'FAQ' },
+//
+// All ten destinations are still reachable; they are grouped now rather than
+// laid out as ten equal-weight links that only stopped colliding at 1280px
+// and collapsed to a hamburger on every laptop below it.
+type NavItem = { href: string; label: string; hint?: string };
+
+const productLinks: NavItem[] = [
+    { href: '/#how-it-works', label: 'How it works', hint: 'Index, query, remember' },
+    { href: '/#features', label: 'Features', hint: 'The full capability list' },
+    { href: '/#benchmarks', label: 'Benchmarks', hint: 'What CI measures, and how' },
+    { href: '/effectiveness', label: 'Effectiveness', hint: 'Before / after, misses included' },
 ];
+
+const resourceLinks: NavItem[] = [
+    { href: '/publications', label: 'Research', hint: 'Write-ups and methodology' },
+    { href: '/#assessment', label: 'Assessment', hint: 'Free spend analysis' },
+    { href: '/#faq', label: 'FAQ', hint: 'Common questions' },
+    { href: 'https://docs.neuralmind.uk/wiki/Home', label: 'Docs', hint: 'CLI and wiki' },
+];
+
+const directLinks: NavItem[] = [
+    { href: '/pricing', label: 'Pricing' },
+    { href: '/team', label: 'Teams' },
+    { href: '/services', label: 'Services' },
+];
+
+function Dropdown({ label, items }: { label: string; items: NavItem[] }) {
+    const [open, setOpen] = useState(false);
+    const ref = useRef<HTMLDivElement>(null);
+
+    // Click-outside and Escape. A hover-only menu is unusable by keyboard and
+    // unreachable by touch, so this opens on click and closes on both.
+    useEffect(() => {
+        if (!open) return;
+        const onPointer = (e: PointerEvent) => {
+            if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+        };
+        const onKey = (e: KeyboardEvent) => {
+            if (e.key === 'Escape') setOpen(false);
+        };
+        document.addEventListener('pointerdown', onPointer);
+        document.addEventListener('keydown', onKey);
+        return () => {
+            document.removeEventListener('pointerdown', onPointer);
+            document.removeEventListener('keydown', onKey);
+        };
+    }, [open]);
+
+    return (
+        <div ref={ref} className="relative">
+            <button
+                type="button"
+                onClick={() => setOpen((v) => !v)}
+                aria-expanded={open}
+                aria-haspopup="true"
+                className={`flex items-center gap-1.5 text-sm transition-colors py-2 ${
+                    open ? 'text-white' : 'text-slate-400 hover:text-white'
+                }`}
+            >
+                {label}
+                <svg
+                    viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth={1.5}
+                    strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"
+                    className={`w-3 h-3 transition-transform duration-200 ${open ? 'rotate-180' : ''}`}
+                >
+                    <path d="M3 4.5 6 7.5 9 4.5" />
+                </svg>
+            </button>
+
+            {open && (
+                <div className="absolute left-0 top-full pt-2 w-[17rem] animate-fade-in">
+                    <div className="panel rounded-xl p-1.5 shadow-2xl shadow-black/50">
+                        {items.map((item) => (
+                            <Link
+                                key={item.href}
+                                href={item.href}
+                                onClick={() => setOpen(false)}
+                                className="block px-3 py-2.5 rounded-lg hover:bg-white/[0.045] transition-colors group"
+                            >
+                                <span className="block text-sm text-slate-200 group-hover:text-white font-medium">
+                                    {item.label}
+                                </span>
+                                {item.hint && (
+                                    <span className="block text-xs text-faint mt-0.5">{item.hint}</span>
+                                )}
+                            </Link>
+                        ))}
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+}
 
 export default function Navbar() {
     const [open, setOpen] = useState(false);
+    const [scrolled, setScrolled] = useState(false);
+
+    // The bar is borderless over the hero and gains its hairline once the page
+    // moves, so it reads as part of the page rather than a strip bolted on top.
+    useEffect(() => {
+        const onScroll = () => setScrolled(window.scrollY > 8);
+        onScroll();
+        window.addEventListener('scroll', onScroll, { passive: true });
+        return () => window.removeEventListener('scroll', onScroll);
+    }, []);
+
+    const allMobileLinks = [...productLinks, ...resourceLinks, ...directLinks];
 
     return (
-        <nav className="fixed top-0 left-0 right-0 z-50 backdrop-blur-md bg-carbon/80 border-b border-carbon-border/50">
-            <div className="max-w-7xl mx-auto px-6 py-4 flex items-center justify-between">
-                <Link href="/" className="flex items-center gap-2">
-                    <div className="w-8 h-8 rounded-lg bg-gradient-to-br from-electric to-proton flex items-center justify-center text-center leading-none">
-                        <span className="text-white font-display font-bold text-sm">N</span>
-                    </div>
-                    <span className="font-display font-bold text-xl tracking-tight text-white">
+        <nav
+            className={`fixed top-0 left-0 right-0 z-50 backdrop-blur-xl transition-colors duration-200 ${
+                scrolled ? 'bg-carbon/85 border-b border-carbon-border' : 'bg-carbon/40 border-b border-transparent'
+            }`}
+        >
+            <div className="max-w-6xl mx-auto px-4 md:px-6 h-16 flex items-center justify-between gap-6">
+                <Link href="/" className="flex items-center gap-2.5 shrink-0 group">
+                    <Logo className="w-[1.625rem] h-[1.625rem] text-electric transition-colors group-hover:text-electric-bright" />
+                    <span className="font-display font-semibold text-[1.0625rem] tracking-tight text-white">
                         NeuralMind
                     </span>
                 </Link>
 
-                <div className="hidden xl:flex items-center gap-x-5">
-                    {navLinks.map((link) => (
+                <div className="hidden lg:flex items-center gap-6">
+                    <Dropdown label="Product" items={productLinks} />
+                    <Dropdown label="Resources" items={resourceLinks} />
+                    {directLinks.map((link) => (
                         <Link
                             key={link.href}
                             href={link.href}
-                            className="text-slate-400 hover:text-white transition-colors text-sm font-medium whitespace-nowrap"
+                            className="text-sm text-slate-400 hover:text-white transition-colors py-2"
                         >
                             {link.label}
                         </Link>
                     ))}
                 </div>
 
-                <div className="hidden xl:flex items-center gap-3">
-                    <Link
-                        href="https://docs.neuralmind.uk/wiki/Home"
-                        className="text-slate-400 hover:text-white transition-colors text-sm font-medium whitespace-nowrap"
-                    >
-                        Docs
-                    </Link>
+                <div className="hidden lg:flex items-center gap-4 shrink-0">
                     <Link
                         href="https://github.com/dfrostar/neuralmind"
-                        className="text-slate-400 hover:text-white transition-colors text-sm font-medium whitespace-nowrap"
+                        aria-label="NeuralMind on GitHub"
+                        className="text-slate-400 hover:text-white transition-colors"
                     >
-                        GitHub
+                        <svg className="w-[1.125rem] h-[1.125rem]" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                            <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
+                        </svg>
                     </Link>
-                    <Link
-                        href="https://pypi.org/project/neuralmind/"
-                        className="btn-primary text-sm"
-                    >
+                    <Link href="https://pypi.org/project/neuralmind/" className="btn-primary text-sm py-2">
                         Install
                     </Link>
                 </div>
 
                 <button
-                    className="xl:hidden text-slate-400 hover:text-white"
+                    className="lg:hidden text-slate-400 hover:text-white -mr-1 p-1"
                     onClick={() => setOpen(!open)}
+                    aria-expanded={open}
                     aria-label="Toggle menu"
                 >
-                    <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <svg className="w-6 h-6" fill="none" stroke="currentColor" strokeWidth={1.5} viewBox="0 0 24 24" aria-hidden="true">
                         {open ? (
-                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                            <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
                         ) : (
-                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
+                            <path strokeLinecap="round" strokeLinejoin="round" d="M4 7h16M4 12h16M4 17h16" />
                         )}
                     </svg>
                 </button>
             </div>
 
             {open && (
-                <div className="xl:hidden border-t border-carbon-border/50 bg-carbon/95 backdrop-blur-md">
-                    <div className="px-6 py-4 flex flex-col gap-3">
-                        {navLinks.map((link) => (
+                <div className="lg:hidden border-t border-carbon-border bg-carbon/95 backdrop-blur-xl max-h-[calc(100vh-4rem)] overflow-y-auto">
+                    <div className="px-4 py-4 flex flex-col gap-1">
+                        {allMobileLinks.map((link) => (
                             <Link
                                 key={link.href}
                                 href={link.href}
-                                className="text-slate-400 hover:text-white transition-colors text-sm font-medium py-2"
+                                className="text-slate-300 hover:text-white transition-colors text-[0.9375rem] py-2.5"
                                 onClick={() => setOpen(false)}
                             >
                                 {link.label}
                             </Link>
                         ))}
                         <Link
-                            href="https://docs.neuralmind.uk/wiki/Home"
-                            className="text-slate-400 hover:text-white transition-colors text-sm font-medium py-2"
-                            onClick={() => setOpen(false)}
-                        >
-                            Docs
-                        </Link>
-                        <Link
                             href="https://github.com/dfrostar/neuralmind"
-                            className="text-slate-400 hover:text-white transition-colors text-sm font-medium py-2"
+                            className="text-slate-300 hover:text-white transition-colors text-[0.9375rem] py-2.5"
                             onClick={() => setOpen(false)}
                         >
                             GitHub
                         </Link>
                         <Link
                             href="https://pypi.org/project/neuralmind/"
-                            className="btn-primary text-sm text-center"
+                            className="btn-primary text-sm mt-3"
                             onClick={() => setOpen(false)}
                         >
                             Install

--- a/site/src/components/sections/Assessment.tsx
+++ b/site/src/components/sections/Assessment.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import SectionHeader from '@/components/ui/SectionHeader';
+
 const assessmentIncludes = [
     'A measured token-reduction ratio on one of your own repos — run locally, with no network calls of its own',
     'A spend model in your numbers: per-seat subscriptions, usage-based API (OpenRouter, Bedrock, Vertex), and self-hosted GPU',
@@ -10,25 +12,16 @@ const assessmentIncludes = [
 export default function Assessment() {
     return (
         <section id="assessment" className="relative py-16 md:py-32 px-4 md:px-6">
-            <div className="absolute bottom-1/3 left-1/2 -translate-x-1/2 w-[800px] h-[600px] bg-iris/2 rounded-full blur-[200px] -z-10" />
 
             <div className="max-w-3xl mx-auto">
-                <div className="text-center mb-10 md:mb-14">
-                    <span className="text-proton text-sm font-semibold tracking-wider uppercase mb-3 block">
-                        Free assessment
-                    </span>
-                    <h2 className="font-display text-3xl sm:text-4xl md:text-5xl font-bold text-white mb-4">
-                        See your savings before you spend a dollar
-                    </h2>
-                    <p className="text-slate-400 text-base sm:text-lg md:text-xl max-w-2xl mx-auto">
-                        NeuralMind is open source and free (MIT) — <code className="font-mono text-electric text-sm">pip install neuralmind</code> and
-                        you have the whole product. For teams evaluating at scale, we run a free
-                        AI-spend assessment: measured on your code, modeled in your numbers, no obligation.
-                    </p>
-                </div>
+                <SectionHeader eyebrow="Free assessment" title="See your savings before you spend a dollar">
+                    NeuralMind is open source and free (MIT) — <code className="font-mono text-[0.9em] text-electric-bright bg-electric/[0.07] rounded px-1 py-0.5">pip install neuralmind</code> and
+                    you have the whole product. For teams evaluating at scale, we run a free
+                    AI-spend assessment: measured on your code, modeled in your numbers, no obligation.
+                </SectionHeader>
 
-                <div className="rounded-2xl p-6 md:p-8 bg-gradient-to-b from-electric/10 to-carbon-card border-2 border-electric shadow-xl shadow-electric/10">
-                    <h3 className="font-display text-2xl font-bold text-white mb-6">What the assessment gives you</h3>
+                <div className="rounded-xl p-6 md:p-8 panel-accent">
+                    <h3 className="font-display text-xl font-semibold tracking-tight text-white mb-6">What the assessment gives you</h3>
                     <ul className="space-y-3 mb-8">
                         {assessmentIncludes.map((item) => (
                             <li key={item} className="flex items-start gap-3 text-sm md:text-base text-slate-300">
@@ -55,7 +48,7 @@ export default function Assessment() {
                     </div>
                 </div>
 
-                <p className="text-center text-slate-500 text-sm mt-6">
+                <p className="text-center text-faint text-sm mt-6">
                     The software is MIT-licensed and free. Commercial support for deployment and integration is available.
                 </p>
             </div>

--- a/site/src/components/sections/Benchmarks.tsx
+++ b/site/src/components/sections/Benchmarks.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import SectionHeader from '@/components/ui/SectionHeader';
+
 // Sourced in site/claims.json; gated by tests/test_site_claims.py. Each row
 // says which kind of evidence it is — a CI gate, an on-demand reproduction, or
 // a single-repo field report — because they are not the same strength of claim.
@@ -14,41 +16,38 @@ const dataPoints = [
 
 export default function Benchmarks() {
     return (
-        <section id="benchmarks" className="relative py-16 md:py-32 px-4 md:px-6">
-            <div className="absolute top-1/3 right-0 w-[500px] h-[500px] bg-proton/3 rounded-full blur-[200px] -z-10" />
+        <section id="benchmarks" className="relative py-20 md:py-28 px-4 md:px-6">
+            <div className="max-w-6xl mx-auto">
+                <SectionHeader eyebrow="Measured, not marketed" title="Benchmarks">
+                    Two of these are recomputed by CI on every commit; the rest reproduce from a
+                    fresh clone with one command. Where a number comes from a single repo, it says so.
+                    Run <code className="font-mono text-[0.9em] text-electric-bright bg-electric/[0.07] rounded px-1 py-0.5">neuralmind benchmark .</code> for your own.
+                </SectionHeader>
 
-            <div className="max-w-5xl mx-auto">
-                <div className="text-center mb-12 md:mb-16">
-                    <span className="text-proton text-sm font-semibold tracking-wider uppercase mb-3 block">
-                        Measured, not marketed
-                    </span>
-                    <h2 className="font-display text-3xl sm:text-4xl md:text-5xl font-bold text-white mb-4">
-                        Benchmarks
-                    </h2>
-                    <p className="text-slate-400 text-base sm:text-lg md:text-xl max-w-xl mx-auto">
-                        Two of these are recomputed by CI on every commit; the rest reproduce from a
-                        fresh clone with one command. Where a number comes from a single repo, it says so.
-                        Run <code className="text-electric font-mono text-sm">neuralmind benchmark .</code> for your own.
-                    </p>
-                </div>
-
-                <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-4">
+                {/* Same ruled matrix as the hero stats and the feature grid, so a
+                    figure looks the same wherever it appears on the page. */}
+                <dl className="grid sm:grid-cols-2 lg:grid-cols-3 border-t border-l border-carbon-border rounded-sm overflow-hidden">
                     {dataPoints.map((dp) => (
-                        <div
-                            key={dp.metric}
-                            className="glow-card rounded-2xl p-6"
-                        >
-                            <p className="text-slate-500 text-xs font-semibold uppercase tracking-wider mb-2">
+                        <div key={dp.metric} className="border-b border-r border-carbon-border p-6">
+                            <dt className="font-mono text-[0.6875rem] uppercase tracking-[0.12em] text-faint mb-3">
                                 {dp.metric}
-                            </p>
-                            <p className="font-display text-3xl font-bold text-white mb-1">{dp.value}</p>
-                            <p className="text-slate-400 text-sm">{dp.detail}</p>
+                            </dt>
+                            <dd>
+                                <p className={`text-white mb-2 leading-none ${
+                                    /^[~\d]/.test(dp.value)
+                                        ? 'metric text-[1.75rem]'
+                                        : 'font-display text-2xl font-semibold tracking-tight'
+                                }`}>
+                                    {dp.value}
+                                </p>
+                                <p className="text-slate-400 text-sm leading-relaxed">{dp.detail}</p>
+                            </dd>
                         </div>
                     ))}
-                </div>
+                </dl>
 
                 {/* Field report — hand-measured, deliberately outside the CI-gated tiles above */}
-                <p className="mt-8 text-center text-slate-400 text-sm">
+                <p className="mt-6 text-slate-400 text-sm max-w-3xl">
                     Plus one labeled <span className="text-slate-300">field report</span> (measured with the CLI, not CI-gated):{' '}
                     <span className="text-white font-semibold">48.8×</span> on a real ~9,300-node TypeScript SaaS
                     platform, through a major rebuild.{' '}
@@ -58,10 +57,10 @@ export default function Benchmarks() {
                 </p>
 
                 {/* Demo callout */}
-                <div className="mt-12 p-6 rounded-2xl border border-carbon-border bg-carbon-raised/50 flex flex-col md:flex-row items-center justify-between gap-4">
-                    <div>
-                        <h3 className="font-display text-xl font-bold text-white mb-1">See it in 30 seconds</h3>
-                        <p className="text-slate-400 text-sm">
+                <div className="mt-12 p-6 md:p-7 rounded-xl panel-accent flex flex-col md:flex-row md:items-center justify-between gap-5">
+                    <div className="max-w-2xl">
+                        <h3 className="font-display text-lg font-semibold tracking-tight text-white mb-1.5">See it in 30 seconds</h3>
+                        <p className="text-slate-400 text-sm leading-relaxed">
                             Clone the repo, run the demo, get numbers on YOUR codebase. Then email the
                             output to hello@neuralmind.uk with your team size for a free full spend model.
                         </p>

--- a/site/src/components/sections/BusinessCase.tsx
+++ b/site/src/components/sections/BusinessCase.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import SectionHeader from '@/components/ui/SectionHeader';
+
 const cards = [
     {
         audience: 'For the CFO',
@@ -28,25 +30,16 @@ const cards = [
 export default function BusinessCase() {
     return (
         <section id="business-case" className="relative py-16 md:py-32 px-4 md:px-6">
-            <div className="absolute top-1/3 left-1/2 -translate-x-1/2 w-[700px] h-[500px] bg-proton/3 rounded-full blur-[200px] -z-10" />
 
             <div className="max-w-5xl mx-auto">
-                <div className="text-center mb-12 md:mb-16">
-                    <span className="text-proton text-sm font-semibold tracking-wider uppercase mb-3 block">
-                        The business case
-                    </span>
-                    <h2 className="font-display text-3xl sm:text-4xl md:text-5xl font-bold text-white mb-4">
-                        The savings are free. The tier is control.
-                    </h2>
-                    <p className="text-slate-400 text-base sm:text-lg md:text-xl max-w-2xl mx-auto">
-                        Dollar figures below are modeled, with published assumptions — the free
-                        assessment runs the same model in your numbers.
-                    </p>
-                </div>
+                <SectionHeader eyebrow="The business case" title="The savings are free. The tier is control.">
+                    Dollar figures below are modeled, with published assumptions — the free
+                    assessment runs the same model in your numbers.
+                </SectionHeader>
 
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-4 md:gap-6 mb-10">
                     {cards.map((card) => (
-                        <div key={card.audience} className="glow-card rounded-2xl p-6 md:p-8">
+                        <div key={card.audience} className="card rounded-2xl p-6 md:p-8">
                             <span className={`text-xs font-semibold uppercase tracking-wider ${card.accent} mb-2 block`}>
                                 {card.audience}
                             </span>

--- a/site/src/components/sections/CTA.tsx
+++ b/site/src/components/sections/CTA.tsx
@@ -1,45 +1,41 @@
 'use client';
 
+import CommandLine from '@/components/ui/CommandLine';
+import Icon from '@/components/ui/Icon';
+
+// The three assurances were dotted in emerald, amber and blue — three colours
+// carrying no distinction, and amber in particular reads as a warning next to
+// the words "CI-verified". One evidence colour, one meaning.
+const assurances = ['No cloud calls', 'CI-verified', '100% local'];
+
 export default function CTA() {
     return (
-        <section id="install" className="relative py-16 md:py-32 px-4 md:px-6">
-            <div className="absolute inset-0 -z-10">
-                <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[800px] h-[400px] bg-electric/5 rounded-full blur-[200px]" />
-            </div>
+        <section id="install" className="relative py-20 md:py-28 px-4 md:px-6">
+            <div className="max-w-6xl mx-auto">
+                <div className="panel-accent rounded-2xl px-6 py-14 md:px-14 md:py-16 text-center">
+                    <h2 className="font-display text-3xl sm:text-4xl md:text-[2.75rem] font-semibold text-white tracking-tighter mb-5 max-w-2xl mx-auto">
+                        Stop paying for tokens you don&apos;t use.
+                    </h2>
+                    <p className="text-slate-400 text-base md:text-lg mb-9 max-w-xl mx-auto leading-relaxed">
+                        One command to install. Seconds to verify. Your agent remembers what matters.
+                    </p>
 
-            <div className="max-w-3xl mx-auto text-center">
-                <h2 className="font-display text-3xl sm:text-4xl md:text-5xl font-bold text-white mb-6">
-                    Stop paying for tokens you don't use.
-                </h2>
-                <p className="text-slate-400 text-base sm:text-lg md:text-xl mb-10 max-w-xl mx-auto">
-                    One command to install. Seconds to verify. Your agent remembers what matters.
-                </p>
+                    <div className="flex flex-col sm:flex-row items-center justify-center gap-3 mb-10">
+                        <CommandLine command="pip install neuralmind" />
+                        <a href="https://pypi.org/project/neuralmind/" className="btn-primary py-3">
+                            Get started
+                            <Icon name="arrow-right" className="w-4 h-4" />
+                        </a>
+                    </div>
 
-                <div className="flex flex-col sm:flex-row items-center justify-center gap-4 mb-10">
-                    <code className="text-base font-mono bg-carbon-raised border border-carbon-border px-6 py-3 rounded-xl text-white shadow-lg">
-                        pip install neuralmind
-                    </code>
-                    <a
-                        href="https://pypi.org/project/neuralmind/"
-                        className="btn-primary"
-                    >
-                        Get started
-                    </a>
-                </div>
-
-                <div className="flex items-center justify-center gap-6 text-sm text-slate-500">
-                    <span className="flex items-center gap-1.5">
-                        <span className="w-2 h-2 rounded-full bg-emerald-400" />
-                        No cloud calls
-                    </span>
-                    <span className="flex items-center gap-1.5">
-                        <span className="w-2 h-2 rounded-full bg-amber-400" />
-                        CI-verified
-                    </span>
-                    <span className="flex items-center gap-1.5">
-                        <span className="w-2 h-2 rounded-full bg-blue-400" />
-                        100% local
-                    </span>
+                    <ul className="flex flex-wrap items-center justify-center gap-x-7 gap-y-2 text-sm text-faint">
+                        {assurances.map((item) => (
+                            <li key={item} className="flex items-center gap-2">
+                                <Icon name="check" className="w-3.5 h-3.5 text-proton" strokeWidth={2.25} />
+                                {item}
+                            </li>
+                        ))}
+                    </ul>
                 </div>
             </div>
         </section>

--- a/site/src/components/sections/FAQ.tsx
+++ b/site/src/components/sections/FAQ.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import SectionHeader from '@/components/ui/SectionHeader';
+
 import { useState } from 'react';
 
 const faqs = [
@@ -55,20 +57,13 @@ export default function FAQ() {
     return (
         <section id="faq" className="relative py-16 md:py-32 px-4 md:px-6">
             <div className="max-w-3xl mx-auto">
-                <div className="text-center mb-12 md:mb-16">
-                    <span className="text-electric text-sm font-semibold tracking-wider uppercase mb-3 block">
-                        FAQ
-                    </span>
-                    <h2 className="font-display text-3xl sm:text-4xl md:text-5xl font-bold text-white mb-4">
-                        Common questions
-                    </h2>
-                </div>
+                <SectionHeader eyebrow="FAQ" title="Common questions" />
 
                 <div className="space-y-3">
                     {faqs.map((faq, i) => (
                         <div
                             key={i}
-                            className="glow-card rounded-xl overflow-hidden"
+                            className="card rounded-xl overflow-hidden"
                         >
                             <button
                                 onClick={() => setOpenIndex(openIndex === i ? null : i)}

--- a/site/src/components/sections/Features.tsx
+++ b/site/src/components/sections/Features.tsx
@@ -1,92 +1,100 @@
 'use client';
 
-const featureList = [
+import Icon, { type IconName } from '@/components/ui/Icon';
+import { withCode } from '@/lib/ticks';
+
+// Copy is unchanged — every figure here is registered in site/claims.json and
+// gated by tests/test_site_claims.py. What changed is `icon`: these were
+// emoji (⚡🧬🔄📊🔬🧠🌐🎯🗑️🆓🔒🚀🛡️📤🤖), drawn by the reader's operating
+// system in full colour at whatever weight it felt like, in the middle of an
+// otherwise monochrome page.
+const featureList: { icon: IconName; title: string; desc: string; badge: string }[] = [
     {
-        icon: '⚡',
+        icon: 'chip',
         title: 'Local Retrieval, No Model Call',
         desc: 'Recall is a local index lookup, not another round trip to a model. The ChromaDB-free TurboVec backend keeps 4-bit quantized vectors 8–16× smaller with fact recall 0.800 vs 0.744 for float32 — parity gated in CI.',
         badge: 'TurboVec',
     },
     {
-        icon: '🧬',
+        icon: 'synapse',
         title: 'Hebbian Synapse Layer',
         desc: 'Associations strengthen when you use them together — like a real hippocampus. Budget-neutral, no cost until it activates.',
         badge: 'Budget-neutral',
     },
     {
-        icon: '🔄',
+        icon: 'layers',
         title: 'Progressive L0–L3 Disclosure',
         desc: 'Retrieves the exact bytes needed. Never pastes the whole repo. 45–257× fewer tokens than full-file context across 40 pre-registered queries on four public repos.',
         badge: '45–257×',
     },
     {
-        icon: '📊',
+        icon: 'dashboard',
         title: 'Team Dashboard',
         desc: 'Read-only web UI: synapse memory, ingestion status, savings, latency trends, community distribution, recent queries.',
         badge: 'New',
     },
     {
-        icon: '🔬',
+        icon: 'doc-code',
         title: 'Self-Documenting Code',
         desc: 'DocEvolver finds undocumented methods, generates JSDoc variants, evolves them against retrieval fitness. Winning variants patched back into source.',
         badge: 'Evolution',
     },
     {
-        icon: '🧠',
+        icon: 'doc-link',
         title: 'Business-Context Synapse Seeding',
         desc: 'seed_from_documents() builds deterministic, LLM-free associations between business documents (decisions, SOPs, meeting notes) and your code graph. Adjacency-matched compounds, title-reference cross-links.',
         badge: 'N-13',
     },
     {
-        icon: '🌐',
+        icon: 'hub',
         title: 'MCP Server',
         desc: 'First-class MCP integration. Works with Claude Code, Cursor, Cline, Continue, and any MCP-compatible agent.',
         badge: 'Universal',
     },
     {
-        icon: '🎯',
+        icon: 'tree',
         title: 'Ten-Language Code Graph',
         desc: 'tree-sitter indexes Python, TypeScript, Go, Rust, Java, C, C++, C#, Ruby, and PHP out of the box.',
         badge: '10 langs',
     },
     {
-        icon: '🗑️',
+        icon: 'restore',
         title: 'Tool Output Recovery',
         desc: 'Caches dropped tool output from context windows. When your agent forgets, neuralmind remembers.',
         badge: 'Auto-recover',
     },
     {
-        icon: '🆓',
+        icon: 'key',
         title: 'Free Tier — Auto-Provisioned',
         desc: '`pip install neuralmind && neuralmind wakeup .` writes the license on first run. Zero signup wall. Default tier is "free", identity auto-issued.',
         badge: 'v1.7.0',
     },
     {
-        icon: '🔒',
+        icon: 'offline',
         title: '100% Local Engine',
         desc: 'NeuralMind makes zero network calls of its own — only the minimal relevant slice ever reaches your AI tool, never your whole codebase. No telemetry.',
         badge: 'Secure',
     },
     {
-        icon: '🚀',
+        icon: 'terminal',
         title: 'One-Command Project Init',
         desc: '`neuralmind init` auto-detects project structure, installs hooks, builds the index — all at once. Your project is ready in seconds.',
         badge: 'v2.0.0',
     },
     {
-        icon: '🛡️',
+        icon: 'shield-check',
         title: 'Compliance Annotation Engine',
         desc: 'Scans code for `Compliance:` annotations, maps them to CMMC 2.0 / NIST SP 800-53 controls. Ingest CMMC assessment guides, export audit reports, gate CI on annotation health.',
         badge: 'v2.0.0',
     },
     {
-        icon: '📤',
+        icon: 'export',
         title: 'Audit Export & CI/CD Check',
         desc: '`neuralmind export --audit` produces flat compliance reports (CSV/JSON) for evidence submission. `neuralmind ci-check` gates builds on annotation health.',
         badge: 'v2.0.0',
     },
     {
-        icon: '🤖',
+        icon: 'report-query',
         title: 'Compliance Report MCP Tool',
         desc: '`neuralmind_compliance_report` surfaces live compliance stance from any MCP-compatible agent. Ask "are we compliant on access control?" and get an answer grounded in real annotations.',
         badge: 'v2.0.0',
@@ -95,36 +103,46 @@ const featureList = [
 
 export default function Features() {
     return (
-        <section id="features" className="relative py-16 md:py-32 px-4 md:px-6">
-            <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[600px] h-[600px] bg-electric/3 rounded-full blur-[200px] -z-10" />
-
-            <div className="max-w-5xl mx-auto">
-                <div className="text-center mb-12 md:mb-16">
-                    <span className="text-electric text-sm font-semibold tracking-wider uppercase mb-3 block">
-                        Capabilities
-                    </span>
-                    <h2 className="font-display text-3xl sm:text-4xl md:text-5xl font-bold text-white mb-4">
+        <section id="features" className="relative py-20 md:py-28 px-4 md:px-6">
+            <div className="max-w-6xl mx-auto">
+                <header className="max-w-2xl mb-10 md:mb-14">
+                    <span className="eyebrow block mb-4">Capabilities</span>
+                    <h2 className="font-display text-3xl sm:text-4xl md:text-[2.75rem] font-semibold text-white tracking-tighter mb-4">
                         Features
                     </h2>
-                    <p className="text-slate-400 text-base sm:text-lg md:text-xl max-w-xl mx-auto">
-                        Everything persistent memory should be — and nothing it shouldn't.
+                    <p className="text-slate-400 text-base md:text-lg leading-relaxed">
+                        Everything persistent memory should be — and nothing it shouldn&apos;t.
                     </p>
-                </div>
+                </header>
 
-                <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 md:gap-6">
+                {/*
+                    One ruled matrix rather than fifteen floating rounded boxes.
+                    Shared hairlines let the grid read as a single specification
+                    table, which is what a fifteen-item capability list actually
+                    is; drop shadows and gaps at this count read as clutter.
+                */}
+                <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 border-t border-l border-carbon-border rounded-sm overflow-hidden">
                     {featureList.map((f) => (
                         <div
                             key={f.title}
-                            className="glow-card rounded-2xl p-6 md:p-8 group"
+                            className="group relative border-b border-r border-carbon-border p-6 lg:p-7 transition-colors duration-200 hover:bg-carbon-card"
                         >
-                            <div className="flex items-start justify-between mb-3">
-                                <span className="text-3xl">{f.icon}</span>
-                                <span className="text-xs font-semibold uppercase tracking-wider text-electric bg-electric/10 px-3 py-1 rounded-full">
+                            <div className="flex items-center gap-3 mb-4">
+                                <Icon
+                                    name={f.icon}
+                                    className="w-[1.375rem] h-[1.375rem] shrink-0 text-faint transition-colors duration-200 group-hover:text-electric"
+                                />
+                                <span className="font-mono text-[0.6875rem] uppercase tracking-[0.12em] text-faint transition-colors duration-200 group-hover:text-faint">
                                     {f.badge}
                                 </span>
                             </div>
-                            <h3 className="font-display text-xl font-bold text-white mb-2">{f.title}</h3>
-                            <p className="text-slate-400 text-sm leading-relaxed">{f.desc}</p>
+
+                            <h3 className="font-display text-[1.0625rem] font-semibold text-white tracking-tight mb-2 text-balance">
+                                {f.title}
+                            </h3>
+                            <p className="text-slate-400 text-[0.875rem] leading-relaxed">
+                                {withCode(f.desc)}
+                            </p>
                         </div>
                     ))}
                 </div>

--- a/site/src/components/sections/Footer.tsx
+++ b/site/src/components/sections/Footer.tsx
@@ -1,48 +1,85 @@
+import Link from 'next/link';
+import Logo from '@/components/ui/Logo';
+
+// Twelve links in one undifferentiated wrapped row, every one of them carrying
+// target="_blank" — so /privacy, /terms, /pricing, /services and /team, all
+// pages on this same site, each opened a new tab. Grouped into columns, and
+// only genuinely external destinations open away from the site.
+const groups: { heading: string; links: { label: string; href: string }[] }[] = [
+    {
+        heading: 'Product',
+        links: [
+            { label: 'Pricing', href: '/pricing' },
+            { label: 'Services', href: '/services' },
+            { label: 'Team', href: '/team' },
+            { label: 'Security', href: '/security' },
+        ],
+    },
+    {
+        heading: 'Developers',
+        links: [
+            { label: 'Docs', href: 'https://docs.neuralmind.uk/wiki/Home' },
+            { label: 'GitHub', href: 'https://github.com/dfrostar/neuralmind' },
+            { label: 'PyPI', href: 'https://pypi.org/project/neuralmind/' },
+            { label: 'Release Notes', href: 'https://github.com/dfrostar/neuralmind/tree/main/docs/releases' },
+        ],
+    },
+    {
+        heading: 'Legal',
+        links: [
+            { label: 'License (MIT)', href: 'https://github.com/dfrostar/neuralmind/blob/main/LICENSE' },
+            { label: 'Privacy', href: '/privacy' },
+            { label: 'Terms', href: '/terms' },
+            { label: 'Contact', href: 'mailto:hello@neuralmind.uk' },
+        ],
+    },
+];
+
+const isExternal = (href: string) => href.startsWith('http');
+
 export default function Footer() {
-    const links = [
-        { label: 'Security', href: '/security' },
-        { label: 'PyPI', href: 'https://pypi.org/project/neuralmind/' },
-        { label: 'GitHub', href: 'https://github.com/dfrostar/neuralmind' },
-        { label: 'Release Notes', href: 'https://github.com/dfrostar/neuralmind/tree/main/docs/releases' },
-        { label: 'Docs', href: 'https://docs.neuralmind.uk/wiki/Home' },
-        { label: 'Pricing', href: '/pricing' },
-        { label: 'Services', href: '/services' },
-        { label: 'Team', href: '/team' },
-        { label: 'License (MIT)', href: 'https://github.com/dfrostar/neuralmind/blob/main/LICENSE' },
-        { label: 'Privacy', href: '/privacy' },
-        { label: 'Terms', href: '/terms' },
-        { label: 'Contact', href: 'mailto:hello@neuralmind.uk' },
-    ];
-
     return (
-        <footer className="border-t border-carbon-border/50 py-12 px-4 md:px-6">
-            <div className="max-w-5xl mx-auto flex flex-col md:flex-row items-center justify-between gap-6">
-                <div className="flex items-center gap-2">
-                    <div className="w-8 h-8 rounded-lg bg-gradient-to-br from-electric to-proton flex items-center justify-center">
-                        <span className="text-white font-display font-bold text-sm">N</span>
+        <footer className="border-t border-carbon-border pt-14 pb-10 px-4 md:px-6">
+            <div className="max-w-6xl mx-auto">
+                <div className="grid gap-10 md:grid-cols-[minmax(0,1.4fr)_repeat(3,minmax(0,1fr))]">
+                    <div>
+                        <Link href="/" className="inline-flex items-center gap-2.5 mb-4">
+                            <Logo className="w-[1.5rem] h-[1.5rem] text-electric" />
+                            <span className="font-display font-semibold text-base tracking-tight text-white">
+                                NeuralMind
+                            </span>
+                        </Link>
+                        <p className="text-faint text-sm leading-relaxed max-w-xs">
+                            Persistent memory and semantic code intelligence for AI coding agents.
+                            Local-first, no telemetry.
+                        </p>
                     </div>
-                    <span className="font-display font-bold text-lg text-white">
-                        NeuralMind
-                    </span>
-                </div>
 
-                <div className="flex flex-wrap items-center justify-center gap-6 text-sm">
-                    {links.map((link) => (
-                        <a
-                            key={link.label}
-                            href={link.href}
-                            className="text-slate-400 hover:text-white transition-colors"
-                            target="_blank"
-                            rel="noopener noreferrer"
-                        >
-                            {link.label}
-                        </a>
+                    {groups.map((group) => (
+                        <nav key={group.heading} aria-label={group.heading}>
+                            <h2 className="eyebrow mb-4">{group.heading}</h2>
+                            <ul className="space-y-2.5">
+                                {group.links.map((link) => (
+                                    <li key={link.label}>
+                                        <a
+                                            href={link.href}
+                                            className="text-slate-400 hover:text-white transition-colors text-sm"
+                                            {...(isExternal(link.href)
+                                                ? { target: '_blank', rel: 'noopener noreferrer' }
+                                                : {})}
+                                        >
+                                            {link.label}
+                                        </a>
+                                    </li>
+                                ))}
+                            </ul>
+                        </nav>
                     ))}
                 </div>
 
-                <p className="text-slate-500 text-sm">
-                    2025–2026 Darren Frost · MIT License
-                </p>
+                <div className="rule mt-12 mb-6" />
+
+                <p className="text-faint text-sm">2025–2026 Darren Frost · MIT License</p>
             </div>
         </footer>
     );

--- a/site/src/components/sections/Hero.tsx
+++ b/site/src/components/sections/Hero.tsx
@@ -1,15 +1,31 @@
 'use client';
 
 import { useState, useEffect } from 'react';
+import CommandLine from '@/components/ui/CommandLine';
+import Icon from '@/components/ui/Icon';
 
 const tags = ['Claude Code', 'Codex', 'Cursor', 'Cline', 'Continue', 'MCP'];
+
 // Every figure here is registered in site/claims.json with its source and
 // reproduction command, and gated by tests/test_site_claims.py.
+//
+// `evidence` is new, and it is presentational only — it labels which kind of
+// claim each figure is, the same grading the Benchmarks table already applies.
+// The site's own rule is that a CI gate and a per-repo mean are not the same
+// strength of claim, so the hero should not render them identically.
 const heroStats = [
-    { label: 'Gold-file recall', value: '93.75%', highlight: true },
-    { label: 'vs. pasting files', value: '45–257×', highlight: false },
-    { label: 'Pre-registered queries', value: '40', highlight: false },
-    { label: 'Free Tier', value: 'Auto-provisioned', highlight: false },
+    { label: 'Gold-file recall', value: '93.75%', evidence: 'mean, 79–100% per repo', figure: true },
+    { label: 'vs. pasting files', value: '45–257×', evidence: 'fewer tokens', figure: true },
+    { label: 'Pre-registered queries', value: '40', evidence: 'four public repos', figure: true },
+    { label: 'Free tier', value: 'Auto-provisioned', evidence: 'no signup', figure: false },
+];
+
+// Real commands, verified against neuralmind/cli.py. Nothing here prints
+// fabricated output — the terminal shows the three calls you actually make.
+const session = [
+    { prompt: '$', cmd: 'pip install neuralmind' },
+    { prompt: '$', cmd: 'neuralmind build .' },
+    { prompt: '$', cmd: 'neuralmind query "where is auth handled?"' },
 ];
 
 export default function Hero() {
@@ -23,70 +39,108 @@ export default function Hero() {
     }, []);
 
     return (
-        <section className="relative min-h-screen flex items-center justify-center overflow-hidden pt-20 pb-16">
-            {/* gradient background */}
-            <div className="absolute inset-0 -z-10">
-                <div className="absolute top-1/4 -left-1/4 w-[600px] h-[600px] bg-electric/5 rounded-full blur-[120px]" />
-                <div className="absolute bottom-1/4 -right-1/4 w-[600px] h-[600px] bg-proton/5 rounded-full blur-[120px]" />
-                <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[800px] h-[800px] bg-iris/3 rounded-full blur-[150px]" />
-            </div>
+        <section className="relative overflow-hidden pt-32 pb-16 md:pt-40 md:pb-20">
+            {/* A 72px hairline grid, masked to fade out. Replaces three
+                600–800px blurred blue/purple radial blobs. */}
+            <div className="grid-bg absolute inset-0 -z-10" aria-hidden="true" />
 
-            <div className="max-w-4xl mx-auto px-4 md:px-6 text-center">
-                {/* Agent compatibility tag */}
-                <div className="inline-flex items-center gap-2 mb-8 px-4 py-2 rounded-full border border-carbon-border bg-carbon-raised/80 backdrop-blur-sm">
-                    <div className="w-2 h-2 rounded-full bg-green-400 animate-pulse" />
-                    <span className="text-slate-400 text-sm font-medium">Native for</span>
-                    <span className="text-white font-semibold text-sm">{tags[tagIndex]}</span>
-                </div>
-
-                {/* Main headline */}
-                <h1 className="font-display text-3xl sm:text-4xl md:text-5xl font-bold tracking-tight text-white leading-[1.05] mb-6">
-                    Your team uses Claude Code?{' '}
-                    <span className="gradient-text">Now it remembers your codebase.</span>
-                </h1>
-                <p className="text-base sm:text-lg md:text-xl text-slate-400 max-w-2xl mx-auto mb-8 leading-relaxed">
-                    Persistent neural memory for AI agents. Your agent opens the right file
-                    first — <span className="text-white font-semibold">93.75% gold-file recall across 40
-                    pre-registered queries on four public repos</span>, at 45–257× fewer tokens than
-                    pasting those files in. Local-first, no telemetry.
-                </p>
-
-                {/* CTA buttons */}
-                <div className="flex flex-col sm:flex-row items-center justify-center gap-4 mb-12">
-                    <a
-                        href="#install"
-                        className="btn-primary flex items-center gap-2 px-8 py-4 text-base"
-                    >
-                        <code className="font-mono text-sm bg-black/30 px-2 py-1 rounded overflow-auto">pip install neuralmind</code>
-                    </a>
-                    <a
-                        href="https://github.com/dfrostar/neuralmind"
-                        className="px-6 py-4 rounded-xl border border-carbon-border text-slate-300 hover:text-white hover:border-electric/40 transition-all font-medium flex items-center gap-2"
-                    >
-                        <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
-                            <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
-                        </svg>
-                        Source on GitHub
-                    </a>
-                    <a
-                        href="/pricing"
-                        className="px-6 py-4 rounded-xl border border-electric/40 text-white hover:bg-electric/10 transition-all font-medium flex items-center gap-2"
-                    >
-                        For teams →
-                    </a>
-                </div>
-
-                {/* Stats */}
-                <div className="flex flex-wrap justify-center gap-4 md:gap-8 mb-8">
-                    {heroStats.map((stat) => (
-                        <div key={stat.label} className="flex items-center gap-3 min-w-[120px] flex-1 justify-center">
-                            <span className={`font-display text-2xl font-bold ${stat.highlight ? 'gradient-text' : 'text-white'}`}>
-                                {stat.value}
+            <div className="max-w-6xl mx-auto px-4 md:px-6">
+                <div className="grid lg:grid-cols-[minmax(0,1fr)_minmax(0,26rem)] gap-12 lg:gap-14 items-center">
+                    {/* ── Copy ───────────────────────────────────────────── */}
+                    <div>
+                        <div className="inline-flex items-center gap-2.5 mb-8 pl-3 pr-4 py-1.5 rounded-full border border-carbon-border bg-carbon-raised">
+                            <span className="w-1.5 h-1.5 rounded-full bg-proton" />
+                            <span className="text-faint text-[0.8125rem]">Native for</span>
+                            <span className="relative grid text-slate-100 font-medium text-[0.8125rem]">
+                                {/* Every name stacked in one cell: the widest sets the
+                                    width, so the pill never resizes mid-rotation. */}
+                                {tags.map((tag, i) => (
+                                    <span
+                                        key={tag}
+                                        aria-hidden={i !== tagIndex}
+                                        className={`col-start-1 row-start-1 transition-opacity duration-500 ${
+                                            i === tagIndex ? 'opacity-100' : 'opacity-0'
+                                        }`}
+                                    >
+                                        {tag}
+                                    </span>
+                                ))}
                             </span>
-                            <span className="text-slate-500 text-sm font-medium">{stat.label}</span>
+                        </div>
+
+                        <h1 className="font-display text-4xl sm:text-5xl lg:text-[3.5rem] font-semibold text-white leading-[1.04] tracking-tightest mb-6">
+                            Your team uses Claude Code?{' '}
+                            <span className="gradient-text">Now it remembers your codebase.</span>
+                        </h1>
+
+                        <p className="text-slate-400 text-base sm:text-lg leading-relaxed max-w-xl mb-9">
+                            Persistent neural memory for AI agents. Your agent opens the right file
+                            first — <span className="text-slate-100 font-medium">93.75% gold-file recall across 40
+                            pre-registered queries on four public repos</span>, at 45–257× fewer tokens than
+                            pasting those files in. Local-first, no telemetry.
+                        </p>
+
+                        <div className="flex flex-wrap items-center gap-3">
+                            <CommandLine command="pip install neuralmind" />
+                            <a href="/pricing" className="btn-primary py-3">
+                                For teams
+                                <Icon name="arrow-right" className="w-4 h-4" />
+                            </a>
+                            <a
+                                href="https://github.com/dfrostar/neuralmind"
+                                className="btn-secondary py-3"
+                            >
+                                <svg className="w-[1.125rem] h-[1.125rem]" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                                    <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
+                                </svg>
+                                Source
+                            </a>
+                        </div>
+                    </div>
+
+                    {/* ── Terminal ───────────────────────────────────────── */}
+                    <div className="panel rounded-xl overflow-hidden shadow-2xl shadow-black/40">
+                        <div className="flex items-center gap-2 px-4 py-3 border-b border-carbon-border bg-carbon-raised">
+                            <span className="w-2.5 h-2.5 rounded-full bg-carbon-line" />
+                            <span className="w-2.5 h-2.5 rounded-full bg-carbon-line" />
+                            <span className="w-2.5 h-2.5 rounded-full bg-carbon-line" />
+                            <span className="ml-2 font-mono text-[0.6875rem] text-faint tracking-wide">
+                                your-repo — zsh
+                            </span>
+                        </div>
+                        <div className="p-5 font-mono text-[0.8125rem] leading-loose">
+                            {session.map((line) => (
+                                <div key={line.cmd} className="flex gap-2.5">
+                                    <span className="text-proton select-none shrink-0">{line.prompt}</span>
+                                    <span className="text-slate-300 break-words">{line.cmd}</span>
+                                </div>
+                            ))}
+                            <div className="flex gap-2.5 mt-1">
+                                <span className="text-proton select-none shrink-0">$</span>
+                                <span className="w-2 h-[1.1em] bg-slate-600 translate-y-[0.2em]" />
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                {/* ── Stats ──────────────────────────────────────────────── */}
+                <dl className="grid grid-cols-2 lg:grid-cols-4 border-t border-l border-carbon-border rounded-sm overflow-hidden mt-14 md:mt-20">
+                    {heroStats.map((stat) => (
+                        <div key={stat.label} className="border-b border-r border-carbon-border px-5 py-6">
+                            <dd
+                                className={
+                                    stat.figure
+                                        ? 'metric text-2xl md:text-[1.75rem] text-white mb-2 leading-none'
+                                        : 'font-display text-xl md:text-2xl font-semibold tracking-tight text-white mb-2 leading-none'
+                                }
+                            >
+                                {stat.value}
+                            </dd>
+                            <dt className="text-slate-300 text-sm font-medium mb-1">{stat.label}</dt>
+                            <p className="text-faint text-xs">{stat.evidence}</p>
                         </div>
                     ))}
-                </div>
+                </dl>
             </div>
         </section>
     );

--- a/site/src/components/sections/HowItWorks.tsx
+++ b/site/src/components/sections/HowItWorks.tsx
@@ -1,20 +1,25 @@
 'use client';
 
-const steps = [
+import Icon, { type IconName } from '@/components/ui/Icon';
+import { withCode } from '@/lib/ticks';
+
+// Copy unchanged. `icon` was ⚡ / 🧠 / 🔮 — a crystal ball for the Hebbian
+// synapse layer, which undersold the one genuinely novel thing in the product.
+const steps: { icon: IconName; title: string; desc: string; time: string }[] = [
     {
-        icon: '⚡',
+        icon: 'index',
         title: 'Index',
         desc: 'tree-sitter parses your codebase into a graph — functions, classes, imports, comments. Ten languages, zero config. TurboVec compresses vectors 4-bit.',
         time: '~15 min',
     },
     {
-        icon: '🧠',
+        icon: 'query',
         title: 'Query',
         desc: 'Your agent asks a question. Progressive L0–L3 disclosure pulls exactly the right amount of context — a local index lookup, not another model call.',
         time: 'local lookup',
     },
     {
-        icon: '🔮',
+        icon: 'recall',
         title: 'Remember',
         desc: 'A Hebbian synapse layer learns co-activations from how you actually use the codebase. Budget-neutral, runs in the background.',
         time: 'Forever',
@@ -23,49 +28,53 @@ const steps = [
 
 export default function HowItWorks() {
     return (
-        <section id="how-it-works" className="relative py-16 md:py-32 px-4 md:px-6">
-            <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[600px] h-[600px] bg-electric/3 rounded-full blur-[200px] -z-10" />
-
-            <div className="max-w-5xl mx-auto">
-                <div className="text-center mb-12 md:mb-20">
-                    <span className="text-electric-mono text-sm font-semibold tracking-wider uppercase mb-3 block">
-                        Pipeline
-                    </span>
-                    <h2 className="font-display text-3xl sm:text-4xl md:text-5xl font-bold text-white mb-4">
+        <section id="how-it-works" className="relative py-20 md:py-28 px-4 md:px-6">
+            <div className="max-w-6xl mx-auto">
+                <header className="max-w-2xl mb-10 md:mb-14">
+                    <span className="eyebrow block mb-4">Pipeline</span>
+                    <h2 className="font-display text-3xl sm:text-4xl md:text-[2.75rem] font-semibold text-white tracking-tighter mb-4">
                         How it works
                     </h2>
-                    <p className="text-slate-400 text-base sm:text-lg md:text-xl max-w-xl mx-auto">
-                        Three steps, then it runs forever on every git commit via `neuralmind init-hook .`
+                    <p className="text-slate-400 text-base md:text-lg leading-relaxed">
+                        {withCode(
+                            'Three steps, then it runs forever on every git commit via `neuralmind init-hook .`',
+                        )}
                     </p>
-                </div>
+                </header>
 
-                <div className="grid grid-cols-1 md:grid-cols-3 gap-4 md:gap-6">
+                <ol className="grid grid-cols-1 md:grid-cols-3 border-t border-l border-carbon-border rounded-sm overflow-hidden">
                     {steps.map((step, i) => (
-                        <div
+                        <li
                             key={step.title}
-                            className="glow-card rounded-2xl p-6 md:p-8 relative overflow-hidden"
+                            className="relative border-b border-r border-carbon-border p-7 md:p-8"
                         >
-                            {/* Step number */}
-                            <div className="absolute top-4 right-4 text-6xl font-display font-bold text-carbon-border/30 leading-none">
-                                {String(i + 1).padStart(2, '0')}
+                            {/*
+                                The step number was 72px of near-invisible outline
+                                type sitting behind the content. It now reads as
+                                what it is: an ordinal, in the same mono face as
+                                every other piece of machine output on the site.
+                            */}
+                            <div className="flex items-center justify-between mb-6">
+                                <Icon name={step.icon} className="w-6 h-6 text-electric" />
+                                <span className="font-mono text-xs text-faint tabular-nums">
+                                    {String(i + 1).padStart(2, '0')} / {String(steps.length).padStart(2, '0')}
+                                </span>
                             </div>
 
-                            {/* Icon */}
-                            <div className="text-4xl mb-4">{step.icon}</div>
+                            <h3 className="font-display text-xl font-semibold text-white tracking-tight mb-3">
+                                {step.title}
+                            </h3>
+                            <p className="text-slate-400 leading-relaxed text-[0.9375rem] mb-6">
+                                {step.desc}
+                            </p>
 
-                            {/* Title */}
-                            <h3 className="font-display text-2xl font-bold text-white mb-3">{step.title}</h3>
-
-                            {/* Description */}
-                            <p className="text-slate-400 leading-relaxed mb-4 text-[15px]">{step.desc}</p>
-
-                            {/* Time */}
-                            <span className="text-electric-mono text-xs font-semibold tracking-wide">
+                            <span className="inline-flex items-center gap-2 font-mono text-[0.6875rem] uppercase tracking-[0.12em] text-faint">
+                                <span className="w-1 h-1 rounded-full bg-proton" />
                                 {step.time}
                             </span>
-                        </div>
+                        </li>
                     ))}
-                </div>
+                </ol>
             </div>
         </section>
     );

--- a/site/src/components/sections/ProveIt.tsx
+++ b/site/src/components/sections/ProveIt.tsx
@@ -1,3 +1,5 @@
+import SectionHeader from '@/components/ui/SectionHeader';
+
 const steps = [
     {
         step: '1',
@@ -22,25 +24,16 @@ const steps = [
 export default function ProveIt() {
     return (
         <section id="prove-it" className="relative py-16 md:py-32 px-4 md:px-6">
-            <div className="absolute top-1/3 left-0 w-[500px] h-[500px] bg-electric/3 rounded-full blur-[200px] -z-10" />
             <div className="max-w-5xl mx-auto">
-                <div className="text-center mb-12 md:mb-16">
-                    <span className="text-electric text-sm font-semibold tracking-wider uppercase mb-3 block">
-                        Don&apos;t take our word for it
-                    </span>
-                    <h2 className="font-display text-3xl sm:text-4xl md:text-5xl font-bold text-white mb-4">
-                        Prove it in 5 minutes
-                    </h2>
-                    <p className="text-slate-400 text-base sm:text-lg md:text-xl max-w-xl mx-auto">
-                        Every claim on this site reproduces from a fresh clone. No account, no signup, no cloud.
-                    </p>
-                </div>
+                <SectionHeader eyebrow="Don&apos;t take our word for it" title="Prove it in 5 minutes">
+                    Every claim on this site reproduces from a fresh clone. No account, no signup, no cloud.
+                </SectionHeader>
 
                 <div className="grid md:grid-cols-3 gap-4 mb-8">
                     {steps.map((s) => (
-                        <div key={s.step} className="glow-card rounded-2xl p-6 flex flex-col">
+                        <div key={s.step} className="card rounded-2xl p-6 flex flex-col min-w-0">
                             <div className="flex items-center gap-3 mb-3">
-                                <span className="w-8 h-8 rounded-lg bg-gradient-to-br from-electric to-proton flex items-center justify-center font-display font-bold text-white text-sm">
+                                <span className="w-7 h-7 rounded-md border border-carbon-line bg-carbon-raised flex items-center justify-center font-mono text-xs text-electric tabular-nums">
                                     {s.step}
                                 </span>
                                 <h3 className="font-display text-lg font-bold text-white">{s.title}</h3>
@@ -50,7 +43,7 @@ export default function ProveIt() {
                                 <div className="bg-carbon rounded-lg p-4 font-mono text-xs text-slate-300 overflow-x-auto mt-auto">
                                     {s.code.map((line) => (
                                         <p key={line} className="whitespace-nowrap">
-                                            <span className="text-slate-600 select-none">$ </span>
+                                            <span className="text-faint select-none">$ </span>
                                             {line}
                                         </p>
                                     ))}
@@ -69,17 +62,17 @@ export default function ProveIt() {
                     ))}
                 </div>
 
-                <div className="glow-card rounded-2xl p-6 md:p-8">
-                    <p className="text-slate-500 text-xs font-semibold uppercase tracking-wider mb-3">
+                <div className="card rounded-2xl p-6 md:p-8">
+                    <p className="text-faint text-xs font-semibold uppercase tracking-wider mb-3">
                         What the demo prints (bundled fixture)
                     </p>
                     <div className="bg-carbon rounded-lg p-4 font-mono text-xs text-slate-400 overflow-x-auto">
                         <p className="whitespace-pre">{'Q: How does authentication work in this codebase?'}</p>
-                        <p className="whitespace-pre text-slate-500">{'   naive = 4,736 tok   neuralmind =  829 tok   reduction =   5.7×'}</p>
+                        <p className="whitespace-pre text-faint">{'   naive = 4,736 tok   neuralmind =  829 tok   reduction =   5.7×'}</p>
                         <p className="whitespace-pre mt-2">{'Average reduction:   5.5×  across 3 queries'}</p>
-                        <p className="whitespace-pre text-slate-500">{'Avg context size:    859 tokens  (vs 4,736 naive)'}</p>
+                        <p className="whitespace-pre text-faint">{'Avg context size:    859 tokens  (vs 4,736 naive)'}</p>
                     </div>
-                    <p className="text-slate-500 text-xs mt-3">
+                    <p className="text-faint text-xs mt-3">
                         Small fixture, small multiplier — by design. It runs in CI on every commit as a regression
                         gate. The 12–50× headline comes from real repos; your own number is one{' '}
                         <code className="font-mono text-electric">neuralmind benchmark .</code> away.

--- a/site/src/components/ui/CommandLine.tsx
+++ b/site/src/components/ui/CommandLine.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import Icon from './Icon';
 
 /**
@@ -14,12 +14,25 @@ import Icon from './Icon';
  */
 export default function CommandLine({ command }: { command: string }) {
     const [copied, setCopied] = useState(false);
+    const resetTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+    // Clear on unmount so the reset cannot fire against a gone component.
+    useEffect(
+        () => () => {
+            if (resetTimer.current) clearTimeout(resetTimer.current);
+        },
+        [],
+    );
 
     const copy = async () => {
         try {
             await navigator.clipboard.writeText(command);
             setCopied(true);
-            setTimeout(() => setCopied(false), 1600);
+            // Cancel the previous reset first. Without this, two clicks 800ms
+            // apart leave the first timer running, and it clears the tick
+            // 800ms into the second click's window instead of 1600ms.
+            if (resetTimer.current) clearTimeout(resetTimer.current);
+            resetTimer.current = setTimeout(() => setCopied(false), 1600);
         } catch {
             // Clipboard is unavailable over plain http and in some locked-down
             // browsers. The text is selectable either way, so fail quietly.

--- a/site/src/components/ui/CommandLine.tsx
+++ b/site/src/components/ui/CommandLine.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import { useState } from 'react';
+import Icon from './Icon';
+
+/**
+ * A copy-to-clipboard install line.
+ *
+ * The hero previously wrapped `pip install neuralmind` inside the gradient
+ * primary button — a control that looked like the page's main action but was
+ * really a link to an anchor, with an unselectable code block sitting inside
+ * it. Developers try to copy that string; it should behave like a string you
+ * can copy.
+ */
+export default function CommandLine({ command }: { command: string }) {
+    const [copied, setCopied] = useState(false);
+
+    const copy = async () => {
+        try {
+            await navigator.clipboard.writeText(command);
+            setCopied(true);
+            setTimeout(() => setCopied(false), 1600);
+        } catch {
+            // Clipboard is unavailable over plain http and in some locked-down
+            // browsers. The text is selectable either way, so fail quietly.
+        }
+    };
+
+    return (
+        <div className="inline-flex items-stretch rounded-lg border border-carbon-border bg-carbon-raised overflow-hidden">
+            <code className="flex items-center gap-2.5 font-mono text-sm text-slate-200 px-4 py-3 select-all">
+                <span className="text-faint select-none">$</span>
+                {command}
+            </code>
+            <button
+                type="button"
+                onClick={copy}
+                aria-label={copied ? 'Copied to clipboard' : `Copy "${command}" to clipboard`}
+                className="flex items-center justify-center w-11 border-l border-carbon-border text-faint hover:text-white hover:bg-white/[0.04] transition-colors"
+            >
+                {copied ? (
+                    <Icon name="check" className="w-4 h-4 text-proton" strokeWidth={2} />
+                ) : (
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5}
+                        strokeLinecap="round" strokeLinejoin="round" className="w-4 h-4" aria-hidden="true">
+                        <rect x="9" y="9" width="12" height="12" rx="2" />
+                        <path d="M5 15H4a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h10a1 1 0 0 1 1 1v1" />
+                    </svg>
+                )}
+            </button>
+            <span aria-live="polite" className="sr-only">
+                {copied ? 'Copied' : ''}
+            </span>
+        </div>
+    );
+}

--- a/site/src/components/ui/Icon.tsx
+++ b/site/src/components/ui/Icon.tsx
@@ -1,0 +1,238 @@
+/**
+ * The icon set.
+ *
+ * Every icon on the homepage used to be an emoji rendered at `text-3xl` —
+ * 🧠 🔮 🚀 🆓 🗑️ and eleven more. Emoji are drawn by the operating system, so
+ * the site had no control over their weight, colour, alignment or metrics:
+ * they arrived full-colour and cartoon-styled into an otherwise monochrome
+ * page, and looked different on macOS, Windows and Android. That is the
+ * single loudest "assembled from a template" signal a product page can send.
+ *
+ * These are drawn to one spec instead: 24×24 box, 1.5 stroke, round caps and
+ * joins, no fills, `currentColor` throughout. They inherit text colour and
+ * size like type does, so an icon in a muted card is muted and an icon in an
+ * accented one is accented, without a second set of assets.
+ *
+ * Each one depicts its actual subject — the synapse layer is a weighted node
+ * cluster, progressive disclosure is four rows of increasing length, the
+ * local engine is a struck-through globe — rather than reaching for the
+ * nearest vaguely-thematic pictograph.
+ */
+
+export type IconName =
+    | 'chip'
+    | 'synapse'
+    | 'layers'
+    | 'dashboard'
+    | 'doc-code'
+    | 'doc-link'
+    | 'hub'
+    | 'tree'
+    | 'restore'
+    | 'key'
+    | 'offline'
+    | 'terminal'
+    | 'shield-check'
+    | 'export'
+    | 'report-query'
+    | 'index'
+    | 'query'
+    | 'recall'
+    | 'check'
+    | 'arrow-right';
+
+const paths: Record<IconName, React.ReactNode> = {
+    // Local retrieval — silicon, not a round trip.
+    chip: (
+        <>
+            <rect x="5" y="5" width="14" height="14" rx="2" />
+            <rect x="9" y="9" width="6" height="6" rx="1" />
+            <path d="M9 3v2M15 3v2M9 19v2M15 19v2M3 9h2M3 15h2M19 9h2M19 15h2" />
+        </>
+    ),
+    // Hebbian layer — a hub and its co-activated neighbours.
+    synapse: (
+        <>
+            <circle cx="12" cy="12" r="2.5" />
+            <circle cx="5" cy="5.5" r="1.75" />
+            <circle cx="19.5" cy="8" r="1.75" />
+            <circle cx="16" cy="19.5" r="1.75" />
+            <path d="M6.3 6.9 10.2 10.4" />
+            <path d="M17.9 8.9 14.2 11" />
+            <path d="M15.1 17.6 13 14.3" />
+        </>
+    ),
+    // L0 → L3: each level discloses more than the last.
+    layers: (
+        <>
+            <path d="M4 5.5h5" />
+            <path d="M4 10.5h9" />
+            <path d="M4 15.5h13" />
+            <path d="M4 20.5h16" />
+        </>
+    ),
+    dashboard: (
+        <>
+            <rect x="3" y="4" width="18" height="16" rx="2" />
+            <path d="M3 9h18" />
+            <path d="M7 16.5l3-3.5 2.5 2L17 10.5" />
+        </>
+    ),
+    'doc-code': (
+        <>
+            <path d="M13.5 3H7a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V8.5Z" />
+            <path d="M13.5 3v5.5H19" />
+            <path d="M10.6 12.6 9 14.2l1.6 1.6" />
+            <path d="M13.4 12.6 15 14.2l-1.6 1.6" />
+        </>
+    ),
+    // Business docs seeded into the code graph.
+    'doc-link': (
+        <>
+            <rect x="3" y="4.5" width="9" height="12" rx="1.5" />
+            <path d="M5.7 8h3.6" />
+            <path d="M5.7 11h3.6" />
+            <circle cx="19.5" cy="7" r="1.75" />
+            <circle cx="18" cy="17.5" r="2" />
+            <path d="M12 10c3.2 0 3.6-2 5.8-2.7" />
+            <path d="M12 13.4c3 0 4.2 1.8 4.9 2.6" />
+        </>
+    ),
+    hub: (
+        <>
+            <rect x="8.5" y="8.5" width="7" height="7" rx="1.75" />
+            <path d="M12 8.5V5.5" />
+            <path d="M15.5 12h3" />
+            <path d="M12 15.5v3" />
+            <path d="M8.5 12h-3" />
+            <circle cx="12" cy="3.75" r="1.5" />
+            <circle cx="20.25" cy="12" r="1.5" />
+            <circle cx="12" cy="20.25" r="1.5" />
+            <circle cx="3.75" cy="12" r="1.5" />
+        </>
+    ),
+    // tree-sitter output: a syntax tree.
+    tree: (
+        <>
+            <circle cx="12" cy="4" r="2" />
+            <circle cx="12" cy="12" r="2" />
+            <circle cx="5.5" cy="20" r="2" />
+            <circle cx="18.5" cy="20" r="2" />
+            <path d="M12 6v4" />
+            <path d="M10.4 13.4 7.1 18.3" />
+            <path d="M13.6 13.4 16.9 18.3" />
+        </>
+    ),
+    // Dropped tool output, pulled back into the buffer.
+    restore: (
+        <>
+            <path d="M4 13.5V18a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-4.5" />
+            <path d="M8 9.5 12 13.5 16 9.5" />
+            <path d="M12 13.5V3.5" />
+        </>
+    ),
+    key: (
+        <>
+            <circle cx="7.5" cy="16.5" r="4" />
+            <path d="M10.4 13.6 20.5 3.5" />
+            <path d="M16.4 7.6 18.9 10.1" />
+            <path d="M13.9 10.1 15.9 12.1" />
+        </>
+    ),
+    // Zero network calls of its own.
+    offline: (
+        <>
+            <circle cx="12" cy="12" r="9" />
+            <path d="M3.2 12h17.6" />
+            <path d="M12 3c2.4 2.7 3.7 5.7 3.7 9s-1.3 6.3-3.7 9c-2.4-2.7-3.7-5.7-3.7-9S9.6 5.7 12 3Z" />
+            <path d="M4.6 19.4 19.4 4.6" />
+        </>
+    ),
+    terminal: (
+        <>
+            <rect x="3" y="4" width="18" height="16" rx="2" />
+            <path d="M7.5 9.5 10.5 12.5 7.5 15.5" />
+            <path d="M13 15.5h4" />
+        </>
+    ),
+    'shield-check': (
+        <>
+            <path d="M12 21.5s7.5-3.5 7.5-9.5V5.5L12 2.5 4.5 5.5V12c0 6 7.5 9.5 7.5 9.5Z" />
+            <path d="M9 11.8 11.2 14 15.2 9.8" />
+        </>
+    ),
+    export: (
+        <>
+            <path d="M12 21H6.5A1.5 1.5 0 0 1 5 19.5v-15A1.5 1.5 0 0 1 6.5 3h6.8L18 7.7v3.6" />
+            <path d="M13 3v5h5" />
+            <path d="M14.5 17.5H21" />
+            <path d="M18.5 15 21 17.5 18.5 20" />
+        </>
+    ),
+    'report-query': (
+        <>
+            <path d="M4 5.5h12" />
+            <path d="M4 10h12" />
+            <path d="M4 14.5h6" />
+            <circle cx="15" cy="16" r="3.5" />
+            <path d="M17.6 18.6 20.6 21.6" />
+        </>
+    ),
+    index: (
+        <>
+            <ellipse cx="12" cy="6" rx="8" ry="3" />
+            <path d="M4 6v6c0 1.66 3.58 3 8 3s8-1.34 8-3V6" />
+            <path d="M4 12v6c0 1.66 3.58 3 8 3s8-1.34 8-3v-6" />
+        </>
+    ),
+    query: (
+        <>
+            <circle cx="10.5" cy="10.5" r="7" />
+            <circle cx="10.5" cy="10.5" r="2" />
+            <path d="M15.6 15.6 21 21" />
+        </>
+    ),
+    // Recall: the loop that keeps running around what you already know.
+    recall: (
+        <>
+            <circle cx="12" cy="12" r="2.5" />
+            <path d="M12 3.6a8.4 8.4 0 0 1 8.1 6.1" />
+            <path d="M12 20.4a8.4 8.4 0 0 1-8.1-6.1" />
+            <path d="M15.9 10.5 20.4 10 19.6 5.6" />
+            <path d="M8.1 13.5 3.6 14l.8 4.4" />
+        </>
+    ),
+    check: <path d="M4.5 12.5 9.5 17.5 19.5 6.5" />,
+    'arrow-right': (
+        <>
+            <path d="M4 12h15" />
+            <path d="M13.5 6.5 19.5 12l-6 5.5" />
+        </>
+    ),
+};
+
+export default function Icon({
+    name,
+    className = 'w-5 h-5',
+    strokeWidth = 1.5,
+}: {
+    name: IconName;
+    className?: string;
+    strokeWidth?: number;
+}) {
+    return (
+        <svg
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={strokeWidth}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className={className}
+            aria-hidden="true"
+            focusable="false"
+        >
+            {paths[name]}
+        </svg>
+    );
+}

--- a/site/src/components/ui/Logo.tsx
+++ b/site/src/components/ui/Logo.tsx
@@ -1,0 +1,25 @@
+/**
+ * The mark.
+ *
+ * Was a rounded square filled with a blue→purple gradient containing the
+ * letter "N" — the default logo of every generated startup template, and the
+ * one element that appears on every page of the site.
+ *
+ * This draws the actual product instead: a hub node with three weighted edges
+ * to its neighbours, which is what the synapse layer is. The three edges carry
+ * different stroke weights because the weights are the point — associations
+ * strengthen with co-activation.
+ */
+export default function Logo({ className = 'w-[1.625rem] h-[1.625rem]' }: { className?: string }) {
+    return (
+        <svg viewBox="0 0 28 28" fill="none" className={className} aria-hidden="true">
+            <path d="M9.6 9.1 12.3 12" stroke="currentColor" strokeWidth="2.1" strokeLinecap="round" />
+            <path d="M15.9 12.6 19.4 10.6" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+            <path d="M14.6 16.5 16.2 20" stroke="currentColor" strokeWidth="1" strokeLinecap="round" />
+            <circle cx="14" cy="14" r="3.1" fill="currentColor" />
+            <circle cx="7.4" cy="7.4" r="2.4" fill="currentColor" />
+            <circle cx="21.4" cy="9" r="1.9" fill="currentColor" opacity="0.75" />
+            <circle cx="17.2" cy="21.6" r="1.5" fill="currentColor" opacity="0.5" />
+        </svg>
+    );
+}

--- a/site/src/components/ui/SectionHeader.tsx
+++ b/site/src/components/ui/SectionHeader.tsx
@@ -1,0 +1,36 @@
+/**
+ * One section header, used by every section.
+ *
+ * Each section previously wrote its own: centred, with an eyebrow in
+ * `text-sm font-semibold uppercase tracking-wider` coloured either electric
+ * or proton depending on the section, and an `md:text-5xl font-bold` title.
+ * Nine near-identical implementations that disagreed on colour and weight is
+ * how a page ends up looking assembled rather than designed.
+ *
+ * Left-aligned, because centred body copy over 60+ characters gives the eye
+ * no consistent return edge — which is why the Benchmarks intro broke into
+ * four ragged lines around its inline code span.
+ */
+export default function SectionHeader({
+    eyebrow,
+    title,
+    children,
+    className = '',
+}: {
+    eyebrow: string;
+    title: string;
+    children?: React.ReactNode;
+    className?: string;
+}) {
+    return (
+        <header className={`max-w-2xl mb-10 md:mb-14 ${className}`}>
+            <span className="eyebrow block mb-4">{eyebrow}</span>
+            <h2 className="font-display text-3xl sm:text-4xl md:text-[2.75rem] font-semibold text-white tracking-tighter mb-4">
+                {title}
+            </h2>
+            {children && (
+                <div className="text-slate-400 text-base md:text-lg leading-relaxed">{children}</div>
+            )}
+        </header>
+    );
+}

--- a/site/src/lib/fonts.ts
+++ b/site/src/lib/fonts.ts
@@ -1,0 +1,43 @@
+/**
+ * Webfonts, actually loaded.
+ *
+ * The site declared `Inter`, `JetBrains Mono` and `Fraunces` in
+ * `tailwind.config.ts` but never loaded a single one, so every `font-display`
+ * heading — 113 of them across 25 files, including the hero and the logo —
+ * fell through to the generic `serif` fallback and rendered in Times New
+ * Roman. That one missing link is most of what made the site read as a
+ * template.
+ *
+ * `next/font` downloads and self-hosts at build time, so the static export
+ * ships the woff2 files itself: no runtime request to fonts.gstatic.com, no
+ * third-party connection for a privacy page to have to explain, and no FOUT
+ * beyond the `swap` window.
+ */
+import { Inter, Inter_Tight, JetBrains_Mono } from 'next/font/google';
+
+/** UI and body copy. */
+export const sans = Inter({
+    subsets: ['latin'],
+    display: 'swap',
+    variable: '--font-sans',
+});
+
+/**
+ * Headlines. Inter Tight is the same voice as the body at display size —
+ * tighter apertures, less sidebearing — so headings read dense and
+ * deliberate instead of introducing a second, unrelated typeface.
+ */
+export const display = Inter_Tight({
+    subsets: ['latin'],
+    display: 'swap',
+    variable: '--font-display',
+});
+
+/** Code, CLI invocations, and every measured figure. */
+export const mono = JetBrains_Mono({
+    subsets: ['latin'],
+    display: 'swap',
+    variable: '--font-mono',
+});
+
+export const fontVariables = `${sans.variable} ${display.variable} ${mono.variable}`;

--- a/site/src/lib/ticks.tsx
+++ b/site/src/lib/ticks.tsx
@@ -1,0 +1,31 @@
+/**
+ * Renders the backtick spans that the copy has always contained.
+ *
+ * Strings like '`neuralmind init-hook .` keeps it current' were being printed
+ * verbatim, backticks and all, on the homepage — the page was showing its own
+ * markdown source. This splits on the ticks and styles the code spans, so the
+ * copy stays byte-identical in source (which `tests/test_site_claims.py`
+ * scans) while rendering the way it was written to read.
+ *
+ * The span must be allowed to wrap. `pip install neuralmind && neuralmind
+ * wakeup .` is 46 characters and does not fit a three-column grid cell; held
+ * on one line it ran straight through the cell border and over the next
+ * column's prose.
+ */
+import { Fragment } from 'react';
+
+export function withCode(text: string) {
+    const parts = text.split('`');
+    return parts.map((part, i) =>
+        i % 2 === 1 ? (
+            <code
+                key={i}
+                className="font-mono text-[0.9em] text-electric-bright bg-electric/[0.07] rounded px-1 py-0.5 break-words"
+            >
+                {part}
+            </code>
+        ) : (
+            <Fragment key={i}>{part}</Fragment>
+        ),
+    );
+}

--- a/site/tailwind.config.ts
+++ b/site/tailwind.config.ts
@@ -1,4 +1,25 @@
 /** @type {import('tailwindcss').Config} */
+
+/**
+ * Design tokens.
+ *
+ * The legacy names (`carbon*`, `electric*`, `proton`, `iris`) are kept because
+ * 200+ usages across 25 files reference them; repointing the values here
+ * restyles every page at once instead of touching each one. What changed is
+ * what they mean:
+ *
+ * - `carbon*` lost its navy cast. The old #070b15 was a blue-black, which is
+ *   what put the whole site on the same footing as every dark SaaS template.
+ *   These are true neutrals, so the one accent is the only chromatic thing on
+ *   the page and therefore actually reads as an accent.
+ * - `electric` is the single interactive colour: links, focus rings, the
+ *   primary action. It is no longer Tailwind's own blue-500 (#3b82f6), which
+ *   is the most default colour on the web.
+ * - `proton` stopped being the purple half of a blue→purple→pink gradient and
+ *   became the evidence colour — verified, measured, CI-gated. Blue means
+ *   "you can click this", green means "this was measured". Two colours with
+ *   two jobs, which is a system; six colours with no jobs is a mood board.
+ */
 module.exports = {
     content: [
         './src/pages/**/*.{js,ts,jsx,tsx,mdx}',
@@ -8,28 +29,46 @@ module.exports = {
     theme: {
         extend: {
             colors: {
-                carbon: '#070b15',
-                'carbon-raised': '#0c1322',
-                'carbon-card': '#0e1626',
-                'carbon-border': '#1b2740',
-                electric: '#3b82f6',
-                'electric-bright': '#60a5fa',
-                proton: '#a855f7',
-                iris: '#8b5cf6',
+                // Surfaces — neutral, four steps, each a real elevation.
+                carbon: '#0A0B0D',
+                'carbon-raised': '#0F1114',
+                'carbon-card': '#131518',
+                'carbon-border': '#22262C',
+                'carbon-line': '#2E333B',
+
+                // Interactive.
+                electric: '#5B8CFF',
+                'electric-bright': '#93B4FF',
+                'electric-dim': '#1B2742',
+
+                // Evidence / measured.
+                proton: '#4FD1A5',
+                'proton-dim': '#16302A',
+
+                // Retained so stray references resolve; deliberately near-neutral.
+                iris: '#8A93A3',
+
+                // Muted text that still clears WCAG AA on `carbon`. Tailwind's
+                // own slate-500 and slate-600 do not, which is what the whole
+                // site was using for captions, labels and legal lines.
+                faint: '#7E8794',
             },
             fontFamily: {
-                sans: ['Inter', 'system-ui', 'sans-serif'],
-                mono: ['JetBrains Mono', 'monospace'],
-                display: ['Fraunces', 'serif'],
+                sans: ['var(--font-sans)', 'ui-sans-serif', 'system-ui', 'sans-serif'],
+                mono: ['var(--font-mono)', 'ui-monospace', 'SFMono-Regular', 'monospace'],
+                display: ['var(--font-display)', 'var(--font-sans)', 'ui-sans-serif', 'system-ui', 'sans-serif'],
+            },
+            letterSpacing: {
+                tightest: '-0.045em',
+                tighter: '-0.03em',
+            },
+            borderRadius: {
+                card: '0.625rem',
             },
             animation: {
-                'fade-in': 'fadeIn 0.8s ease-out',
-                'fade-up': 'fadeUp 0.6s ease-out',
-                'pulse-glow': 'pulseGlow 2s ease-in-out infinite',
-                'slide-up': 'slideUp 0.6s ease-out',
-                'tag-roll': 'tagRoll 0.5s ease-out',
-                'sparkle': 'sparkle 1.5s ease-in-out infinite',
-                'ping-slow': 'ping 3s cubic-bezier(0, 0, 0.2, 1) infinite',
+                'fade-in': 'fadeIn 0.5s ease-out both',
+                'fade-up': 'fadeUp 0.5s cubic-bezier(0.16, 1, 0.3, 1) both',
+                'tag-roll': 'tagRoll 0.4s cubic-bezier(0.16, 1, 0.3, 1)',
             },
             keyframes: {
                 fadeIn: {
@@ -37,24 +76,12 @@ module.exports = {
                     '100%': { opacity: '1' },
                 },
                 fadeUp: {
-                    '0%': { opacity: '0', transform: 'translateY(16px)' },
-                    '100%': { opacity: '1', transform: 'translateY(0)' },
-                },
-                pulseGlow: {
-                    '0%, 100%': { boxShadow: '0 0 0 0 rgba(96, 165, 250, 0.3)' },
-                    '50%': { boxShadow: '0 0 30px 5px rgba(96, 165, 250, 0.4)' },
-                },
-                slideUp: {
-                    '0%': { opacity: '0', transform: 'translateY(24px)' },
+                    '0%': { opacity: '0', transform: 'translateY(10px)' },
                     '100%': { opacity: '1', transform: 'translateY(0)' },
                 },
                 tagRoll: {
-                    '0%': { opacity: '0', transform: 'translateY(20px)' },
+                    '0%': { opacity: '0', transform: 'translateY(8px)' },
                     '100%': { opacity: '1', transform: 'translateY(0)' },
-                },
-                sparkle: {
-                    '0%, 100%': { opacity: '0.4' },
-                    '50%': { opacity: '1' },
                 },
             },
         },


### PR DESCRIPTION
## Description

The site read as a generated template because, structurally, it was one: a blue→purple→pink gradient headline, glow cards, six 200px-blurred colour blobs, and fifteen operating-system emoji standing in for a product icon set. This replaces the visual system underneath it.

**No marketing copy changed.** Every figure is byte-identical in source, and `tests/test_site_claims.py` still gates all of it.

**The single largest defect: no webfont was ever loaded.** `tailwind.config.ts` declared Inter, JetBrains Mono and Fraunces, but nothing imported them — so all 113 `font-display` headings across 25 files (the hero, the logo, every section title) fell through to the generic `serif` fallback and rendered in **Times New Roman**. Fonts are now loaded and self-hosted via `next/font`; the static export makes no request to `fonts.gstatic.com`.

### Design system

- **Neutral surfaces.** The old `#070b15` was a blue-black. True neutrals let the one accent read as an accent.
- **Two colours with two jobs**: `electric` = interactive, `proton` = measured evidence. Replaces a six-colour palette where nothing meant anything. This mirrors the evidence-grading the Benchmarks table already applied in prose.
- **A drawn 24×24 icon set** at one spec (1.5 stroke, `currentColor`), each icon depicting its actual subject, replacing ⚡🧬🔄📊🔬🧠🌐🎯🗑️🆓🔒🚀🛡️📤🤖.
- **A shared `SectionHeader`**, replacing nine hand-rolled headers that disagreed on colour, weight and alignment.
- **Ruled matrices** for the hero stats, feature grid, pipeline and benchmark figures, so a number looks the same everywhere it appears.
- **A synapse-glyph logo mark** in place of the gradient "N" tile.
- **Navbar**: ten equal-weight links that only stopped colliding at 1280px, now grouped into Product/Resources menus with keyboard and click-outside handling; mobile breakpoint moved 1280px → 1024px. All ten destinations still reachable.
- **Footer**: three labelled columns instead of one wrapped row of twelve links.

### Defects fixed along the way

| Defect | Effect |
|---|---|
| `text-electric-mono` (3 uses) was not a defined colour | Those elements silently inherited |
| Backtick spans rendered literally | The page was showing its own markdown source |
| Every footer link carried `target="_blank"` | `/privacy`, `/terms`, `/pricing`, `/services`, `/team` each opened a new tab |
| ProveIt step cards had no `min-w-0` | Grid item sized to its widest code line — the whole document scrolled sideways at 390px (580px wide) |
| `slate-500` (4.14:1) and `slate-600` (2.50:1) used for captions, labels, legal lines | Below the 4.5:1 WCAG AA floor |
| No `:focus-visible` styling existed at all | Keyboard users navigated by the browser default outline over a dark background |
| `prefers-reduced-motion` unhandled | A status dot pulsed indefinitely regardless of the OS setting |

### Note on the commit type

Typed `feat(site):` so this ships with the next release. `release-please-config.json` is root-scoped with no path filtering, so this will cut a **minor** version bump and a PyPI + GHCR publish, and the change will appear in `CHANGELOG.md`.

Worth knowing when merging: `main` uses squash merges (its commits carry `(#NNN)` suffixes), so the **PR title** is what becomes the commit subject release-please parses. The branch commit has been retyped to match, so either merge strategy produces `feat`.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🎨 Style/formatting change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Unit tests
- [x] Manual testing

- `npx next build` and `npx tsc --noEmit` — clean
- `tests/test_site_claims.py` + `tests/test_docs_claims.py` — 16 passed
- `scripts/check_commercial_terms.py` — passed
- **Contrast audit**: every text node on all nine pages measured against its computed effective background. Was 13 nodes below AA on `/` alone; now `0` across `/`, `/pricing`, `/effectiveness`, `/security`, `/team`, `/services`, `/publications`, `/privacy`, `/terms`.
- **Overflow check**: `scrollWidth == clientWidth` at 390 / 768 / 1024px (was 580px at 390px).
- Rendered fonts confirmed resolving to Inter Tight / Inter / JetBrains Mono, and 20 `.woff2` files confirmed emitted into `out/` with zero external font requests in the built HTML.

### Test Configuration

* **Test command**: `python3 -m pytest tests/test_site_claims.py tests/test_docs_claims.py -q` and `cd site && npx next build`

## Documentation & discoverability

- [x] N/A — no CLI command, MCP tool, hook, env var or agent-visible behavior changed. This is presentation-only on the marketing site; product surfaces are untouched.
- [x] I did **not** edit `CHANGELOG.md` or hand-bump the `pyproject.toml` version

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Code Quality

- [x] Type hints are added for new functions/methods (TS prop types on all six new components)
- [x] Docstrings are added/updated for public APIs (each new module documents what it replaced and why)

## Additional Notes

Two things I noticed but deliberately left alone, since both are copy decisions rather than design ones:

1. **The feature grid is fifteen flat items** whose `badge` field mixes version numbers (`v2.0.0`), superlatives (`New`) and metrics (`45–257×`). It reads as a changelog rather than a capability list. Grouping it into three or four themed clusters would help, but that's an IA/copy call.
2. **`~15 min` renders in the mono `metric` face** alongside `93.75%` and `45–257×`. Consistent with treating it as a measured quantity, but the word "min" in JetBrains Mono may read as code to you. One-line change if you'd prefer it in the display face.