### PR TITLE
fix(compliance): make the compliance surfaces actually find annotations

### DIFF
--- a/neuralmind/ci_check.py
+++ b/neuralmind/ci_check.py
@@ -51,7 +51,7 @@ def _detect_framework(framework_arg: str) -> list[str]:
     """
     framework = (framework_arg or "").upper().strip()
     if framework == "ALL" or not framework:
-        return ["CMMC", "NIST", "SOX ITGC", "HIPAA", "ISO 27001"]
+        return ["CMMC", "NIST", "SOX ITGC", "HIPAA", "ISO 27001", "SOC2"]
     # Map user input to registered pattern names
     framework_map = {
         "CMMC": "CMMC",
@@ -61,6 +61,9 @@ def _detect_framework(framework_arg: str) -> list[str]:
         "HIPAA": "HIPAA",
         "ISO": "ISO 27001",
         "ISO 27001": "ISO 27001",
+        "SOC": "SOC2",
+        "SOC2": "SOC2",
+        "SOC 2": "SOC2",
     }
     mapped = framework_map.get(framework)
     return [mapped] if mapped else [framework]
@@ -92,12 +95,21 @@ def run_ci_check(
     affected_controls: set[str] = set()
     files_with_annotations: list[str] = []
 
+    # _detect_framework existed but was never called, so `--framework cmmc`
+    # printed "Framework: CMMC" and then reported findings from every
+    # framework anyway.
+    wanted_frameworks = set(_detect_framework(framework))
+
     for rel_path in changed_files:
         full_path = project_path / rel_path
         if not full_path.is_file():
             continue
 
-        matches = find_compliance_annotations_in_file(full_path)
+        matches = [
+            m
+            for m in find_compliance_annotations_in_file(full_path)
+            if m.get("framework", "") in wanted_frameworks
+        ]
         if matches:
             files_with_annotations.append(rel_path)
             for m in matches:

--- a/neuralmind/cli.py
+++ b/neuralmind/cli.py
@@ -3076,7 +3076,10 @@ def cmd_compliance(args):
     use_watch = getattr(args, "watch", False)
 
     # Scan files for compliance annotations
-    from neuralmind.compliance_matcher import find_compliance_annotations_in_file
+    from neuralmind.compliance_matcher import (
+        find_compliance_annotations_in_file,
+        iter_scannable_files,
+    )
 
     if use_watch:
         # Watch mode: run a watcher that checks every file change
@@ -3121,29 +3124,16 @@ def cmd_compliance(args):
     matches_total = 0
     results: list[dict] = []
 
-    for f in path.rglob("*"):
-        if f.is_file() and f.suffix in {
-            ".py",
-            ".ts",
-            ".tsx",
-            ".js",
-            ".jsx",
-            ".go",
-            ".rs",
-            ".java",
-            ".cs",
-            ".rb",
-            ".php",
-            ".c",
-            ".cpp",
-            ".h",
-        }:
-            matches = find_compliance_annotations_in_file(f)
-            if matches:
-                matches_total += len(matches)
-                for m in matches:
-                    rel = f.relative_to(path)
-                    results.append({"file": str(rel), **m})
+    # iter_scannable_files includes .md — this allowlist was code-only, so a
+    # scan of this very repository reported zero of its seven real annotations,
+    # all of which live in docs/compliance/*.md.
+    for f in iter_scannable_files(path):
+        matches = find_compliance_annotations_in_file(f)
+        if matches:
+            matches_total += len(matches)
+            for m in matches:
+                rel = f.relative_to(path)
+                results.append({"file": str(rel), **m})
 
     if getattr(args, "json", False):
         print(json.dumps(results, indent=2))

--- a/neuralmind/compliance_matcher.py
+++ b/neuralmind/compliance_matcher.py
@@ -165,6 +165,71 @@ _PATTERNS: list[tuple[str, re.Pattern]] = [
 
 
 # --------------------------------------------------------------------------- #
+# What counts as a scannable file
+# --------------------------------------------------------------------------- #
+
+#: Suffixes every compliance surface scans.
+#:
+#: This lived twice, differently: ``neuralmind compliance`` had a code-only
+#: allowlist and ``neuralmind_compliance_report`` did ``rglob("*.py")``.
+#: Neither included ``.md`` — and every genuine annotation in this repository
+#: lives in ``docs/compliance/*.md``, so both surfaces reported zero while
+#: seven real annotations sat on disk. Defined once here so the two cannot
+#: drift apart again.
+SCANNABLE_SUFFIXES: frozenset[str] = frozenset(
+    {
+        # source
+        ".py",
+        ".ts",
+        ".tsx",
+        ".js",
+        ".jsx",
+        ".go",
+        ".rs",
+        ".java",
+        ".cs",
+        ".rb",
+        ".php",
+        ".c",
+        ".cpp",
+        ".h",
+        # policy and evidence documents — where control annotations actually live
+        ".md",
+        ".mdx",
+        ".rst",
+        ".txt",
+    }
+)
+
+#: Directories never worth scanning.
+SCAN_EXCLUDE_DIRS: frozenset[str] = frozenset(
+    {
+        ".git",
+        "node_modules",
+        "__pycache__",
+        ".neuralmind",
+        ".next",
+        "out",
+        "htmlcov",
+        ".venv",
+        "venv",
+    }
+)
+
+
+def iter_scannable_files(root):
+    """Yield every scannable file under ``root``, skipping noise directories."""
+    from pathlib import Path as _Path
+
+    for f in _Path(root).rglob("*"):
+        if not f.is_file() or f.suffix not in SCANNABLE_SUFFIXES:
+            continue
+        if any(part in SCAN_EXCLUDE_DIRS for part in f.parts):
+            continue
+        yield f
+
+
+# --------------------------------------------------------------------------- #
 # Public API
 # --------------------------------------------------------------------------- #
 
@@ -192,7 +257,7 @@ def find_compliance_annotations(text: str) -> list[dict]:
     for framework, pattern in _PATTERNS:
         for m in pattern.finditer(text):
             control_id = m.group("control_id").strip().upper()
-            label = m.group("label").strip()
+            label = _same_line_label(text, m)
             key = (control_id, framework)
             if key not in seen:
                 seen.add(key)
@@ -200,6 +265,23 @@ def find_compliance_annotations(text: str) -> list[dict]:
                     {
                         "framework": framework,
                         "control_id": control_id,
+                        "label": label,
+                        "match_text": m.group(0).strip(),
+                        "span": (m.start(), m.end()),
+                    }
+                )
+
+            # Comma-separated lists: the pattern can only accept one id per
+            # match, so pick up the rest from the line it already validated.
+            for sibling in _sibling_control_ids(text, m, framework):
+                sib_key = (sibling.upper(), framework)
+                if sib_key in seen:
+                    continue
+                seen.add(sib_key)
+                results.append(
+                    {
+                        "framework": framework,
+                        "control_id": sibling.upper(),
                         "label": label,
                         "match_text": m.group(0).strip(),
                         "span": (m.start(), m.end()),
@@ -216,6 +298,54 @@ def find_compliance_annotations_in_file(file_path: str | Path) -> list[dict]:
     except OSError:
         return []
     return find_compliance_annotations(text)
+
+
+def _same_line_label(text: str, m: re.Match) -> str:
+    r"""Return the label, but only if it is on the same line as the control id.
+
+    The ``label`` group is ``.+?``, and ``.`` does not match a newline — but the
+    separator before it (``[:\s]+``) does. So when a control id ends its line,
+    the separator swallows the newline and the label is captured from the line
+    *below*. Every one of this repository's seven genuine SOC 2 annotations is
+    written as ``**SOC 2 Control:** CC6.1`` followed by a markdown rule, and so
+    every one of them exported ``label='---'`` into ``neuralmind export
+    --audit``, the CSV evidence column, and the ci-check findings table.
+    """
+    line_end = text.find("\n", m.end("control_id"))
+    if line_end == -1:
+        line_end = len(text)
+    tail = text[m.end("control_id") : line_end]
+    # Drop a leading separator (": ", " - ", " — ") before the description.
+    tail = re.sub(r"^[\s:\-\u2013\u2014]+", "", tail)
+    return tail.strip().rstrip(".").strip()
+
+
+#: Control-id shapes for the frameworks that permit comma-separated lists.
+#: Uppercase-only and boundary-anchored, matching the strictness of the main
+#: patterns — these run only on a line that already carried a valid marker.
+_SIBLING_ID_RES: dict[str, re.Pattern] = {
+    "SOC2": re.compile(r"(?<![A-Za-z0-9.])([A-Z]{1,3}\d+\.\d+)(?![\d.])"),
+    "ISO 27001": re.compile(r"(?<![A-Za-z0-9.])(A\.\d+(?:\.\d+)+)(?![\d.])"),
+}
+
+
+def _sibling_control_ids(text: str, m: re.Match, framework: str) -> list[str]:
+    r"""Other control ids listed on the same line as an accepted match.
+
+    ``**SOC 2 Controls:** CC3.1, CC8.1, A1.1`` yielded only ``A1.1``: the
+    pattern requires ``[:\s]+`` after the id and a comma is neither, so the
+    engine walked past the first two. Rather than loosen the pattern — which is
+    what let version strings and SVG path data in — this re-reads the line the
+    match already validated and picks up its siblings.
+    """
+    sib_re = _SIBLING_ID_RES.get(framework)
+    if sib_re is None:
+        return []
+    line_start = text.rfind("\n", 0, m.start("control_id")) + 1
+    line_end = text.find("\n", m.end("control_id"))
+    if line_end == -1:
+        line_end = len(text)
+    return sib_re.findall(text[line_start:line_end])
 
 
 def compliance_synapse_key(control_id: str, framework: str) -> str:

--- a/neuralmind/mcp_server.py
+++ b/neuralmind/mcp_server.py
@@ -405,6 +405,7 @@ def tool_compliance_report(project_path: str, format: str = "json") -> dict[str,
     from neuralmind.compliance_matcher import (
         compliance_synapse_key,
         find_compliance_annotations_in_file,
+        iter_scannable_files,
     )
 
     mind = get_mind(project_path, auto_build=False)
@@ -413,10 +414,10 @@ def tool_compliance_report(project_path: str, format: str = "json") -> dict[str,
     annotations = []
     control_ids_found = set()
 
-    # Scan Python source files in the project for compliance annotations
-    for fpath in sorted(project_root.rglob("*.py")):
-        if ".neuralmind" in fpath.parts or "__pycache__" in fpath.parts:
-            continue
+    # Scan the project for compliance annotations. This was rglob("*.py"),
+    # which cannot see the policy documents where control annotations are
+    # actually written — the tool reported zero on a repo holding seven.
+    for fpath in sorted(iter_scannable_files(project_root)):
         try:
             results = find_compliance_annotations_in_file(str(fpath))
             for r in results:

--- a/tests/test_compliance_matcher.py
+++ b/tests/test_compliance_matcher.py
@@ -17,7 +17,11 @@ set.
 
 from __future__ import annotations
 
-from neuralmind.compliance_matcher import find_compliance_annotations
+from neuralmind.compliance_matcher import (
+    SCANNABLE_SUFFIXES,
+    find_compliance_annotations,
+    iter_scannable_files,
+)
 
 
 def _controls(text: str, framework: str) -> set[str]:
@@ -169,3 +173,116 @@ def test_plain_source_code_yields_nothing() -> None:
         '    return {"status": 200, "version": "v1.2"}\n'
     )
     assert find_compliance_annotations(source) == []
+
+
+# --------------------------------------------------------------------------- #
+# Scan scope, label capture and comma lists
+#
+# These three shipped broken together and are what made the compliance surfaces
+# report nothing useful on a repo that holds real annotations.
+# --------------------------------------------------------------------------- #
+
+
+def test_markdown_is_scannable() -> None:
+    """Policy documents are where control annotations actually live.
+
+    `neuralmind compliance` had a code-only suffix allowlist and
+    `neuralmind_compliance_report` did rglob("*.py"). Neither could see
+    docs/compliance/*.md, so both reported zero while seven real annotations
+    sat on disk.
+    """
+    for suffix in (".md", ".mdx", ".rst", ".txt"):
+        assert suffix in SCANNABLE_SUFFIXES, suffix
+    # source files must keep working too
+    for suffix in (".py", ".ts", ".go", ".rs"):
+        assert suffix in SCANNABLE_SUFFIXES, suffix
+
+
+def test_scanner_skips_noise_directories(tmp_path) -> None:
+    (tmp_path / "docs").mkdir()
+    (tmp_path / "docs" / "policy.md").write_text("**SOC 2 Control:** CC6.1\n")
+    (tmp_path / "node_modules").mkdir()
+    (tmp_path / "node_modules" / "junk.md").write_text("**SOC 2 Control:** CC6.1\n")
+
+    found = {f.name for f in iter_scannable_files(tmp_path)}
+    assert "policy.md" in found
+    assert "junk.md" not in found
+
+
+def test_label_is_never_taken_from_the_next_line() -> None:
+    """The documented form puts the id last on its line, followed by a rule.
+
+    The separator before the label group matches newlines, so every one of this
+    repo's genuine annotations exported label='---' — the markdown rule beneath
+    it — straight into `neuralmind export --audit` and its CSV label column.
+    """
+    hits = find_compliance_annotations("**SOC 2 Control:** CC6.1\n---\n")
+    assert [h["control_id"] for h in hits] == ["CC6.1"]
+    assert hits[0]["label"] == ""
+
+
+def test_same_line_label_is_still_captured() -> None:
+    hits = find_compliance_annotations(
+        "# Compliance: CC6.1: Logical access controls restrict access.\n"
+    )
+    assert hits[0]["label"] == "Logical access controls restrict access"
+
+
+def test_comma_separated_control_lists_yield_every_id() -> None:
+    """`**SOC 2 Controls:** CC3.1, CC8.1, A1.1` used to yield only A1.1.
+
+    The pattern requires a separator after the id and a comma is not one, so
+    the engine walked past the first two. docs/compliance/SDLC_POLICY.md and
+    CHANGE_MANAGEMENT.md were each under-reporting two controls.
+    """
+    hits = find_compliance_annotations("**SOC 2 Controls:** CC3.1, CC8.1, A1.1\n---\n")
+    assert {h["control_id"] for h in hits} == {"CC3.1", "CC8.1", "A1.1"}
+
+
+def test_comma_list_recovery_does_not_reintroduce_false_positives() -> None:
+    """The sibling pass only reads lines a real marker already validated."""
+    for text in (
+        "Shipped in v0.13.0, v2.0 and v0.22 today.\n",
+        '<path d="M13.5 3H7a2 2 0 0 0-2 2v14, M3.2 12h17" />\n',
+        "noncompliance: CC3.1, CC8.1, A1.1\n",
+    ):
+        assert find_compliance_annotations(text) == [], text
+
+
+# --------------------------------------------------------------------------- #
+# ci-check --framework
+# --------------------------------------------------------------------------- #
+
+
+def test_detect_framework_maps_user_input() -> None:
+    from neuralmind.ci_check import _detect_framework
+
+    assert _detect_framework("cmmc") == ["CMMC"]
+    assert _detect_framework("soc2") == ["SOC2"]
+    assert _detect_framework("soc 2") == ["SOC2"]
+    assert _detect_framework("iso") == ["ISO 27001"]
+    # "all" must include SOC2 — it was omitted, so wiring the filter without
+    # this would have silently dropped every SOC 2 finding.
+    assert "SOC2" in _detect_framework("all")
+
+
+def test_ci_check_framework_actually_filters(tmp_path, monkeypatch) -> None:
+    """`--framework` was accepted, echoed, and ignored.
+
+    _detect_framework had zero callers, so `ci-check --framework cmmc` printed
+    "Framework: CMMC" and then reported findings from every framework.
+    """
+    from neuralmind import ci_check
+
+    (tmp_path / "policy.md").write_text(
+        "**SOC 2 Control:** CC6.1\n// CMMC AC.L2-3.1.1: Authorized Access Control\n"
+    )
+    monkeypatch.setattr(ci_check, "_get_diff_files", lambda *a, **k: ["policy.md"])
+
+    every = ci_check.run_ci_check(tmp_path, framework="all")
+    frameworks = {f["framework"] for f in every["findings"]}
+    assert {"SOC2", "CMMC"} <= frameworks, frameworks
+
+    only_cmmc = ci_check.run_ci_check(tmp_path, framework="cmmc")
+    assert {f["framework"] for f in only_cmmc["findings"]} == {"CMMC"}
+    assert "CC6.1" not in only_cmmc["affected_controls"]


### PR DESCRIPTION
## Description

#453 corrected the matcher. The surfaces that **call** it were broken in a larger way, and on this repository they reported nothing at all. Measured over the whole repo before this change:

```
`neuralmind compliance .`         SOC 2 found: 0
`neuralmind_compliance_report`    SOC 2 found: 0
actually present on disk          SOC 2 found: 7
```

After: **12 found, 0 labels reading `---`.**

### Four defects, one surface

**1. Scan scope.** `cli.py:3125` carried a code-only suffix allowlist; `mcp_server.py:416` did `rglob("*.py")`. Neither could see a `.md` file — and every genuine annotation in this repo lives in `docs/compliance/*.md`. Both reported zero. The allowlist now lives once, as `compliance_matcher.SCANNABLE_SUFFIXES`, with `iter_scannable_files()` shared by both callers so they cannot drift apart again.

**2. `--framework` was ignored.** `_detect_framework()` (`ci_check.py:47`) had **zero callers**, so `ci-check --framework cmmc` printed `Framework: CMMC` and then reported findings from every framework anyway. Now wired into `run_ci_check`. Its `"all"` expansion also omitted `SOC2` — wiring the filter without fixing that would have silently dropped every SOC 2 finding.

**3. Labels came from the wrong line.** The separator before the `label` group matches newlines, so when a control id ends its line the label was captured from the line *below*. The documented form is `**SOC 2 Control:** CC6.1` followed by a markdown rule — so **all seven real annotations exported `label='---'`** into `neuralmind export --audit`, its CSV `label` column (`export.py:82`), and the ci-check findings table.

**4. Comma lists dropped all but the last id.** `**SOC 2 Controls:** CC3.1, CC8.1, A1.1` yielded only `A1.1` — the pattern requires a separator after the id and a comma is not one. `SDLC_POLICY.md` and `CHANGE_MANAGEMENT.md` were each under-reporting two controls.

### Approach

Both fixes for (3) and (4) are **additive post-passes that leave the #453 regexes untouched**. Loosening the pattern is exactly what let version strings and SVG path data in, so the sibling pass instead re-reads a line the match has *already validated* and picks up the rest, with an uppercase-only, boundary-anchored id shape.

The false-positive guards still hold — including inside a comma list on a line that does carry a valid marker:

```python
"Shipped in v0.13.0, v2.0 and v0.22 today."          -> []
'<path d="M13.5 3H7a2 2 0 0 0-2 2v14, M3.2 12h17" />' -> []
"noncompliance: CC3.1, CC8.1, A1.1"                   -> []
```

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🧪 Test update

## How Has This Been Tested?

- [x] Unit tests
- [x] Manual testing

- **8 new tests** (19 total in this module). Two are worth calling out: one proves `--framework` *filters* rather than merely echoing (it asserts a SOC 2 finding disappears under `--framework cmmc`), and one proves the comma-list recovery cannot reintroduce false positives.
- **End-to-end**: ran the shared scanner over the whole repo and confirmed 0 → 12 SOC 2 annotations, 7 → 0 labels reading `---`.
- **Full-suite regression diff**: 109 failures before, 109 after, **zero new**. Those 109 are pre-existing in this sandbox from uninstalled optional deps (`numpy`, `chromadb`, `onnxruntime`).
- `black --check` and `ruff check` clean.

### Test Configuration

* **Python version**: 3.11 (CI covers 3.10–3.12)
* **Test command**: `pytest tests/test_compliance_matcher.py -v`

## Documentation & discoverability

- [ ] N/A
- [x] This **does** change agent-visible output — `neuralmind compliance`, `neuralmind_compliance_report`, `ci-check --framework`, and `export --audit` all return different (correct) results now.

Deliberately **not** documented in this PR. `docs/wiki/CLI-Reference.md` has no section for `compliance`, `ci-check` or `export --audit` at all, so there is nowhere for the annotation-syntax rules to live yet. That reference section is worth writing once these semantics settle, and it should also carry the same-line marker rule #453 introduced. Happy to do it as a follow-up.

- [x] I did **not** edit `CHANGELOG.md` or hand-bump the `pyproject.toml` version

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

## Code Quality

- [x] I have run `black .` for formatting
- [x] I have run `ruff check .` for linting
- [x] Type hints are added for new functions/methods
- [x] Docstrings are added/updated for public APIs

## Additional Notes

Found by auditing what v3.3.0 shipped. Two adjacent items I did **not** touch:

1. **`docs/COMPLIANCE-SUMMARY.md` and `docs/SECURITY-GUIDE.md` assert `CC7.1`, `CC7.2`, `C1.2` and `P4.1`** — controls with no policy document under `docs/compliance/`, which is why the tightened matcher does not find them. Both files also defer evidence to `docs/SOC2_COMPLIANCE_MAPPING.md`, **which does not exist**. That is a content decision for you: either write the policy docs or trim the claims.
2. **`docs/wiki/Home.md:83` and `site/src/components/sections/Features.tsx:87`** both state that `Compliance:` annotations map to NIST SP 800-53. Verified false — `# Compliance: AC-1: ...` returns no match, because NIST requires its own prefix. Two-line copy fix, but it is marketing copy so I left it to you.

---
_Generated by [Claude Code](https://claude.ai/code/session_01V4Lu38Xs9kZhm74XnvL4Qv)_