### PR TITLE
fix(docs): repair about.html — the published page renders completely blank

### DIFF
--- a/docs/about.html
+++ b/docs/about.html
@@ -21,7 +21,7 @@
       "@context": "https://schema.org",
       "@type": "TechArticle",
       "headline": "About NeuralMind — Semantic Code Intelligence with Brain-like Memory",
-      "dateModified": "2026-07-31",
+      "dateModified": "2026-08-22",
       "description": "How NeuralMind gives AI coding agents persistent memory: a brain-like synapse layer that learns associations from how you use the codebase, progressive context disclosure for 12-50× token reduction, a bundled tree-sitter code graph indexing ten languages (Python, TypeScript, Go, Rust, Java, C, C++, C#, Ruby, PHP), an Obsidian-style graph view, an MCP server, and a built-in install doctor.",
       "author": { "@type": "Person", "name": "Darren Frost" },
       "publisher": { "@type": "Person", "name": "Darren Frost" },
@@ -35,7 +35,7 @@
         "name": "NeuralMind",
         "applicationCategory": "DeveloperApplication",
         "operatingSystem": "Linux, macOS, Windows",
-        "softwareVersion": "1.11.0",
+        "softwareVersion": "3.3.0",
         "downloadUrl": "https://pypi.org/project/neuralmind/",
         "license": "https://opensource.org/licenses/MIT",
         "isAccessibleForFree": true,
@@ -67,6 +67,7 @@
             header h1 { font-size: 1.5rem; }
             h2 { font-size: 1.3rem; }
         }
+    </style>
 </head>
 <body>
     <header>
@@ -101,11 +102,9 @@
             <p>100% local. No cloud lock-in. No telemetry. MIT-licensed.</p>
         </section>
     </div>
-    <footer>
-        <p>© 2026 Darren Frost · MIT-licensed · <a href="https://github.com/dfrostar/neuralmind" style="color: #667eea;">View on GitHub</a></p>
-    </footer>
-</body>
-</html>
+    <section>
+        <div class="container">
+            <ul>
                 <li><strong>100% local engine.</strong> NeuralMind makes zero network calls of its own — only the minimal relevant slice ever reaches your AI tool; no telemetry by default.</li>
                 <li><strong>New in v0.22.0 — ChromaDB-free by default, when available.</strong> <code>import neuralmind</code> no longer requires ChromaDB, and the default backend is now <code>auto</code> — it prefers the ChromaDB-free <code>turbovec</code> path when its deps are installed, else falls back to chroma. Plain installs are unchanged; <code>neuralmind doctor</code> shows the resolved backend.</li>
                 <li><strong>In v0.21.0 — ChromaDB-free option.</strong> Embed <em>and</em> search with zero ChromaDB at <strong>8–16× smaller</strong> vectors and <strong>byte-identical</strong> embeddings (cosine 1.0) — same answer quality, far fewer dependencies, and the CVE-2026-45829 advisory surface gone.</li>


### PR DESCRIPTION
## Description

**`docs.neuralmind.uk/about.html` serves 169KB and renders nothing.** Measured in a real browser against the live bytes:

| | before | after |
|---|---:|---:|
| visible text | **0 chars** | populated |
| body children | **0** | populated |
| headings | **0** | 193 |
| sections | **0** | 64 |
| footers | 0 | 1 |
| CSS leaking into body | — | none |

The page is listed in `docs/sitemap.xml:10`, so it is invisible to every reader and every crawler that reaches it.

*(Note: tag names below are written without angle brackets — GitHub strips raw HTML tags from PR descriptions, which mangled the first version of this text.)*

### Two structural faults

Both are present in **every commit that has ever touched this file** — `833b7e2`, `04594d1`, `6d1071a`, `d1e2e52`. Each one has zero closing `style` tags and two closing `body` tags. **This page has never rendered.**

1. **The opening `style` tag at line 49 was never closed.** The HTML parser therefore stayed in CSS mode and swallowed the closing `head` tag, the opening `body` tag, and the entire document.

2. **An older, shorter copy of the page was spliced in ahead of the current one.** That left a duplicate `footer` element and a premature closing `body`/`html` pair at line 104 — with 1,100 lines of real content stranded after them. The stranded content began mid-list, so its own closing `ul`/`div`/`section` tags had no matching opening tags.

### The fix

- Close the `style` block before the closing `head` tag.
- Drop the duplicate footer and the premature document end (the real footer is at what is now line 1212).
- Reopen the `section` / `div.container` / `ul` that the stranded content still closes.
- Refresh the schema.org block, frozen at `softwareVersion: 1.11.0` / `dateModified: 2026-07-31` while the package is at 3.3.0.

Net diff: **6 additions, 7 deletions, 1 file.**

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 📝 Documentation update

## How Has This Been Tested?

- [x] Manual testing

- Rendered the **live** bytes (`curl` of `docs.neuralmind.uk/about.html`) in headless Chromium to establish the failure: 0 body children, 0 headings, 0 visible text.
- Rendered the repaired file the same way: 193 headings, 64 sections, 1 footer, first heading `About NeuralMind`, plus an explicit assertion that no CSS declarations leak into `innerText`.
- Verified tag balance: exactly one opening/closing `style` pair, one `body` pair, one closing `html`.

### Test Configuration

* **Test command**: headless Chromium against `file:///…/docs/about.html`, asserting `document.body.innerText`, heading/section counts, and absence of CSS leak

## Documentation & discoverability

- [x] N/A — this repairs an existing documentation page; it adds no CLI command, MCP tool, hook or env var.
- [x] I did **not** edit `CHANGELOG.md` or hand-bump the `pyproject.toml` version

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

## Additional Notes

**One thing needs your input.** The recovered section has **no heading** — the splice destroyed it, and I did not want to invent copy for a page that speaks in your voice. Its content is the "100% local engine" / v0.22.0 / v0.21.0 highlights list plus the "what we don't claim" note, and it currently sits between "Supply chain" and "Who it's for — and who it isn't". It renders fine untitled, but it wants a heading.

Two related items I found and deliberately left out of this PR:

1. `docs/sitemap.xml:334` points at `/ASSESSMENT`, which 404s — the file was renamed to `HONEST-ASSESSMENT.md`.
2. `docs/COMPLIANCE-SUMMARY.md` and `docs/SECURITY-GUIDE.md` both defer evidence to `docs/SOC2_COMPLIANCE_MAPPING.md`, which does not exist.