### PR TITLE
fix(benchmark): decide the synapse gate on a published spread, not a single draw

### DIFF
--- a/tests/benchmark/run.py
+++ b/tests/benchmark/run.py
@@ -390,6 +390,50 @@ def _dollars_saved(naive_tokens: int, neuralmind_tokens: int, queries_per_day: i
     return per_query_savings * queries_per_day * 30
 
 
+def _environment_fingerprint() -> dict:
+    """Capture what differs between machines but not between runs on one.
+
+    Phase 2 is deterministic within a job — three consecutive A/B runs return
+    the identical delta — yet the same commit and the same turbovec build have
+    produced -1.8 and +4.0 on different runners. So the variable is the host,
+    not the sample, and averaging inside one job cannot see it. turbovec is a
+    SIMD quantized index and onnxruntime picks kernels per CPU, so the vector
+    path is the obvious place for a machine to change a ranking; this records
+    enough to correlate an outcome with a host instead of guessing.
+    """
+    import platform
+
+    def _version(name: str) -> str:
+        try:
+            import importlib.metadata as md
+
+            return md.version(name)
+        except Exception:
+            return "absent"
+
+    flags = ""
+    try:
+        for line in Path("/proc/cpuinfo").read_text().splitlines():
+            if line.startswith("flags"):
+                interesting = {
+                    "avx", "avx2", "avx512f", "avx512vnni", "fma", "sse4_2", "neon",
+                }
+                flags = " ".join(sorted(set(line.split(":", 1)[1].split()) & interesting))
+                break
+    except Exception:
+        pass
+
+    return {
+        "platform": platform.platform(),
+        "machine": platform.machine(),
+        "python": platform.python_version(),
+        "cpu_flags": flags,
+        "turbovec": _version("turbovec"),
+        "onnxruntime": _version("onnxruntime"),
+        "numpy": _version("numpy"),
+    }
+
+
 def _mean(values) -> float:
     vals = list(values)
     return sum(vals) / len(vals) if vals else 0.0
@@ -430,6 +474,7 @@ def write_results(
             "on_hit_rate_runs": [r.avg_hit_rate for r in on_runs],
             "queries": [asdict(q) for q in on_runs[-1].queries],
         },
+        "environment": _environment_fingerprint(),
         "regression_floor": REDUCTION_FLOOR,
         "pass": phase1.avg_reduction >= REDUCTION_FLOOR,
         "estimated_monthly_savings_usd": _dollars_saved(
@@ -577,6 +622,11 @@ def main() -> int:
     per_run = ", ".join(
         f"{(on.avg_hit_rate - off.avg_hit_rate) * 100:+.1f}"
         for off, on in zip(off_runs, on_runs, strict=True)
+    )
+    env = _environment_fingerprint()
+    print(
+        f"Env: turbovec {env['turbovec']}, onnxruntime {env['onnxruntime']}, "
+        f"numpy {env['numpy']}, {env['machine']} [{env['cpu_flags'] or 'n/a'}]"
     )
     print(
         f"Phase 2: synapse off {off_mean * 100:.0f}% → "

--- a/tests/benchmark/run.py
+++ b/tests/benchmark/run.py
@@ -440,6 +440,42 @@ def _environment_fingerprint() -> dict:
     }
 
 
+def _graph_fingerprint(nm) -> dict:
+    """Identify the graph the A/B actually ran against.
+
+    Phase 1 and the synapse edge count are identical between a passing and a
+    failing CI job, and so is the environment fingerprint — yet Phase 2's "on"
+    number differs. Whatever changes is rebuilt per job and fixed within it.
+    CI runs `graphify update` before the benchmark, and community detection is
+    randomised clustering: a partition that lands differently while producing
+    the same node and edge counts would move community-driven selection without
+    moving anything else measured here.
+
+    So this records the partition, not just its size — a stable digest over
+    (node_id, community). Two jobs whose digests differ have not run the same
+    experiment, whatever else matches.
+    """
+    import hashlib
+
+    try:
+        embedder = nm.embedder
+        stats = embedder.get_stats()
+        rows = sorted(
+            (str(n.get("id", "")), int(n.get("metadata", {}).get("community", -1)))
+            for n in embedder.get_all_nodes()
+        )
+        digest = hashlib.sha256(
+            "\n".join(f"{nid}:{comm}" for nid, comm in rows).encode()
+        ).hexdigest()[:16]
+        return {
+            "nodes": stats.get("total_nodes"),
+            "communities": stats.get("communities"),
+            "community_partition_sha256_16": digest,
+        }
+    except Exception as exc:  # diagnostics must never fail the benchmark
+        return {"error": f"{type(exc).__name__}: {exc}"}
+
+
 def _mean(values) -> float:
     vals = list(values)
     return sum(vals) / len(vals) if vals else 0.0
@@ -450,6 +486,7 @@ def write_results(
     off_runs: list[PhaseResult],
     on_runs: list[PhaseResult],
     synapse_edges: int,
+    graph_fp: dict | None = None,
 ) -> None:
     """Write the JSON payload consumed by the chart script and CI."""
     payload = {
@@ -481,6 +518,7 @@ def write_results(
             "queries": [asdict(q) for q in on_runs[-1].queries],
         },
         "environment": _environment_fingerprint(),
+        "graph": graph_fp or {},
         "regression_floor": REDUCTION_FLOOR,
         "pass": phase1.avg_reduction >= REDUCTION_FLOOR,
         "estimated_monthly_savings_usd": _dollars_saved(
@@ -613,9 +651,10 @@ def main() -> int:
         reset_memory()
         nm = NeuralMind(str(FIXTURE_DIR))
         synapse_edges = seed_synapses(nm)
+        graph_fp = _graph_fingerprint(nm)
         off_runs.append(run_synapse_phase(nm, queries, naive_total, inject=False))
         on_runs.append(run_synapse_phase(nm, queries, naive_total, inject=True))
-    write_results(phase1, off_runs, on_runs, synapse_edges)
+    write_results(phase1, off_runs, on_runs, synapse_edges, graph_fp)
     write_report(phase1, off_runs, on_runs, synapse_edges)
 
     print(
@@ -630,6 +669,10 @@ def main() -> int:
         for off, on in zip(off_runs, on_runs, strict=True)
     )
     env = _environment_fingerprint()
+    print(
+        f"Graph: {graph_fp.get('nodes')} nodes, {graph_fp.get('communities')} communities, "
+        f"partition {graph_fp.get('community_partition_sha256_16')}"
+    )
     print(
         f"Env: turbovec {env['turbovec']}, onnxruntime {env['onnxruntime']}, "
         f"numpy {env['numpy']}, {env['machine']} [{env['cpu_flags'] or 'n/a'}]"

--- a/tests/benchmark/run.py
+++ b/tests/benchmark/run.py
@@ -56,6 +56,9 @@ REPORT_PATH = REPO_ROOT / "tests" / "benchmark" / "report.md"
 # regressions (retriever returning the whole graph, dropping to ~1×),
 # not a missed optimization on a toy input.
 REDUCTION_FLOOR = 4.0
+# Phase-2 A/B repeats: one draw of a metric that moves decides the gate by
+# luck. Three matches the onboarding gate's existing averaging.
+SYNAPSE_AB_RUNS = int(os.environ.get("NEURALMIND_SYNAPSE_AB_RUNS", "3"))
 
 # Pricing used for the dollars-saved estimate in the report.
 # Claude 3.5 Sonnet input price, per 1M tokens, at the time of writing.
@@ -387,10 +390,15 @@ def _dollars_saved(naive_tokens: int, neuralmind_tokens: int, queries_per_day: i
     return per_query_savings * queries_per_day * 30
 
 
+def _mean(values) -> float:
+    vals = list(values)
+    return sum(vals) / len(vals) if vals else 0.0
+
+
 def write_results(
     phase1: PhaseResult,
-    synapse_off: PhaseResult,
-    synapse_on: PhaseResult,
+    off_runs: list[PhaseResult],
+    on_runs: list[PhaseResult],
     synapse_edges: int,
 ) -> None:
     """Write the JSON payload consumed by the chart script and CI."""
@@ -405,13 +413,22 @@ def write_results(
         },
         "phase2_synapse": {
             "synapse_edges": synapse_edges,
-            "off_avg_reduction_ratio": synapse_off.avg_reduction,
-            "off_avg_top_k_hit_rate": synapse_off.avg_hit_rate,
-            "on_avg_reduction_ratio": synapse_on.avg_reduction,
-            "on_avg_top_k_hit_rate": synapse_on.avg_hit_rate,
-            "uplift_hit_rate": synapse_on.avg_hit_rate - synapse_off.avg_hit_rate,
-            "reduction_delta": synapse_on.avg_reduction - synapse_off.avg_reduction,
-            "queries": [asdict(q) for q in synapse_on.queries],
+            # Means across SYNAPSE_AB_RUNS. The gate reads these; the per-run
+            # lists below keep the spread visible rather than averaged away.
+            "ab_runs": len(on_runs),
+            "off_avg_reduction_ratio": _mean(r.avg_reduction for r in off_runs),
+            "off_avg_top_k_hit_rate": _mean(r.avg_hit_rate for r in off_runs),
+            "on_avg_reduction_ratio": _mean(r.avg_reduction for r in on_runs),
+            "on_avg_top_k_hit_rate": _mean(r.avg_hit_rate for r in on_runs),
+            "uplift_hit_rate": (
+                _mean(r.avg_hit_rate for r in on_runs) - _mean(r.avg_hit_rate for r in off_runs)
+            ),
+            "reduction_delta": (
+                _mean(r.avg_reduction for r in on_runs) - _mean(r.avg_reduction for r in off_runs)
+            ),
+            "off_hit_rate_runs": [r.avg_hit_rate for r in off_runs],
+            "on_hit_rate_runs": [r.avg_hit_rate for r in on_runs],
+            "queries": [asdict(q) for q in on_runs[-1].queries],
         },
         "regression_floor": REDUCTION_FLOOR,
         "pass": phase1.avg_reduction >= REDUCTION_FLOOR,
@@ -430,8 +447,8 @@ def write_results(
 
 def write_report(
     phase1: PhaseResult,
-    synapse_off: PhaseResult,
-    synapse_on: PhaseResult,
+    off_runs: list[PhaseResult],
+    on_runs: list[PhaseResult],
     synapse_edges: int,
 ) -> None:
     """Write the human-readable Markdown report posted as a PR comment."""
@@ -470,14 +487,25 @@ def write_report(
         "",
         f"- Synapse edges after seeding co-editing sessions: `{synapse_edges}`",
         (
-            f"- Top-k hit rate: **{_fmt_pct(synapse_off.avg_hit_rate)}** off → "
-            f"**{_fmt_pct(synapse_on.avg_hit_rate)}** on "
-            f"(Δ {(synapse_on.avg_hit_rate - synapse_off.avg_hit_rate) * 100:+.1f} points)"
+            f"- Top-k hit rate: **{_fmt_pct(_mean(r.avg_hit_rate for r in off_runs))}** off → "
+            f"**{_fmt_pct(_mean(r.avg_hit_rate for r in on_runs))}** on "
+            f"(Δ {(_mean(r.avg_hit_rate for r in on_runs) - _mean(r.avg_hit_rate for r in off_runs)) * 100:+.1f} "
+            f"points, mean of {len(on_runs)} runs)"
         ),
         (
-            f"- Reduction ratio: **{synapse_off.avg_reduction:.1f}×** off → "
-            f"**{synapse_on.avg_reduction:.1f}×** on "
-            f"(Δ {synapse_on.avg_reduction - synapse_off.avg_reduction:+.2f}× — "
+            "- Per-run deltas: "
+            + ", ".join(
+                f"`{(on.avg_hit_rate - off.avg_hit_rate) * 100:+.1f}`"
+                for off, on in zip(off_runs, on_runs, strict=True)
+            )
+            + " points — published because this metric moves between runs, and a"
+            " mean that hides its own spread is how a directional claim gets"
+            " decided by luck."
+        ),
+        (
+            f"- Reduction ratio: **{_mean(r.avg_reduction for r in off_runs):.1f}×** off → "
+            f"**{_mean(r.avg_reduction for r in on_runs):.1f}×** on "
+            f"(Δ {_mean(r.avg_reduction for r in on_runs) - _mean(r.avg_reduction for r in off_runs):+.2f}× — "
             "budget-neutral by design)"
         ),
         "",
@@ -519,25 +547,44 @@ def main() -> int:
     # Reinforce co-editing sessions, then measure the same queries with
     # synapse recall off vs on. Verifies the boost is budget-neutral
     # (reduction holds) while associative recall lifts the hit rate.
-    reset_memory()
-    nm = NeuralMind(str(FIXTURE_DIR))
-    synapse_edges = seed_synapses(nm)
-    synapse_off = run_synapse_phase(nm, queries, naive_total, inject=False)
-    synapse_on = run_synapse_phase(nm, queries, naive_total, inject=True)
-
-    write_results(phase1, synapse_off, synapse_on, synapse_edges)
-    write_report(phase1, synapse_off, synapse_on, synapse_edges)
+    # Repeated, because a single draw does not settle a directional claim.
+    # This A/B has returned both -1.75 and +4.0 points from the *same* commit
+    # and the same turbovec build, and the two outcomes recur bit-for-bit
+    # rather than spreading — so one sample decides the gate by luck. The
+    # sibling onboarding gate in ci-benchmark.yml already averages three runs
+    # for the same reason ("Averaged to absorb any ChromaDB HNSW query-time
+    # jitter"). Every run is published below, so the spread stays visible
+    # instead of being hidden behind its own mean.
+    off_runs: list[PhaseResult] = []
+    on_runs: list[PhaseResult] = []
+    synapse_edges = 0
+    for _ in range(SYNAPSE_AB_RUNS):
+        reset_memory()
+        nm = NeuralMind(str(FIXTURE_DIR))
+        synapse_edges = seed_synapses(nm)
+        off_runs.append(run_synapse_phase(nm, queries, naive_total, inject=False))
+        on_runs.append(run_synapse_phase(nm, queries, naive_total, inject=True))
+    write_results(phase1, off_runs, on_runs, synapse_edges)
+    write_report(phase1, off_runs, on_runs, synapse_edges)
 
     print(
         f"Phase 1: {phase1.avg_reduction:.1f}× reduction, "
         f"{phase1.avg_hit_rate * 100:.0f}% top-k hit rate "
         f"({phase1_seconds:.1f}s)"
     )
+    off_mean = _mean(r.avg_hit_rate for r in off_runs)
+    on_mean = _mean(r.avg_hit_rate for r in on_runs)
+    per_run = ", ".join(
+        f"{(on.avg_hit_rate - off.avg_hit_rate) * 100:+.1f}"
+        for off, on in zip(off_runs, on_runs, strict=True)
+    )
     print(
-        f"Phase 2: synapse off {synapse_off.avg_hit_rate * 100:.0f}% → "
-        f"on {synapse_on.avg_hit_rate * 100:.0f}% hit rate "
-        f"(Δ {(synapse_on.avg_hit_rate - synapse_off.avg_hit_rate) * 100:+.0f}pts), "
-        f"reduction {synapse_off.avg_reduction:.1f}× → {synapse_on.avg_reduction:.1f}×, "
+        f"Phase 2: synapse off {off_mean * 100:.0f}% → "
+        f"on {on_mean * 100:.0f}% hit rate "
+        f"(Δ {(on_mean - off_mean) * 100:+.0f}pts, mean of {len(on_runs)}; "
+        f"runs [{per_run}]), "
+        f"reduction {_mean(r.avg_reduction for r in off_runs):.1f}× → "
+        f"{_mean(r.avg_reduction for r in on_runs):.1f}×, "
         f"{synapse_edges} edges"
     )
 

--- a/tests/benchmark/run.py
+++ b/tests/benchmark/run.py
@@ -416,7 +416,13 @@ def _environment_fingerprint() -> dict:
         for line in Path("/proc/cpuinfo").read_text().splitlines():
             if line.startswith("flags"):
                 interesting = {
-                    "avx", "avx2", "avx512f", "avx512vnni", "fma", "sse4_2", "neon",
+                    "avx",
+                    "avx2",
+                    "avx512f",
+                    "avx512vnni",
+                    "fma",
+                    "sse4_2",
+                    "neon",
                 }
                 flags = " ".join(sorted(set(line.split(":", 1)[1].split()) & interesting))
                 break

--- a/tests/test_benchmark_regression.py
+++ b/tests/test_benchmark_regression.py
@@ -70,11 +70,45 @@ def test_synapse_recall_does_not_reduce_hit_rate(benchmark_results):
     hit for a co-activated-but-wrong one. This gate catches that: with the
     same warm graph, recall on must surface at least as many expected
     modules as recall off.
+
+    Read from the mean of several A/B runs, not one. This measurement moves:
+    the same commit and the same turbovec build have produced both -1.75 and
+    +4.0 points, and the two outcomes recur bit-for-bit rather than spreading,
+    so a single draw decided the gate by luck. The per-run values are in
+    `off_hit_rate_runs` / `on_hit_rate_runs` when a failure needs diagnosing.
     """
     p3 = benchmark_results["phase2_synapse"]
+    runs = ", ".join(
+        f"{(on - off) * 100:+.1f}"
+        for off, on in zip(
+            p3.get("off_hit_rate_runs", []), p3.get("on_hit_rate_runs", []), strict=False
+        )
+    )
     assert p3["on_avg_top_k_hit_rate"] >= p3["off_avg_top_k_hit_rate"] - 1e-9, (
         f"Synapse recall lowered hit rate: {p3['off_avg_top_k_hit_rate']:.2%} off → "
-        f"{p3['on_avg_top_k_hit_rate']:.2%} on. Displacement is dropping relevant hits."
+        f"{p3['on_avg_top_k_hit_rate']:.2%} on, averaged over "
+        f"{p3.get('ab_runs', 1)} run(s) [{runs}] points. "
+        "Displacement is dropping relevant hits."
+    )
+
+
+def test_synapse_ab_is_averaged_over_several_runs(benchmark_results):
+    """The gate above is only meaningful if it reads more than one sample.
+
+    Without this, dropping the repeat — or setting NEURALMIND_SYNAPSE_AB_RUNS=1
+    to make a red build go green — would silently restore the single-draw
+    behaviour that made the directional claim a coin toss, and nothing would
+    say so.
+    """
+    p3 = benchmark_results["phase2_synapse"]
+    assert p3.get("ab_runs", 1) >= 2, (
+        f"Phase-2 A/B ran {p3.get('ab_runs', 1)} time(s). The hit-rate gate "
+        "decides a directional claim from a metric that moves between runs, so "
+        "it must average at least two."
+    )
+    assert len(p3.get("on_hit_rate_runs", [])) == p3.get("ab_runs", 1), (
+        "Per-run hit rates must be published alongside the mean — a mean that "
+        "hides its own spread is what let this metric look stable."
     )
 
 

--- a/tests/test_benchmark_regression.py
+++ b/tests/test_benchmark_regression.py
@@ -71,11 +71,25 @@ def test_synapse_recall_does_not_reduce_hit_rate(benchmark_results):
     same warm graph, recall on must surface at least as many expected
     modules as recall off.
 
-    Read from the mean of several A/B runs, not one. This measurement moves:
-    the same commit and the same turbovec build have produced both -1.75 and
-    +4.0 points, and the two outcomes recur bit-for-bit rather than spreading,
-    so a single draw decided the gate by luck. The per-run values are in
-    `off_hit_rate_runs` / `on_hit_rate_runs` when a failure needs diagnosing.
+    Read from the mean of several A/B runs, not one — but do not mistake that
+    mean for a fix. This measurement is bimodal: the same commit on the same
+    runner image has produced both -1.75 and +4.0 points, and it lands on one
+    mode or the other *per job*, returning that mode bit-for-bit on every
+    in-process repeat. So the mean of N runs inside one job is the mean of N
+    copies of a single draw, and averaging cannot make it converge.
+
+    What the repeat actually buys is the published spread. `off_hit_rate_runs`
+    / `on_hit_rate_runs` are what showed the runs were identical rather than
+    scattered, which is how the variance was localised to between jobs; they
+    are also the tripwire that would catch genuine within-job jitter if it
+    ever appears. Read them first when this gate fails.
+
+    Ruled out as the cause so far, each by measurement rather than argument:
+    CPU/SIMD feature set, PYTHONHASHSEED, the graph partition (seeded Louvain,
+    stable across rebuilds), Python patch version, resolved dependency
+    versions, neighbour-row order out of the un-ORDER BY'd synapse query, and
+    the recall ranking reverted in #464 — the identical failing pair
+    (74.56% -> 72.81%) occurs both with that change and without it.
     """
     p3 = benchmark_results["phase2_synapse"]
     runs = ", ".join(
@@ -93,12 +107,14 @@ def test_synapse_recall_does_not_reduce_hit_rate(benchmark_results):
 
 
 def test_synapse_ab_is_averaged_over_several_runs(benchmark_results):
-    """The gate above is only meaningful if it reads more than one sample.
+    """The gate above is only meaningful if it publishes more than one sample.
 
-    Without this, dropping the repeat — or setting NEURALMIND_SYNAPSE_AB_RUNS=1
-    to make a red build go green — would silently restore the single-draw
-    behaviour that made the directional claim a coin toss, and nothing would
-    say so.
+    Not because the mean converges — it does not, see above — but because the
+    per-run list is the evidence that distinguishes "this job drew the low
+    mode" from "retrieval genuinely regressed". Dropping the repeat, or
+    setting NEURALMIND_SYNAPSE_AB_RUNS=1 to make a red build go green, would
+    throw away exactly the signal needed to tell those two apart, and nothing
+    else would say so.
     """
     p3 = benchmark_results["phase2_synapse"]
     assert p3.get("ab_runs", 1) >= 2, (


### PR DESCRIPTION
## Description

Split: the `turbovec` index-recovery fix that this PR originally carried has moved to #467. This PR is now the benchmark-gate half only. The investigation thread below stays here because it is all about this half.

**The synapse hit-rate gate decided a directional claim from one sample.** It went red three times on #451 through measurement, not regression. This PR repeats the Phase-2 A/B, publishes every per-run value, and fingerprints the environment and the graph partition the run was measured against.

**Read the honest framing first:** the repeat does **not** make the metric converge, and the docstrings no longer imply it does. See "What this does not fix".

Fixes # N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🧪 Test update

## How Has This Been Tested?

- [x] Unit tests
- [x] Integration tests
- [x] Manual testing

### Test Configuration

* **Python version**: 3.11
* **Operating System**: Linux
* **Test command**: `pytest tests/test_benchmark_regression.py`

**The gate**, verified in both directions: `test_synapse_ab_is_averaged_over_several_runs` fails under `NEURALMIND_SYNAPSE_AB_RUNS=1`, passes at the default.

**Per-run values are now published** (`off_hit_rate_runs` / `on_hit_rate_runs`, plus the printed line and PR comment). Had they been visible, the bimodality would have been obvious the first time rather than needing a re-run of an identical commit to establish. They are what made the diagnosis below possible.

## What this does not fix

The metric is bimodal **per job**, not per run. A job lands on one mode and then returns it bit-for-bit on every in-process repeat — CI printed `[-1.8, -1.8, -1.8]` and `[+3.5, +3.5, +3.5]`, never a spread. So a mean over N in-process runs is a mean over N copies of a single draw, and no N makes it converge. `db81664` (now `56f6635`) corrects the docstrings, which had implied otherwise.

What the repeat is actually worth is the published per-run list: *identical rather than scattered* is precisely what localised the variance to between jobs, and it stays as the tripwire for genuine within-job jitter.

## Diagnosis so far

Installing the pinned `graphifyy==0.9.5` gave a sandbox that reproduces CI byte-for-byte — 121 nodes, 212 graph edges, 14 communities, 2954 synapse edges, `Phase 1: 4.9× / 67%`. Earlier hypothesis tests had run against a 4121-edge graph and were therefore meaningless.

Against a failing CI job, Phase 1, the synapse graph and the A/B **off**-arm are all bit-identical; **only the recall arm moves**. That rules out vector retrieval and graph construction, and made the rest individually testable.

Eliminated by measurement, not argument:

| Hypothesis | How it died |
|---|---|
| CPU / SIMD feature set | env fingerprint byte-identical, sandbox vs CI |
| `PYTHONHASHSEED` | 7 seeds (0,1,2,3,42,1337,90210), all `+3.5` |
| Graph partition | seeded Louvain (`seed=42`; Leiden needs `graspologic`, not installed); digest stable across 6 fresh build cycles |
| Python patch / dep versions | failing `fcae016` and passing `e1e5254` — same image, same resolved deps, same pip cache key |
| Neighbour-row order | `_spread`'s query has no `ORDER BY`, so rows were shuffled under 6 seeds; all `+3.5` (the activation sum is additive) |
| The #461 ranking change | see below |

**The #464 revert is not the fix.** It merged between a red run and a green one, which makes it look causal:

| Commit | Carries #461's ranking change? | Result |
|---|---|---|
| `fcae016` (main) | **yes** | `74.56% → 72.81%` ❌ |
| `e1e5254` (main) | no (reverted) | `74.6% → 78.1%` ✅ |
| `aaf3166` (here) | no | `74.56% → 72.81%` ❌ |
| `25dcb58` (here) | no | `74.56% → 72.81%` ❌ |
| `6e0dd04` (here) | no | `74.6% → 78.1%` ✅ |

Same failing digits on both sides of the revert. Applying `d188768`'s diff to the faithful sandbox also still gives `+3.5`. It is neither necessary nor sufficient — anyone reading that green run as proof would be re-landing a revert that does not address this.

**Still open:** the cause. It lives in the recall arm and is none of the above. I have not reproduced the low mode locally under any condition, which is itself a clue. I have deliberately not re-run CI jobs to fish for a red one.

## Documentation & discoverability

- [x] Docs answer *"what does the user/agent now see?"* — CI output and the PR comment now carry per-run A/B values plus an environment and graph-partition fingerprint, so a red gate can be triaged from the log alone
- [x] I did **not** edit `CHANGELOG.md` or hand-bump the `pyproject.toml` version

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

## Code Quality

- [x] `ruff check .` — clean
- [x] `black --check --diff .` — clean (CI's exact invocation; an earlier `--target-version` override of mine disagreed with CI on a magic-trailing-comma set and produced a red Lint)
- [x] Type hints and docstrings on the new helpers

## Additional Notes

**The averaging strengthens the gate, it does not relax it.** A single unlucky sample can no longer fail it on its own; a real regression still does, because a genuine drop moves every run. `test_synapse_ab_is_averaged_over_several_runs` pins that, so deleting the repeat — or setting `NEURALMIND_SYNAPSE_AB_RUNS=1` to turn a red build green — fails loudly instead of silently discarding the evidence needed to tell a low draw from a regression.