### PR TITLE
fix(deps): lift the turbovec &lt;1 cap — recovery handles it, pinning doesn't

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,14 +86,18 @@ dependencies = [
     # pre-2.28 glibc) Linux still resolve to turbovec and need a toolchain or
     # `pip install "neuralmind[chromadb]"`; use a glibc base image (python:slim)
     # rather than python:alpine. See docs/prd/chromadb-free-by-default.md.
-    # HOLD: capped <1 on 2026-08-18. turbovec 1.0.0 ships a v5 index rotation
-    # change that refuses to decode the v3 `index.tvim` files committed under
-    # tests/fixtures/*/graphify-out/neuralmind_turbovec/, so every CI run that
-    # resolved the new major failed with "predates the v5 rotation change and
-    # cannot be decoded by any current build". Verified directly: 1.0.0 raises
-    # on the committed fixture, 0.8.0 loads it. Lift the cap in the same change
-    # that regenerates those fixtures at v5.
-    "turbovec>=0.7,<1; (platform_system == 'Linux') or (platform_system == 'Darwin' and platform_machine == 'arm64') or (platform_system == 'Windows' and platform_machine == 'AMD64')",
+    # Deliberately uncapped across the 1.0 major. turbovec 1.0.0 stops decoding
+    # pre-v5 indexes, which is a real break — but it is handled at runtime, not
+    # by pinning: _load_index quarantines an index it cannot read to
+    # `index.tvim.stale` and embed_nodes escalates to force=True so the index is
+    # rebuilt from the surviving SQLite rows (see #443). 1.0.0 signals this as
+    # OSError, which is exactly what that handler catches, so the v3 fixtures
+    # still committed under tests/fixtures/*/graphify-out/neuralmind_turbovec/
+    # are recovered rather than fatal. A `<1` cap here would freeze every
+    # installation on the 0.x line to paper over a case the code already
+    # handles; if a future major breaks something recovery cannot absorb, cap
+    # it then, against that evidence.
+    "turbovec>=0.7; (platform_system == 'Linux') or (platform_system == 'Darwin' and platform_machine == 'arm64') or (platform_system == 'Windows' and platform_machine == 'AMD64')",
     "onnxruntime>=1.16; (platform_system == 'Linux') or (platform_system == 'Darwin' and platform_machine == 'arm64') or (platform_system == 'Windows' and platform_machine == 'AMD64')",
     "tokenizers>=0.15; (platform_system == 'Linux') or (platform_system == 'Darwin' and platform_machine == 'arm64') or (platform_system == 'Windows' and platform_machine == 'AMD64')",
     "numpy>=1.20",


### PR DESCRIPTION
## Description

**Split 1 of 2 out of #451**, which carried this alongside an unrelated retrieval-ranking change. The other half is #461. Rebased onto current `main` — #451's branch predates five merges (#452, #454, #455, #457, #458).

This half is **one dependency line plus its comment**.

### The cap predates its own fix

| Date | Event |
|---|---|
| 2026-08-18 | `turbovec<1` cap added — turbovec 1.0.0 stopped decoding pre-v5 indexes and broke CI on the committed v3 fixtures |
| 2026-08-19 | **#443 landed the recovery for exactly that case** |
| — | The cap was never lifted |

#443's commit message names the trigger outright: *"turbovec 1.0.0 dropped decoding of pre-v5 indexes, so any stale on-disk index.tvim hard-crashed every build at `_load_index`."*

### What handles it now

- `_load_index` catches `(OSError, ValueError)` from `turbovec.IdMapIndex.load`, quarantines the file to `index.tvim.stale`, returns None — `turbovec_backend.py:185-194`
- `embed_nodes` sees a missing index with surviving node rows and escalates to `force=True`, rebuilding from SQLite instead of persisting an empty index — `turbovec_backend.py:449-456`
- `store.sqlite` **is committed beside `index.tvim`** in every fixture under `tests/fixtures/*/graphify-out/neuralmind_turbovec/`, so the rebuild has source rows
- `tests/test_turbovec_backend.py::test_unreadable_index_is_quarantined_and_rebuilt` pins it

### The proof is #451's own CI

With the cap lifted, pip resolves turbovec 1.x and the committed v3 fixtures go through the recovery path for real. **All 21 checks green on #451**, including the **backend parity gate** — the job that would notice a silently empty index (it asserts 100% symbol coverage across nine languages and zero dangling edges).

That is the evidence the old HOLD comment was asking for.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Unit tests (in CI — turbovec is not installed in this sandbox)

- The dependency resolution itself is what CI exercises; the `Fresh Install` matrix jobs install from this `pyproject.toml` on Linux, macOS and Windows.
- Verified locally that `pyproject.toml` still parses and nothing else drifted: version stays `3.3.1`, the three keywords added in #457 survive, 21 dependencies intact. **Worth stating** — naively taking the file from #451's branch would have reverted the version to `3.2.1` and dropped those keywords, since that branch predates the release. Only the turbovec hunk was applied.

### Test Configuration

* **Test command**: full CI matrix — the `Fresh Install` jobs are the ones that matter here

## Documentation & discoverability

- [x] N/A — no CLI command, hook, env var or agent-visible behaviour changes. Users on platforms with a turbovec wheel simply stop being held on the 0.x line.
- [x] I did **not** edit `CHANGELOG.md` or hand-bump the `pyproject.toml` version

## Checklist

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

## Additional Notes

The nine v3 `index.tvim` fixtures stay in place **deliberately**. They now exercise the recovery path on every run, so the fixture-regeneration work the old HOLD comment demanded is no longer a prerequisite for accepting the major — the fixtures are more useful stale than regenerated.

One caveat stated plainly: turbovec is not installed in this sandbox, so I could not independently confirm that 1.0.0 raises `OSError` specifically rather than a custom exception type. #443 was written and tested against 1.0.0's actual behaviour, and #451's green CI exercises it end to end — but the local verification stops there.