### PR TITLE
fix(compliance): let documentation show an annotation without becoming evidence

### DIFF
--- a/docs/wiki/CLI-Reference.md
+++ b/docs/wiki/CLI-Reference.md
@@ -1923,6 +1923,40 @@ Code **and** prose: `.py .js .jsx .ts .tsx .go .java .rb .php .cs .c .cpp
 markdown — the usual place for a policy document — were invisible to this
 command even though the matcher supported them.)*
 
+#### Showing an annotation without becoming evidence
+
+Documentation, tests and marketing copy have to *show* what an annotation
+looks like. Before v3.4.1 every one of those examples was counted as a real
+annotation — on this repository the scan reported 37 controls, 25 of which
+were syntax samples in the very pages that document the syntax, and all 37
+flowed into `neuralmind export --controls`, which users submit as audit
+evidence.
+
+Two opt-out markers fix that. Neither is a comment syntax of its own — put
+the text anywhere a given file lets you put text (an HTML comment in
+markdown, a `#` or `//` comment in code, prose in a docstring):
+
+| Marker | Scope | Use it when |
+|--------|-------|-------------|
+| `neuralmind:example-file` | the whole file, wherever it appears | the file is *about* the syntax — a reference page, a test fixture |
+| `neuralmind:example` | the one line it sits on | a single sample inside a file whose other annotations are real |
+
+```markdown
+<!-- neuralmind:example-file — annotations here are syntax examples, not evidence. -->
+# CLI Reference
+```
+
+```python
+help="e.g. # NIST AC-1: Access control policy",  # neuralmind:example
+```
+
+The file-level marker is checked before any pattern runs, so an opted-out
+file costs nothing to scan. The line-level marker is tested against the
+whole line the control id sits on, not the start of the match.
+
+Both markers are inert everywhere else — nothing else in NeuralMind reads
+them, and a file carrying one still indexes, embeds and queries normally.
+
 ---
 
 ### ci-check *(v3.1.4+)*

--- a/docs/wiki/CLI-Reference.md
+++ b/docs/wiki/CLI-Reference.md
@@ -1,3 +1,4 @@
+<!-- neuralmind:example-file — annotations here are syntax examples, not evidence. -->
 # CLI Reference
 
 Complete command-line interface documentation for NeuralMind.

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -1,3 +1,4 @@
+<!-- neuralmind:example-file — annotations here are syntax examples, not evidence. -->
 # 🧠 NeuralMind Wiki
 
 **Reduce Claude, GPT, and Gemini token costs 12–50× on code questions.** Local semantic codebase index + MCP server + PostToolUse compression hooks for Claude Code, Cursor, Cline, Continue, and any LLM.

--- a/neuralmind/cli.py
+++ b/neuralmind/cli.py
@@ -3606,8 +3606,9 @@ def cmd_compliance(args):
         print(f"No compliance annotations found in {path}.")
         print(
             "Tip: add annotations like:\n"
-            "  // CMMC AC.L2-3.1.1: Authorized Access Control\n"
-            "  # SOX ITGC-CM-001: Change approved via CAB\n"
+            # The two samples below are help text, not annotations on this file.
+            "  // CMMC AC.L2-3.1.1: Authorized Access Control\n"  # neuralmind:example
+            "  # SOX ITGC-CM-001: Change approved via CAB\n"  # neuralmind:example
         )
         return
 

--- a/neuralmind/compliance_matcher.py
+++ b/neuralmind/compliance_matcher.py
@@ -234,6 +234,31 @@ def iter_scannable_files(root):
 # --------------------------------------------------------------------------- #
 
 
+#: Opt-out markers.
+#:
+#: Documentation and tests have to *show* what an annotation looks like, and a
+#: shown annotation is byte-identical to a real one. That is how this repository
+#: came to report 37 annotations of which only 12 were evidence: the other 25
+#: were worked examples in docstrings, the CLI reference and the test suite,
+#: all flowing into ``neuralmind export --controls``.
+#:
+#: ``neuralmind:example`` on the same line drops that one annotation.
+#: ``neuralmind:example-file`` anywhere in the text drops the whole file.
+#:
+#: A file that merely *mentions* ``neuralmind:example-file`` therefore silences
+#: itself. That is intended rather than tolerated: a file explaining how to
+#: write an annotation is a file that shows one, and it is not evidence.
+EXAMPLE_FILE_MARKER = "neuralmind:example-file"
+_EXAMPLE_LINE_RE = re.compile(r"neuralmind:example(?!-file)")
+
+
+def _line_containing(text: str, pos: int) -> str:
+    """Return the whole line ``pos`` falls on, without its newline."""
+    start = text.rfind("\n", 0, pos) + 1
+    end = text.find("\n", pos)
+    return text[start : len(text) if end == -1 else end]
+
+
 def find_compliance_annotations(text: str) -> list[dict]:
     """Scan ``text`` for compliance annotations of any supported framework.
 
@@ -251,11 +276,19 @@ def find_compliance_annotations(text: str) -> list[dict]:
 
     Empty list when nothing matches.
     """
