### PR TITLE
Revert "fix(context_selector): rank synapse recalls before they displace hits"

### DIFF
--- a/neuralmind/context_selector.py
+++ b/neuralmind/context_selector.py
@@ -705,27 +705,13 @@ class ContextSelector:
         if not fetched:
             return results
 
-        # Assign scores to fetched nodes so we can compare against displaced hits.
+        kept = results[: len(results) - len(fetched)]
         for node in fetched:
             boost = self._synapse_boost_weight * energy_by_id.get(node.get("id"), 0.0)
             node["score"] = boost
             node["_synapse_boost"] = boost
             node["_synapse_recalled"] = True
-
-        # Replace the weakest hits with the recalled nodes, strongest first.
-        # `results` is score-ordered, so the tail is the weakest slice and
-        # trimming it spends exactly the least-relevant hits. `fetched` comes
-        # back in whatever order the embedder chose, so it is ranked here
-        # rather than relied on.
-        #
-        # There is deliberately no score comparison gating individual swaps.
-        # A recalled node's score is `boost_weight * energy` (~0.30 at the
-        # default weight) while a vector hit carries a cosine similarity
-        # (~0.50+); the two are incommensurable, and comparing them rejects
-        # every candidate that clears the energy bar. `_synapse_pull_in_min_energy`
-        # is the gate, and it compares energy against energy.
-        ranked = sorted(fetched, key=lambda n: n.get("score", 0.0), reverse=True)
-        return results[: len(results) - len(ranked)] + ranked
+        return kept + fetched
 
     def _apply_structural_expansion(self, results: list[dict]) -> list[dict]:
         """Fold the static code graph's wiring into L3 hits.


### PR DESCRIPTION
## main is red, and I caused it

`ci-benchmark` on `main` is failing at `fcae016` — the **v3.3.2 release commit**. It has failed twice with byte-identical numbers, so this is deterministic, not a flake:

```
tests/test_benchmark_regression.py::test_synapse_recall_does_not_reduce_hit_rate
AssertionError: Synapse recall lowered hit rate: 74.56% off → 72.81% on.
                Displacement is dropping relevant hits.
```

Last green on `main` was `b644876` (#458, docs only). The only changes since are **#460** (`pyproject.toml`, turbovec cap) and **#461** (`context_selector.py`, this one). I merged both.

## Why this PR exists

**I do not yet know which of the two caused it, and I am not going to guess.** The evidence is genuinely contradictory:

| Configuration | Phase 2 `on` | Result |
|---|---:|---|
| #461 PR CI — turbovec **0.x** + ranking change | 78.1% | PASS |
| #460 PR CI — turbovec **1.x**, no ranking change | 78.1% | PASS |
| `main` — turbovec **1.x** + ranking change | **72.81%** | **FAIL** |

Each change passed alone. Neither PR's CI exercised the combination, because #461 was branched before #460 merged. That gap is on me — I noted at merge time that #460 changes the resolved turbovec major, and I did not draw the conclusion that #461's green run therefore proved nothing about the merged state.

There is also a clue pointing the other way: #451's commit `2544901` reports this gate failing with **exactly 74.56% → 72.81%** back on 2026-08-22, when that branch carried *only* the dependency change. If that reading is right, #460 is the cause and this revert will not fix it.

**So this PR is a controlled experiment, not a conclusion.** It reverts #461 alone against current `main`. CI answers the question:

- **Green** → #461 was the cause. Merge this; `main` is restored.
- **Still red** → #460 is the cause. Close this, revert #460 instead, and #461 goes back in.

## Why #461 first rather than #460

Not because it is more likely — because it is the cheaper thing to be wrong about.

#461 reorders synapse-recalled nodes; the failing gate measures exactly that surface. Its benefit was never demonstrated: both #460 and #461 reported an identical +3.5-point A/B, which means the ranking change moved that number by **zero** on this fixture. I said as much in its own PR body — *"the effect may not show on that fixture"* — and shipped it on a green run that could not see the interaction.

#460, by contrast, has measured benefits that reproduced exactly across two independent runs (parity 6.26× → 6.32×, faithfulness +0.013 → +0.041) and corrects a dependency cap that had outlived its own fix.

If the experiment says #460, it gets reverted too — the gate matters more than either change.

## Type of Change

- [x] 🐛 Bug fix — restores a failing regression gate on `main`

## How Has This Been Tested?

- [x] This PR **is** the test. Its `benchmark` job is the measurement.

I cannot reproduce locally: this sandbox has no `numpy`, `chromadb` or `turbovec`, so `tests/test_benchmark_regression.py` cannot run here at all. That limitation is exactly why the interaction went unnoticed pre-merge, and I am not going to paper over it by asserting a cause I have not measured.

## Additional Notes

**v3.3.2 is already published to PyPI from the red commit.** Nothing in the failing gate affects install or import — it is a retrieval-quality regression on a benchmark fixture, not a crash — so there is no case for yanking. But the shipped release does carry whichever of the two changes is at fault, and a follow-up patch will be needed once the cause is known.

---
_Generated by [Claude Code](https://claude.ai/code/session_01V4Lu38Xs9kZhm74XnvL4Qv)_