### PR TITLE
fix(context_selector): rank synapse recalls before they displace hits

### DIFF
--- a/neuralmind/context_selector.py
+++ b/neuralmind/context_selector.py
@@ -705,13 +705,27 @@ class ContextSelector:
         if not fetched:
             return results
 
-        kept = results[: len(results) - len(fetched)]
+        # Assign scores to fetched nodes so we can compare against displaced hits.
         for node in fetched:
             boost = self._synapse_boost_weight * energy_by_id.get(node.get("id"), 0.0)
             node["score"] = boost
             node["_synapse_boost"] = boost
             node["_synapse_recalled"] = True
-        return kept + fetched
+
+        # Replace the weakest hits with the recalled nodes, strongest first.
+        # `results` is score-ordered, so the tail is the weakest slice and
+        # trimming it spends exactly the least-relevant hits. `fetched` comes
+        # back in whatever order the embedder chose, so it is ranked here
+        # rather than relied on.
+        #
+        # There is deliberately no score comparison gating individual swaps.
+        # A recalled node's score is `boost_weight * energy` (~0.30 at the
+        # default weight) while a vector hit carries a cosine similarity
+        # (~0.50+); the two are incommensurable, and comparing them rejects
+        # every candidate that clears the energy bar. `_synapse_pull_in_min_energy`
+        # is the gate, and it compares energy against energy.
+        ranked = sorted(fetched, key=lambda n: n.get("score", 0.0), reverse=True)
+        return results[: len(results) - len(ranked)] + ranked
 
     def _apply_structural_expansion(self, results: list[dict]) -> list[dict]:
         """Fold the static code graph's wiring into L3 hits.


### PR DESCRIPTION
## Description

**Split 2 of 2 out of #451**, which carried this alongside an unrelated dependency change. The other half is #460. Rebased onto current `main` — #451's branch predates five merges.

### Why it needed its own PR

The repo squash-merges, and release-please writes the changelog from the **PR title**. Shipping this under `fix(deps): lift the turbovec <1 cap` would have put a retrieval-ordering change into the release with no changelog entry describing it, filed under a dependency fix.

### The change

`_apply_synapse_boost` replaces the weakest N results with N synapse-recalled nodes. It appended `fetched` in whatever order the embedder returned, so the recalled tail was unordered among itself — anything downstream that truncates top-k saw an arbitrary subset rather than the strongest recalls.

```python
ranked = sorted(fetched, key=lambda n: n.get("score", 0.0), reverse=True)
return results[: len(results) - len(ranked)] + ranked
```

Ran both expressions in isolation — results scored 0.9/0.8/0.7/0.6/0.5, recalls arriving out of order at 0.10/0.30/0.20:

```
main   : r0 r1 s1 s2 s3
branch : r0 r1 s2 s3 s1
```

Same length, so displacement stays **budget-neutral**; the recalled tail is now strongest-first. `len(ranked) == len(fetched)`, so the trim is unchanged and no extra result is spent.

### No score guard, deliberately

A recalled node's score is `boost_weight * energy` (~0.30 at the default weight); a vector hit carries a cosine similarity (~0.50+). They are incommensurable, and comparing them rejects **every** candidate that clears the energy bar — that is the regression which took the synapse A/B from 74.6% to 72.8% partway through #451's history. `_synapse_pull_in_min_energy` is the gate, and it compares energy against energy.

The comment in the diff says this, so the next person to reach for a guard finds the reason rather than the scar.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Manual testing

- Both expressions compared directly in isolation (above): the ordering changes, the length does not.
- `black --check` and `ruff check` clean on `neuralmind/context_selector.py`.
- **The unit tests for this path skip in this sandbox** — `tests/test_context_selector.py` needs `chromadb` and `tests/test_relevance.py` needs `numpy`, neither installed here. CI runs them.

### Test Configuration

* **Test command**: `pytest tests/test_context_selector.py tests/test_relevance.py`

## Documentation & discoverability

- [x] N/A — no CLI command, hook or env var. It reorders nodes that were already being returned.
- [x] I did **not** edit `CHANGELOG.md` or hand-bump the `pyproject.toml` version

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## Additional Notes

**The number that should judge this PR is the self-benchmark's Phase 2 synapse A/B** — top-k hit rate with recall off vs on, currently **74.6% → 78.1% (+3.5 points)** on the CI fixture. That is the measurement this change exists to move, and it is the reason it deserved a title of its own rather than riding in under a dependency fix.

Be aware the effect may not show on that fixture. A note in #451's history records that instrumenting a run gave an identical 19 admitted / 38 nodes swapped before and after a related change, because on that corpus the admissible set is always a full suffix. If the A/B is flat here, that is the fixture being small, not evidence the ordering does not matter — the property it fixes is about which recalls survive downstream top-k truncation.

---
_Generated by [Claude Code](https://claude.ai/code/session_01V4Lu38Xs9kZhm74XnvL4Qv)_