+    # Whole-file opt-out, checked before any pattern runs.
+    if EXAMPLE_FILE_MARKER in text:
+        return []
+
     results: list[dict] = []
     seen: set[tuple[str, str]] = set()  # dedup (framework, control_id)
 
     for framework, pattern in _PATTERNS:
         for m in pattern.finditer(text):
+            # Per-line opt-out. Tested against the line the control id sits on,
+            # not the match start: a match may run to the following newline.
+            if _EXAMPLE_LINE_RE.search(_line_containing(text, m.start("control_id"))):
+                continue
             control_id = m.group("control_id").strip().upper()
             label = _same_line_label(text, m)
             key = (control_id, framework)

--- a/neuralmind/content_node.py
+++ b/neuralmind/content_node.py
@@ -16,7 +16,7 @@ Usage:
         node_id="cmc:AC.L2-3.1.1",
         label="Authorized Access Control",
         content_type="cmmc_practice",
-        text="AC.L2-3.1.1: Authorized Access Control - Limit system access...",
+        text="AC.L2-3.1.1: Authorized Access Control - Limit system access...",  # neuralmind:example
         metadata={"domain": "AC", "framework": "CMMC"},
     )
 

--- a/site/src/components/sections/Features.tsx
+++ b/site/src/components/sections/Features.tsx
@@ -1,3 +1,4 @@
+// neuralmind:example-file — annotations here are syntax examples, not evidence.
 'use client';
 
 import Icon, { type IconName } from '@/components/ui/Icon';

--- a/tests/test_compliance_matcher.py
+++ b/tests/test_compliance_matcher.py
@@ -7,12 +7,15 @@ commands, and milestone ids. Scanning this repo produced 147 SOC 2
 "annotations" of which 129 were noise.
 
 That matters more than a noisy scan: these annotations feed ``neuralmind
-export --audit``, documented as producing "flat compliance reports (CSV/JSON)
-for evidence submission". A fabricated control in an audit export is a
+export --controls``, documented as producing control-to-code mappings for
+evidence submission. A fabricated control in an audit export is a
 materially worse failure than a missed one, so these tests pin precision.
 
 Stdlib-only, like the other guard modules, so they run without the full dep
 set.
+
+neuralmind:example-file — every annotation in this file is a fixture, not
+evidence, and must not reach ``neuralmind export --controls``.
 """
 
 from __future__ import annotations
@@ -286,3 +289,50 @@ def test_ci_check_framework_actually_filters(tmp_path, monkeypatch) -> None:
     only_cmmc = ci_check.run_ci_check(tmp_path, framework="cmmc")
     assert {f["framework"] for f in only_cmmc["findings"]} == {"CMMC"}
     assert "CC6.1" not in only_cmmc["affected_controls"]
+
+
+# --------------------------------------------------------------------------- #
+# Opt-out markers
+# --------------------------------------------------------------------------- #
+# Documentation has to *show* an annotation, and a shown one is byte-identical
+# to a real one. This repo reported 37 annotations of which 12 were evidence.
+# The markers are spelled by concatenation here so this file's own tests do not
+# trip the file-level marker before it is under test.
+
+_LINE = "neuralmind:" + "example"
+_FILE = "neuralmind:" + "example-file"
+
+
+def test_same_line_marker_drops_that_annotation() -> None:
+    assert find_compliance_annotations(f"# NIST AC-1: Access policy  {_LINE}") == []
+
+
+def test_same_line_marker_leaves_other_lines_alone() -> None:
+    text = f"# NIST AC-1: Access policy  {_LINE}\n# NIST AU-3: Audit review"
+    assert [a["control_id"] for a in find_compliance_annotations(text)] == ["AU-3"]
+
+
+def test_file_marker_drops_every_annotation_in_the_text() -> None:
+    text = f"{_FILE}\n# NIST AC-1: x\n# CMMC AC.L2-3.1.1: y"
+    assert find_compliance_annotations(text) == []
+
+
+def test_markers_do_not_themselves_match() -> None:
+    assert find_compliance_annotations(f"{_LINE} {_FILE}") == []
+
+
+def test_marker_suppresses_a_whole_comma_list() -> None:
+    """The #455 sibling pass must not resurrect ids from a suppressed line."""
+    text = f"**SOC 2 Controls:** CC3.1, CC8.1, A1.1 - change mgmt  {_LINE}"
+    assert find_compliance_annotations(text) == []
+
+
+def test_unsuppressed_comma_list_still_yields_every_id() -> None:
+    text = "**SOC 2 Controls:** CC3.1, CC8.1, A1.1 - change mgmt"
+    assert len(find_compliance_annotations(text)) == 3
+
+
+def test_markers_do_not_weaken_the_false_positive_guards() -> None:
+    """The #453 guards must survive the marker work."""
+    assert find_compliance_annotations("Shipped in v0.13.0, v2.0 and v0.22 today.") == []
+    assert find_compliance_annotations("noncompliance: CC3.1, CC8.1 - nope") == []


