### PR TITLE
docs: correct the NIST annotation claim and a CLI flag that never existed

### DIFF
--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -80,9 +80,9 @@ New compliance capabilities for regulated teams, plus a one-command project init
 | Feature | What |
 |---------|------|
 | `neuralmind init` | One-command project setup — auto-detects structure, installs hooks, builds index, all at once |
-| Compliance annotation detection | Scans code for `# Compliance:` / `// Compliance:` annotations — flags each against CMMC 2.0 / NIST SP 800-53 controls |
+| Compliance annotation detection | Scans code **and docs** for annotations across CMMC 2.0, NIST SP 800-53, SOX ITGC, HIPAA, SOC 2 and ISO 27001. Each framework needs its own marker on the same line — `# NIST AC-1: …`, `# CMMC AC.L2-3.1.1: …`. `Compliance:` is a SOC 2 / ISO 27001 marker and does **not** match NIST ids; see [CLI-Reference](CLI-Reference.md#compliance-v314) |
 | CMMC content ingestion | `neuralmind ingest-cmmc` imports CMMC 2.0 assessment guides + POA&M templates into the doc index |
-| Audit export | `neuralmind export --audit` produces flat compliance reports (CSV/JSON) for evidence submission |
+| Audit export | `neuralmind export --controls` produces control-to-code mappings as CSV for evidence submission; `--format pdf` renders an SSP report |
 | CI/CD compliance check | `neuralmind ci-check` gates builds on compliance annotation health |
 | MCP tool | `neuralmind_compliance_report` — live compliance stance via any MCP-compatible agent |
 | Savings recalibration | 12–50× typical (44× avg vs 30K naive baseline; 12–25× vs realistic 10K human baseline) |

--- a/site/src/components/sections/Features.tsx
+++ b/site/src/components/sections/Features.tsx
@@ -84,13 +84,13 @@ const featureList: { icon: IconName; title: string; desc: string; badge: string 
     {
         icon: 'shield-check',
         title: 'Compliance Annotation Engine',
-        desc: 'Scans code for `Compliance:` annotations, maps them to CMMC 2.0 / NIST SP 800-53 controls. Ingest CMMC assessment guides, export audit reports, gate CI on annotation health.',
+        desc: 'Scans code and docs for annotations across CMMC 2.0, NIST SP 800-53, SOX ITGC, HIPAA, SOC 2 and ISO 27001. Each framework carries its own marker on the line — `# NIST AC-1:`, `# CMMC AC.L2-3.1.1:`. Ingest CMMC assessment guides, export control mappings, gate CI on annotation health.',
         badge: 'v2.0.0',
     },
     {
         icon: 'export',
         title: 'Audit Export & CI/CD Check',
-        desc: '`neuralmind export --audit` produces flat compliance reports (CSV/JSON) for evidence submission. `neuralmind ci-check` gates builds on annotation health.',
+        desc: '`neuralmind export --controls` produces control-to-code mappings as CSV for evidence submission, or an SSP report with `--format pdf`. `neuralmind ci-check` gates builds on annotation health.',
         badge: 'v2.0.0',
     },
     {


### PR DESCRIPTION
## Description

`docs/wiki/Home.md` and `site/src/components/sections/Features.tsx` both stated that `Compliance:` annotations map to **CMMC 2.0 / NIST SP 800-53**. Run against the matcher:

```
# Compliance: AC-1: Access control policy    -> NO MATCH
# NIST AC-1: Access control policy           -> NIST:AC-1
# Compliance: AC.L2-3.1.1: MFA required      -> CMMC:AC.L2-3.1.1
# Compliance: CC6.1: Logical access          -> SOC2:CC6.1
```

The **CMMC half was true by accident** — its control-id shape (`AC.L2-3.1.1`) is self-identifying, so any text ahead of the id is ignored and `Compliance:` happens to work. The **NIST half was false**: NIST requires its own prefix, deliberately, so it cannot collide with SOX ITGC ids. `Compliance:` is in fact a SOC 2 / ISO 27001 marker.

This got worse with v3.3.1, which added the per-framework marker table to `docs/wiki/CLI-Reference.md`. These two pages contradicted the reference in public.

### Second defect, same two files

Both also advertised:

> `neuralmind export --audit` produces flat compliance reports (CSV/JSON)

**That flag has never existed.** `git log -S'"--audit"' -- neuralmind/cli.py` returns nothing. The real interface is:

```
usage: cli.py export [-h] [--format {csv,pdf}] [--output OUTPUT] [--controls]
                     [--nodes] [--report {ssp}] [--json]
```

`--controls`, not `--audit`; csv and pdf, not CSV/JSON. Anyone following either page got an argparse error. Since it is the same class of defect — a documented thing that does not exist — in the same table row and the adjacent feature card, I corrected it here rather than leaving it beside a freshly-corrected neighbour.

## Type of Change

- [x] 📝 Documentation update
- [x] 🐛 Bug fix — both pages documented a nonexistent CLI flag

## How Has This Been Tested?

- [x] Manual testing

Every replacement example is verified to match, not assumed:

```
# NIST AC-1: …                -> NIST:AC-1
# CMMC AC.L2-3.1.1: …         -> CMMC:AC.L2-3.1.1
**SOC 2 Control:** CC6.1      -> SOC2:CC6.1
# ISO 27001 A.9.2.1: …        -> ISO 27001:A.9.2.1
```

- `--controls` and `--format {csv,pdf}` confirmed against `export --help`.
- `scripts/check_commercial_terms.py` passes; `tests/test_site_claims.py` and `tests/test_docs_claims.py` pass.
- `npm run build` in `site/` succeeds — all routes prerender.

## Documentation & discoverability

- [x] This IS the documentation change. Both corrected passages now agree with `CLI-Reference.md#compliance-v314`, and the wiki row links to it.
- [x] I did **not** edit `CHANGELOG.md` or hand-bump the `pyproject.toml` version.

## Checklist

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

## Additional Notes

**Deliberately not touched:** `docs/releases/RELEASE_NOTES_v2.0.0.md` carries the same `--audit` error. Release notes are a historical record of what was claimed at the time, not live documentation — rewriting them would erase the evidence that the claim was made. Flagging rather than editing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01V4Lu38Xs9kZhm74XnvL4Qv)_