### PR TITLE
fix(compliance): stop parsing version strings and SVG paths as SOC 2 controls

### DIFF
--- a/neuralmind/compliance_matcher.py
+++ b/neuralmind/compliance_matcher.py
@@ -109,7 +109,7 @@ _PATTERNS: list[tuple[str, re.Pattern]] = [
         "ISO 27001",
         re.compile(
             r"""
-            (?:ISO\s*27001|COMPLIANCE)   # required marker
+            (?:\bISO\s*27001|\bCOMPLIANCE)\b   # required marker, whole word
             [^\n]{0,32}?                  # optional intervening words, same line
             \b
             (?P<control_id>
@@ -137,11 +137,17 @@ _PATTERNS: list[tuple[str, re.Pattern]] = [
     # marker may be the framework name or the generic ``Compliance:`` keyword,
     # and intervening words are allowed so the documented form
     # ``**SOC 2 Control:** CC6.1`` keeps working.
+    #
+    # The marker needs word boundaries or it matches as a substring: without
+    # them ``noncompliance: CC6.1`` matches on the tail of "noncompliance" —
+    # a word that appears constantly in compliance prose — and ``SOC 20`` /
+    # ``ISO 270010`` match the real marker and absorb the trailing digit as
+    # intervening text.
     (
         "SOC2",
         re.compile(
             r"""
-            (?:SOC\s*2|COMPLIANCE)      # required marker
+            (?:\bSOC\s*2|\bCOMPLIANCE)\b  # required marker, whole word
             [^\n]{0,32}?                 # optional intervening words, same line
             \b
             (?P<control_id>

--- a/neuralmind/compliance_matcher.py
+++ b/neuralmind/compliance_matcher.py
@@ -103,13 +103,17 @@ _PATTERNS: list[tuple[str, re.Pattern]] = [
         ),
     ),
     # ISO 27001: A.9.2.1, A.12.6.1, etc.
+    # Marker required — see the SOC 2 note below. Without one, minified SVG arc
+    # shorthand (``a.5.5 0 0 1``) parses as control ``A.5.5``.
     (
         "ISO 27001",
         re.compile(
             r"""
-            (?:ISO\s*27001[:\s]+)?
+            (?:ISO\s*27001|COMPLIANCE)   # required marker
+            [^\n]{0,32}?                  # optional intervening words, same line
+            \b
             (?P<control_id>
-                A\.\d+(?:\.\d+)+     # e.g. A.9.2.1
+                (?-i:A)\.\d+(?:\.\d+)+   # e.g. A.9.2.1 — never lowercase
             )
             [:\s]+
             (?P<label>.+?)
@@ -119,13 +123,30 @@ _PATTERNS: list[tuple[str, re.Pattern]] = [
         ),
     ),
     # SOC 2: CC6.1, CC7.2, P1.1, PI1.4, etc. (Trust Services Criteria)
+    #
+    # The marker is REQUIRED. It used to be optional, which left the pattern as
+    # "any 1-3 letters, digits, a dot, digits" — a shape that matches far more
+    # than SOC 2 criteria. Scanning this repo produced 147 SOC 2 "annotations"
+    # of which 129 were noise: 67 version strings (``v0.13``, ``v2.0``), 39 SVG
+    # path commands (``M13.5``, ``A1.5`` — ``M``/``L``/``C``/``A``/``S`` are
+    # path verbs), 18 eval milestone ids (``E1.4``), plus ``python3.10``,
+    # ``TLSv1.2`` and ``llama3.1``. Those flowed into ``neuralmind export
+    # --audit``, which users submit as compliance evidence.
+    #
+    # NIST above already required its prefix for exactly this reason. The
+    # marker may be the framework name or the generic ``Compliance:`` keyword,
+    # and intervening words are allowed so the documented form
+    # ``**SOC 2 Control:** CC6.1`` keeps working.
     (
         "SOC2",
         re.compile(
             r"""
-            (?:SOC\s*2?[:\s]+)?         # optional "SOC2" or "SOC 2" prefix
+            (?:SOC\s*2|COMPLIANCE)      # required marker
+            [^\n]{0,32}?                 # optional intervening words, same line
+            \b
             (?P<control_id>
-                [A-Z]{1,3}\d+\.\d+       # e.g. CC6.1, CC7.2, P1.1, PI1.4
+                (?-i:[A-Z]{1,3})\d+\.\d+  # e.g. CC6.1 — never lowercase, so
+                                          # ``v0.13`` and ``m13.5`` cannot match
             )
             [:\s]+
             (?P<label>.+?)

--- a/tests/test_compliance_matcher.py
+++ b/tests/test_compliance_matcher.py
@@ -1,0 +1,129 @@
+"""Guard the compliance annotation matcher against false positives.
+
+``neuralmind/compliance_matcher.py`` had no tests, and two of its six patterns
+made their framework marker optional. That reduced them to "one to three
+letters, digits, a dot, digits" — a shape shared by version strings, SVG path
+commands, and milestone ids. Scanning this repo produced 147 SOC 2
+"annotations" of which 129 were noise.
+
+That matters more than a noisy scan: these annotations feed ``neuralmind
+export --audit``, documented as producing "flat compliance reports (CSV/JSON)
+for evidence submission". A fabricated control in an audit export is a
+materially worse failure than a missed one, so these tests pin precision.
+
+Stdlib-only, like the other guard modules, so they run without the full dep
+set.
+"""
+
+from __future__ import annotations
+
+from neuralmind.compliance_matcher import find_compliance_annotations
+
+
+def _controls(text: str, framework: str) -> set[str]:
+    return {
+        h["control_id"] for h in find_compliance_annotations(text) if h["framework"] == framework
+    }
+
+
+# --------------------------------------------------------------------------- #
+# SOC 2 — the pattern that regressed
+# --------------------------------------------------------------------------- #
+
+
+def test_soc2_matches_the_documented_annotation_forms() -> None:
+    """Every form the repo's own docs and CLI help actually use."""
+    # The form used throughout docs/compliance/*.md.
+    assert "CC6.1" in _controls("**SOC 2 Control:** CC6.1\n---\n", "SOC2")
+    # A comma list — the last id is the one that reaches a separator.
+    assert "A1.1" in _controls("**SOC 2 Controls:** CC3.1, CC8.1, A1.1\n---\n", "SOC2")
+    # The generic `Compliance:` keyword CLAUDE.md documents.
+    assert "CC6.1" in _controls("# Compliance: CC6.1: Logical access controls.\n", "SOC2")
+    # An inline code annotation.
+    assert "CC7.2" in _controls("// SOC2 CC7.2: System monitoring detects anomalies.\n", "SOC2")
+
+
+def test_soc2_does_not_match_svg_path_data() -> None:
+    """M, L, C, A and S are SVG path verbs, not Trust Services Criteria.
+
+    The regression that surfaced this: a 15-icon SVG set added to the
+    marketing site produced 33 fabricated SOC 2 annotations in one PR.
+    """
+    icons = [
+        '<path d="M13.5 3H7a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V8.5Z" />',
+        '<path d="M3.2 12h17.6" />',
+        '<path d="M15.5 12h3" />',
+        '<path d="M9.6 9.1 12.3 12" stroke="currentColor" />',
+        '<path d="M4.5 12.5 9.5 17.5 19.5 6.5" />',
+    ]
+    for markup in icons:
+        assert find_compliance_annotations(markup) == [], markup
+
+
+def test_soc2_does_not_match_version_strings() -> None:
+    """The single largest source of noise: 67 of the 129 false positives."""
+    prose = [
+        'Shipped in v0.13.0 — the "Measure" release is built around this.\n',
+        "Roadmap: v2.0 Complete, v0.22 flipped the default backend to auto.\n",
+        "pip install neuralmind==0.3 for the old format.\n",
+    ]
+    for text in prose:
+        assert _controls(text, "SOC2") == set(), text
+
+
+def test_soc2_does_not_match_toolchain_and_milestone_identifiers() -> None:
+    """`python3.10` became HON3.10, `TLSv1.2` became LSV1.2, `llama3.1` AMA3.1."""
+    for text in (
+        "Install with python3.10 -m venv neuralmind-env\n",
+        "Requires TLSv1.2 or newer for transport.\n",
+        "Tested against llama3.1 70b locally.\n",
+        "Milestone E1.4 deliverable) implemented in the harness.\n",
+    ):
+        assert _controls(text, "SOC2") == set(), text
+
+
+# --------------------------------------------------------------------------- #
+# ISO 27001 — same latent flaw, found while fixing SOC 2
+# --------------------------------------------------------------------------- #
+
+
+def test_iso27001_matches_its_documented_form() -> None:
+    assert "A.9.2.1" in _controls(
+        "**ISO 27001:** A.9.2.1: User access provisioning.\n", "ISO 27001"
+    )
+
+
+def test_iso27001_does_not_match_minified_svg_arcs() -> None:
+    """`a.5.5 0 0 1` is legal SVG arc shorthand; it parsed as control A.5.5."""
+    markup = '<path d="M4 8a.5.5 0 0 1 .5-.5h7a.5.5 0 0 1 0 1h-7A.5.5 0 0 1 4 8Z"/>'
+    assert find_compliance_annotations(markup) == []
+
+
+# --------------------------------------------------------------------------- #
+# The four patterns that were already correct must stay correct
+# --------------------------------------------------------------------------- #
+
+
+def test_other_frameworks_still_match() -> None:
+    cases = [
+        ("CMMC", "// CMMC AC.L2-3.1.1: Authorized Access Control\n", "AC.L2-3.1.1"),
+        # Note: the NIST pattern accepts "NIST AC-1" and "NIST SP 800-53: AC-1"
+        # but not "NIST: AC-1" — its prefix group consumes exactly one
+        # separator char. Pre-existing, and out of scope here; pinned so a
+        # future change to that pattern is a deliberate one.
+        ("NIST", "# NIST AC-1: Access control policy\n", "AC-1"),
+        ("SOX ITGC", "// SOX ITGC-CM-001: Change approved via CAB\n", "ITGC-CM-001"),
+        ("HIPAA", "/* HIPAA 164.312(a)(1): Access control required */\n", "164.312(A)(1)"),
+    ]
+    for framework, text, control_id in cases:
+        assert control_id in _controls(text, framework), (framework, text)
+
+
+def test_plain_source_code_yields_nothing() -> None:
+    """A file with no compliance intent must produce no annotations at all."""
+    source = (
+        "def handle(request):\n"
+        "    # Retry up to 3.5 seconds, see RFC 7231 section 6.5.\n"
+        '    return {"status": 200, "version": "v1.2"}\n'
+    )
+    assert find_compliance_annotations(source) == []

--- a/tests/test_compliance_matcher.py
+++ b/tests/test_compliance_matcher.py
@@ -82,6 +82,37 @@ def test_soc2_does_not_match_toolchain_and_milestone_identifiers() -> None:
         assert _controls(text, "SOC2") == set(), text
 
 
+def test_soc2_marker_must_be_a_whole_word() -> None:
+    """The marker is matched with word boundaries, not as a substring.
+
+    Raised by Copilot review on #453. Without boundaries, "noncompliance" —
+    a word that appears constantly in compliance prose — ends in the generic
+    marker, and "SOC 20" matches the real marker then absorbs the stray digit
+    as intervening text.
+    """
+    for text in (
+        "SOC 20 CC6.1: fabricated\n",
+        "noncompliance: CC6.1: fabricated\n",
+        "Our noncompliance with CC6.1: fabricated\n",
+    ):
+        assert _controls(text, "SOC2") == set(), text
+
+
+def test_soc2_control_ids_are_case_sensitive() -> None:
+    """Pins the scoped ``(?-i:)`` on the control id.
+
+    The SVG tests above carry no marker, so they pass on the marker rule alone
+    and would still pass if the case-sensitivity modifier were deleted. These
+    supply a marker, so only the modifier can reject them — which matters
+    because SVG path verbs are as often lowercase as upper.
+    """
+    for text in (
+        "# Compliance: m13.5 3H7a2 2 0 0 0-2 2v14\n",
+        "# Compliance: cc6.1 lowercase is not a control id\n",
+    ):
+        assert _controls(text, "SOC2") == set(), text
+
+
 # --------------------------------------------------------------------------- #
 # ISO 27001 — same latent flaw, found while fixing SOC 2
 # --------------------------------------------------------------------------- #
@@ -97,6 +128,17 @@ def test_iso27001_does_not_match_minified_svg_arcs() -> None:
     """`a.5.5 0 0 1` is legal SVG arc shorthand; it parsed as control A.5.5."""
     markup = '<path d="M4 8a.5.5 0 0 1 .5-.5h7a.5.5 0 0 1 0 1h-7A.5.5 0 0 1 4 8Z"/>'
     assert find_compliance_annotations(markup) == []
+
+
+def test_iso27001_marker_must_be_a_whole_word_and_control_id_case_sensitive() -> None:
+    """Same two guards as SOC 2, on the pattern that shares the flaw."""
+    for text in (
+        "ISO 270010 A.9.2.1: fabricated\n",
+        "Our noncompliance with A.9.2.1: fabricated\n",
+        # Marker present, lowercase arc verb — only the scoped (?-i:) rejects this.
+        "# Compliance: a.5.5 0 0 1 .5-.5h7\n",
+    ):
+        assert _controls(text, "ISO 27001") == set(), text
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Description

The SOC 2 and ISO 27001 patterns in `neuralmind/compliance_matcher.py` made their framework marker **optional**. That reduced SOC 2 to *"one to three letters, digits, a dot, digits"* — a shape shared by version strings, SVG path commands and milestone ids — and under `re.IGNORECASE`, lowercase ones too.

Scanning this repo produced **147 SOC 2 "annotations", of which 129 were noise**:

| Count | Cause | Examples |
|------:|-------|----------|
| 67 | version strings | `v0.13` → `V0.13`, `v2.0` → `V2.0` |
| 39 | SVG path commands | `M13.5`, `M3.2`, `A1.5` (`M`/`L`/`C`/`A`/`S` are path verbs) |
| 18 | eval milestone ids | `E1.4`, `E1.5` |
| 3 | `python3.10` | → `HON3.10` |
| 1 | `TLSv1.2` | → `LSV1.2` |
| 1 | `llama3.1` | → `AMA3.1` |

ISO 27001 had the same latent flaw: minified SVG arc shorthand (`a.5.5 0 0 1` — legal and common in production bundles) parsed as control `A.5.5`.

**Why this is more than a noisy scan.** These annotations feed `neuralmind export --audit`, documented as producing *"flat compliance reports (CSV/JSON) for evidence submission"*, plus the `neuralmind_compliance_report` MCP tool and compliance nodes in the graph. A fabricated control in an audit export is a materially worse failure than a missed one.

### The fix

The NIST pattern **already** required its prefix, carrying the comment *"Requires explicit NIST prefix to avoid false matches"* — the same bug, found and fixed for one framework but not the other two. This applies that fix consistently:

- The marker is required, and may be the framework name (`SOC 2`, `ISO 27001`) or the generic `Compliance:` keyword the docs describe.
- Intervening words are allowed on the same line, so the documented form `**SOC 2 Control:** CC6.1` used throughout `docs/compliance/*.md` keeps working.
- Control-id letters are now case-sensitive via a scoped `(?-i:)`, so lowercase path verbs (`m13.5`, `a.5.5`) cannot match while the rest of the pattern stays case-insensitive.

**Result: 147 SOC 2 hits become 7, and all 7 are the genuine annotations in `docs/compliance/*.md`.** CMMC, NIST, SOX ITGC and HIPAA are untouched.

### Known trade-off

Three controls referenced **only in prose blocks** — `CC7.1`, `CC7.2` and `C1.2` in `docs/SECURITY-GUIDE.md` and `docs/COMPLIANCE-SUMMARY.md`, where the `SOC 2` marker sits on a *preceding* line — are no longer detected.

I tried widening the marker window to 200 and 400 characters including newlines; it recovers none of them and adds no false positives, because `finditer` doesn't overlap, so one marker can only ever license one control id. Recovering them properly needs a block-scoped two-phase scanner rather than a per-line regex — a bigger change than this fix, and one that reintroduces false-positive risk. Adding the standard `**SOC 2 Control:**` marker to those lines restores them with **no code change**, matching the convention `docs/compliance/*.md` already uses.

I took precision over recall deliberately here, given the audit-evidence use case. Happy to go the other way if you'd rather.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🧪 Test update

## How Has This Been Tested?

- [x] Unit tests
- [x] Manual testing

Adds `tests/test_compliance_matcher.py` — the module's **first** tests (it had none).

- The four false-positive tests **fail against the old patterns and pass against the new ones** — verified by stashing the fix and re-running, a real red→green demonstration rather than tests written to match current behaviour.
- The four already-correct frameworks (CMMC, NIST, SOX ITGC, HIPAA) are pinned so a future change to them is deliberate.
- **Full-suite regression diff**: 113 failures before the change, 109 after, **zero new failures**. The 113 are all pre-existing in this sandbox from uninstalled optional deps (`numpy`, `chromadb`, `onnxruntime`); the 4-failure drop is exactly my own new tests going green.
- `black --check` and `ruff check` clean on both files.

### Test Configuration

* **Python version**: 3.11 (CI covers 3.10–3.12)
* **Test command**: `pytest tests/test_compliance_matcher.py -v`

## Documentation & discoverability

- [x] N/A — no new CLI command, MCP tool, hook or env var. This corrects the output of existing surfaces (`neuralmind export --audit`, `neuralmind ci-check`, `neuralmind_compliance_report`) rather than adding any.
- [x] I did **not** edit `CHANGELOG.md` or hand-bump the `pyproject.toml` version

Flagging one judgement call: this is typed `fix:` so release-please cuts a patch. That seemed right for a correctness bug in shipped compliance output, but it does mean a PyPI + GHCR release — say the word if you'd rather it wait and ride with the next feature.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

## Code Quality

- [x] I have run `black .` for formatting
- [x] I have run `ruff check .` for linting
- [x] Type hints are added for new functions/methods
- [x] Docstrings are added/updated for public APIs

## Additional Notes

Two adjacent observations, neither fixed here:

1. **The NIST pattern accepts `NIST AC-1` and `NIST SP 800-53: AC-1`, but not `NIST: AC-1`** — its prefix group `NIST[\s:]` consumes exactly one separator character. Pre-existing; I pinned the working forms in a test with a comment so a future change there is deliberate.
2. **Comma lists only capture their last id.** `**SOC 2 Controls:** CC3.1, CC8.1, A1.1` yields only `A1.1`, because the pattern requires `[:\s]+` after the id and a comma is neither. Pre-existing and unchanged by this PR, but it means `docs/compliance/SDLC_POLICY.md` and `CHANGE_MANAGEMENT.md` are each under-reporting two controls.

Found while reviewing the compliance-check bot output on #452 (marketing site redesign), whose new SVG icon set contributed 39 of the false positives — but as the table shows, version strings were already the larger source before that PR existed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01V4Lu38Xs9kZhm74XnvL4Qv)_