### PR DESCRIPTION
Closes #463.

## Description

`neuralmind compliance .` reported **37 annotations on this repository. Twelve were real.** The other 25 were worked examples — five in `compliance_matcher.py`'s own module docstring, six in the CLI reference, seven in its test suite, plus `cli.py`, `content_node.py`, `Home.md` and `Features.tsx` — and every one flowed into `neuralmind export --controls`, the file users submit as audit evidence.

#453 and #455 spent two PRs removing version strings and SVG path data from that export. The largest remaining contaminant was the tool's own documentation of how to write an annotation.

It also got **worse as the docs got better**: correcting the NIST claim in #458 required showing the real syntax, which added four more.

## The mechanism

Two markers, **no path exclusions**:

| Marker | Scope |
|---|---|
| `neuralmind:example` | drops that one annotation, on that line |
| `neuralmind:example-file` | drops every annotation in the file |

Path exclusion was the other option in #463 and is the wrong one. Excluding `tests/` would hide genuine annotations in a user's own test suite, and it does nothing for a docstring or a wiki page — where most of this repo's noise actually lived.

A file that merely *mentions* `neuralmind:example-file` silences itself. That is intended rather than tolerated, and the docstring says so: a file explaining how to write an annotation is a file that shows one, and it is not evidence. It is also why `compliance_matcher.py` needs no marker of its own — the constant's string literal *is* the marker.

Two details that needed care:

- The per-line check runs against the line the **control id** sits on, not the match start — a match may run to the following newline.
- It runs **before** the #455 sibling pass, so a suppressed comma list cannot have its remaining ids resurrected. Pinned by a test.

## Measured

```
genuine (docs/compliance/*.md)   12    12
examples elsewhere               25 ->  0
total reported                   37 -> 12
```

All twelve genuine annotations still resolve — `neuralmind compliance .` now reports exactly them and nothing else.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🧪 Test update
- [x] 📝 Documentation

## How Has This Been Tested?

- [x] Unit tests
- [x] Manual testing

- **7 new tests** (26 in the module), including that the markers create no annotations of their own, that a suppressed comma list stays suppressed, and that the #453 false-positive guards survive.
- The markers are spelled by **concatenation** inside the test file, so its own assertions do not trip the file-level marker before it is under test.
- **End-to-end**: whole-repo scan, 37 → 12, all twelve genuine.
- **Full-suite regression diff**: 109 failures before, 109 after, **zero new** — the pre-existing set from uninstalled optional deps (`numpy`, `chromadb`, `onnxruntime`) in this sandbox.
- `black --check` and `ruff check` clean.

### Test Configuration

* **Test command**: `pytest tests/test_compliance_matcher.py -q`

## Documentation & discoverability

- [x] This **does** change agent-visible output — `neuralmind compliance`, `neuralmind_compliance_report`, `ci-check` and `export --controls` all stop reporting this repo's examples.
- [x] `docs/wiki/CLI-Reference.md` gains a **"Showing an annotation without becoming evidence"** subsection under `compliance`: both markers, what each is for, where the text may sit in a given file type, and the measurement that motivated them. Ships in this PR rather than a follow-up, per the shipping checklist.
- [x] I did **not** edit `CHANGELOG.md` or hand-bump the `pyproject.toml` version.

The docs section pins the behavior to **v3.4.1** — the next patch from `main` at 3.4.0, with no `feat:` PRs open. If a feature lands first, that label needs bumping before merge.

## Additional Notes

**Corrected in passing:** the test module's docstring cited `neuralmind export --audit` — the flag that has never existed. #458 fixed that claim on the wiki and the site; this was the third instance.

**One judgement call to flag:** the markers change what the scanner reports for *existing users*, not just this repo. Anyone who already has `neuralmind:example` in a file — unlikely, but not impossible — would see those annotations disappear. Nothing is suppressed unless the string is present, so the default for everyone else is unchanged.