### PR TITLE
fix(skills): sync SKILL.md version to the release and document the target hosts

### DIFF
--- a/docs/use-cases/multi-agent.md
+++ b/docs/use-cases/multi-agent.md
@@ -62,7 +62,7 @@ Registers `PostToolUse` compression + `SessionStart` / `UserPromptSubmit` /
   "mcpServers": {
     "neuralmind": {
       "command": "neuralmind-mcp",
-      "args": ["/absolute/path/to/project"]
+      "args": []
     }
   }
 }
@@ -71,7 +71,7 @@ Registers `PostToolUse` compression + `SessionStart` / `UserPromptSubmit` /
 **Cursor / Cline / Continue:** Drop a `.mcp.json` at the project root:
 
 ```json
-{ "mcpServers": { "neuralmind": { "command": "neuralmind-mcp", "args": ["."] } } }
+{ "mcpServers": { "neuralmind": { "command": "neuralmind-mcp", "args": [] } } }
 ```
 
 **Hermes-Agent:**
@@ -83,11 +83,14 @@ hermes mcp add  # or edit ~/.hermes/config.yaml
 **OpenClaw:**
 
 ```bash
-openclaw mcp set neuralmind '{"command":"neuralmind-mcp","args":["/absolute/path/to/project"]}'
+openclaw mcp set neuralmind '{"command":"neuralmind-mcp","args":[]}'
 ```
 
-All five point at the same project. Same MCP tools (`neuralmind_wakeup`,
-`_query`, `_skeleton`, `_search`, ...). Same `.neuralmind/synapses.db`.
+The launch spec carries no project path — `neuralmind-mcp` takes no
+arguments. Every tool takes its own `project_path`, so what points all five
+at the same brain is passing the same path per call, not the registration.
+Same MCP tools (`neuralmind_wakeup`, `_query`, `_skeleton`, `_search`, ...).
+Same `.neuralmind/synapses.db`.
 
 ## The new v0.6.0 superpower: see the union
 

--- a/docs/wiki/Integration-Guide.md
+++ b/docs/wiki/Integration-Guide.md
@@ -43,11 +43,20 @@ synapse edges. The brain is one brain.
 
 ### Verifying the shared-brain setup
 
+The launch spec is *not* what scopes the server to a project.
+`neuralmind-mcp` takes no arguments — every MCP tool carries its own
+`project_path`, resolved against the server process's working directory. So
+register it bare in every host, and make the shared brain by passing the same
+absolute project path on each call:
+
 ```bash
 # In each agent's host (Claude Desktop, Hermes, OpenClaw, etc.),
-# the MCP server is registered with the SAME args:
+# the server is registered with NO arguments:
 
-neuralmind-mcp /absolute/path/to/project
+neuralmind-mcp
+
+# What makes it one brain is the per-call argument, identical everywhere:
+#   neuralmind_query(project_path="/absolute/path/to/project", question="…")
 
 # Verify the agent connected:
 hermes mcp test neuralmind          # if using Hermes

--- a/docs/wiki/Integration-Guide.md
+++ b/docs/wiki/Integration-Guide.md
@@ -9,6 +9,7 @@ Guide to integrating NeuralMind with MCP tools, graphify, and other development 
 - [MCP Integration](#mcp-integration)
   - [Claude Desktop](#claude-desktop)
   - [Cursor](#cursor)
+  - [Hermes-Agent](#hermes-agent)
   - [Custom MCP Clients](#custom-mcp-clients)
 - [CI/CD Integration](#cicd-integration)
 - [IDE Integration](#ide-integration)
@@ -310,6 +311,45 @@ Create `.cursor/mcp.json` in your project:
   }
 }
 ```
+
+### Hermes-Agent
+
+Hermes ships its own MCP client and discovers configured servers at
+startup, so NeuralMind's tools arrive as first-class tools alongside
+`terminal` and `read_file` — no bridge process.
+
+#### Configuration
+
+```bash
+hermes mcp add                      # interactive
+# …or edit ~/.hermes/config.yaml directly
+hermes mcp test neuralmind          # verify the agent connected
+```
+
+#### Without the MCP server: install the skill
+
+NeuralMind also ships a portable skill at
+[`skills/neuralmind/SKILL.md`](https://github.com/dfrostar/neuralmind/blob/main/skills/neuralmind/SKILL.md).
+Hermes can install it straight from GitHub — no registry submission, no
+release pipeline, just a repo containing a `skills/` directory:
+
+```bash
+# One skill, without subscribing to the whole repo
+hermes skills install dfrostar/neuralmind/skills/neuralmind
+
+# …or add the repo as a tap and get everything under skills/
+hermes skills tap add dfrostar/neuralmind
+```
+
+Both forms follow Hermes's documented
+`owner/repo/skills/<name>` syntax — see
+[Hermes: Skills](https://hermes-agent.nousresearch.com/docs/user-guide/features/skills).
+New taps are assigned community trust, so the first install shows a
+third-party warning panel after the security scan.
+
+The skill drives the `neuralmind` CLI through Hermes's `terminal` tool, so
+it works with or without the MCP server registered. With both, the MCP
+tools take precedence — same retrieval, fewer shell round-trips.
 
 ### Custom MCP Clients
 

--- a/docs/wiki/Setup-Guide.md
+++ b/docs/wiki/Setup-Guide.md
@@ -137,7 +137,7 @@ Or add a `.mcp.json` at your project root so Claude Code loads NeuralMind automa
   "mcpServers": {
     "neuralmind": {
       "command": "neuralmind-mcp",
-      "args": ["."]
+      "args": []
     }
   }
 }
@@ -168,7 +168,7 @@ Or add NeuralMind to your Claude Desktop config manually:
   "mcpServers": {
     "neuralmind": {
       "command": "neuralmind-mcp",
-      "args": ["/absolute/path/to/your-project"]
+      "args": []
     }
   }
 }

--- a/docs/wiki/Usage-Guide.md
+++ b/docs/wiki/Usage-Guide.md
@@ -384,7 +384,7 @@ writer (you still get the in-process feed for the agent running
   "mcpServers": {
     "neuralmind": {
       "command": "neuralmind-mcp",
-      "args": ["/path/to/your/project"]
+      "args": []
     }
   }
 }
@@ -682,7 +682,7 @@ pip install neuralmind
   "mcpServers": {
     "neuralmind": {
       "command": "neuralmind-mcp",
-      "args": ["/path/to/your/project"]
+      "args": []
     }
   }
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,7 +5,10 @@
     ".": {
       "release-type": "python",
       "changelog-path": "CHANGELOG.md",
-      "version-file": "neuralmind/__init__.py"
+      "version-file": "neuralmind/__init__.py",
+      "extra-files": [
+        "skills/neuralmind/SKILL.md"
+      ]
     }
   }
 }

--- a/skills/neuralmind/SKILL.md
+++ b/skills/neuralmind/SKILL.md
@@ -199,7 +199,7 @@ case drive the `neuralmind` CLI through `terminal` instead. See
 **OpenClaw.** Registered once with:
 
 ```bash
-openclaw mcp set neuralmind '{"command":"neuralmind-mcp","args":["/absolute/path/to/project"]}'
+openclaw mcp set neuralmind '{"command":"neuralmind-mcp","args":[]}'
 ```
 
 `openclaw mcp show neuralmind` confirms the connection.
@@ -209,6 +209,17 @@ openclaw mcp set neuralmind '{"command":"neuralmind-mcp","args":["/absolute/path
 plugin-index manifest for the registry listing — it is not runtime config,
 so its presence tells you nothing about whether the server is wired up.
 Check for the tools.
+
+**Pass a real path, not `.`, when the host runs the server detached.**
+`neuralmind-mcp` takes no launch arguments — every tool resolves its own
+`project_path` argument, relative to whatever working directory the *server*
+process happens to have. Under Claude Code and Cursor that is the project, so
+`project_path="."` above is correct. Under a host that starts the server as a
+long-lived background process — Hermes, OpenClaw, Agent Zero — it may not be,
+and `"."` then silently reads the wrong directory or reports `built: false`
+for an index that exists. If `neuralmind_stats(project_path=".")` claims the
+project is unbuilt when the user says it is built, re-run it with the
+absolute project path before telling them to build.
 
 **One brain, several hosts.** Every host pointed at the same project path
 reinforces the same `.neuralmind/synapses.db`. Associations the user's other

--- a/skills/neuralmind/SKILL.md
+++ b/skills/neuralmind/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: neuralmind
 description: Answer questions about a code repository in ~800 tokens instead of loading 50,000+ tokens of raw source. Use whenever the user asks how something works, where something is defined, who calls what, or to explore an unfamiliar file. Provides progressive context disclosure (L0 identity → L1 architecture → L2 relevant clusters → L3 semantic search) and a learned synapse graph for usage-based recall.
-version: 0.5.2
+version: 3.4.1 # x-release-please-version
 author: dfrostar
 license: MIT
 tags:
@@ -180,6 +180,42 @@ not for routine question-answering.
   repo wasn't indexed at sufficient depth. Try `neuralmind_search` with the
   most distinctive term from the question.
 - **`built: false`:** stop and tell the user. See *Prerequisite check*.
+
+## Host notes (Hermes-Agent, OpenClaw, Agent Zero)
+
+The decision tree above is identical in every host. What differs is how
+NeuralMind reaches you, and what to do when it hasn't.
+
+**Hermes-Agent.** Hermes has a built-in MCP client and discovers servers at
+startup, so the `neuralmind_*` tools arrive as first-class tools alongside
+`terminal` and `read_file` — no bridge CLI. If they are absent, the server
+isn't registered: the user runs `hermes mcp add` (or edits
+`~/.hermes/config.yaml`) and confirms with `hermes mcp test neuralmind`.
+This file also installs as a Hermes skill *without* the MCP server —
+`hermes skills install dfrostar/neuralmind/skills/neuralmind` — in which
+case drive the `neuralmind` CLI through `terminal` instead. See
+*Failure modes*.
+
+**OpenClaw.** Registered once with:
+
+```bash
+openclaw mcp set neuralmind '{"command":"neuralmind-mcp","args":["/absolute/path/to/project"]}'
+```
+
+`openclaw mcp show neuralmind` confirms the connection.
+
+**Agent Zero.** Reached through its MCP configuration, pointed at the same
+`neuralmind-mcp` command. The `plugin.yaml` in this repo's root is the
+plugin-index manifest for the registry listing — it is not runtime config,
+so its presence tells you nothing about whether the server is wired up.
+Check for the tools.
+
+**One brain, several hosts.** Every host pointed at the same project path
+reinforces the same `.neuralmind/synapses.db`. Associations the user's other
+agents built are visible to you, and yours to them — so
+`neuralmind_synaptic_neighbors` can legitimately surface code this session
+never touched. That is the feature, not a stale index. Don't rebuild to
+"clear" it.
 
 ## Environment toggles (for reference)
 

--- a/tests/test_docs_claims.py
+++ b/tests/test_docs_claims.py
@@ -60,6 +60,10 @@ PUBLISHED_GLOBS = (
     # once. Posts are drafted in-repo precisely so this guard vets them BEFORE
     # they're pasted somewhere no CI can reach.
     "docs/social/*.md",
+    # Shipped to Hermes-Agent taps, OpenClaw's ClawHub and the Agent Zero
+    # index — read by models in other people's runtimes, where no CI of ours
+    # can reach it. Same argument as docs/llms.txt above.
+    "skills/*/SKILL.md",
 )
 
 # A post may legitimately *quote* a forbidden phrase in order to correct it —

--- a/tests/test_skill_manifest.py
+++ b/tests/test_skill_manifest.py
@@ -1,0 +1,141 @@
+"""Guard the portable skill manifest against version drift and registry rejects.
+
+`skills/neuralmind/SKILL.md` is the copy three external registries read —
+Hermes-Agent taps, OpenClaw's ClawHub, and (indirectly) Agent Zero. Its
+frontmatter `version` sat at 0.5.2 while the package shipped 3.4.1, because
+nothing bumped it and nothing checked. Anyone installing from a registry
+would have been told they were running a version three majors old.
+
+release-please now owns that line via `extra-files` + the
+`x-release-please-version` annotation. This test is the backstop for the
+wiring itself: if the annotation is edited away, or the file drops out of
+`extra-files`, the bump silently stops happening again. It also asserts the
+two identity rules the Agent Zero index CI enforces on submission, so a
+rename is caught here rather than in a third-party PR.
+
+Stdlib-only by repo convention — no PyYAML — so it runs without the full
+dep set.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+SKILL_PATH = REPO_ROOT / "skills" / "neuralmind" / "SKILL.md"
+PLUGIN_PATH = REPO_ROOT / "plugin.yaml"
+MANIFEST_PATH = REPO_ROOT / ".release-please-manifest.json"
+CONFIG_PATH = REPO_ROOT / "release-please-config.json"
+
+# The extra-files entry is a repo-relative POSIX path in release-please's config.
+SKILL_REL = "skills/neuralmind/SKILL.md"
+
+# Agent Zero's a0-plugins index rejects anything outside this shape, and
+# requires the folder name submitted there to equal plugin.yaml's `name`.
+A0_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9_]*$")
+
+
+def _frontmatter(path: Path) -> dict[str, str]:
+    """Return top-level scalar frontmatter keys from a SKILL.md.
+
+    Deliberately shallow: nested blocks (tags, runtime, metadata) are skipped
+    rather than parsed, because the only fields registries key on are scalars
+    and a real YAML parser is not available in the stdlib-only test set.
+    """
+    text = path.read_text(encoding="utf-8")
+    if not text.startswith("---\n"):
+        raise AssertionError(f"{path} does not open with a YAML frontmatter fence")
+    _, _, rest = text.partition("---\n")
+    body, fence, _ = rest.partition("\n---\n")
+    if not fence:
+        raise AssertionError(f"{path} has an unterminated frontmatter block")
+
+    fields: dict[str, str] = {}
+    for line in body.splitlines():
+        if not line or line.startswith((" ", "\t", "#")):
+            continue  # nested value or comment
+        key, sep, value = line.partition(":")
+        if not sep:
+            continue
+        value = value.split(" #", 1)[0].strip()  # drop inline YAML comment
+        fields[key.strip()] = value.strip("'\"")
+    return fields
+
+
+def _plugin_name(path: Path) -> str:
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if line.startswith("name:"):
+            return line.partition(":")[2].split(" #", 1)[0].strip().strip("'\"")
+    raise AssertionError(f"{path} has no top-level `name:` key")
+
+
+def _released_version() -> str:
+    return json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))["."]
+
+
+class TestSkillVersionTracksTheRelease:
+    def test_version_matches_the_release_manifest(self):
+        declared = _frontmatter(SKILL_PATH)["version"]
+        assert declared == _released_version(), (
+            f"{SKILL_REL} advertises v{declared} but the package is "
+            f"v{_released_version()}. Registries publish the frontmatter "
+            "version verbatim. Do not hand-edit it — release-please bumps it "
+            "via extra-files; if it drifted, that wiring is broken."
+        )
+
+    def test_version_line_carries_the_release_please_annotation(self):
+        """Without the annotation the generic updater silently no-ops."""
+        lines = SKILL_PATH.read_text(encoding="utf-8").splitlines()
+        version_lines = [ln for ln in lines if ln.startswith("version:")]
+        assert len(version_lines) == 1, f"expected one version line, got {version_lines}"
+        assert "x-release-please-version" in version_lines[0], (
+            "the frontmatter version line lost its `# x-release-please-version` "
+            "annotation — release-please will stop bumping it and the file will "
+            "drift out of date again"
+        )
+
+    def test_skill_is_registered_as_a_release_please_extra_file(self):
+        config = json.loads(CONFIG_PATH.read_text(encoding="utf-8"))
+        extra = config["packages"]["."].get("extra-files", [])
+        assert SKILL_REL in extra, (
+            f"{SKILL_REL} is not in release-please's extra-files, so the "
+            "annotation above will never fire"
+        )
+
+
+class TestRegistryIdentityIsStable:
+    """The identity fields three registries key on, and a0-plugins CI enforces."""
+
+    def test_required_frontmatter_fields_are_present(self):
+        fields = _frontmatter(SKILL_PATH)
+        for key in ("name", "description", "version", "author", "license"):
+            assert fields.get(key), f"SKILL.md frontmatter is missing `{key}`"
+
+    def test_skill_name_matches_the_plugin_manifest(self):
+        skill_name = _frontmatter(SKILL_PATH)["name"]
+        plugin_name = _plugin_name(PLUGIN_PATH)
+        assert skill_name == plugin_name, (
+            f"SKILL.md name `{skill_name}` != plugin.yaml name `{plugin_name}`. "
+            "Agent Zero's index requires plugin.yaml's name to equal the folder "
+            "submitted to a0-plugins; keeping the skill in step avoids shipping "
+            "two different identities for one tool."
+        )
+
+    def test_plugin_name_is_a_legal_a0_folder_name(self):
+        plugin_name = _plugin_name(PLUGIN_PATH)
+        assert A0_NAME_RE.match(plugin_name), (
+            f"`{plugin_name}` is not a legal a0-plugins folder name "
+            "(lowercase letters, digits and underscores; no leading underscore)"
+        )
+
+
+class TestHostCoverage:
+    """The skill is shipped *for* these hosts; it should tell the agent about them."""
+
+    def test_skill_documents_every_target_host(self):
+        text = SKILL_PATH.read_text(encoding="utf-8")
+        for host in ("Hermes-Agent", "OpenClaw", "Agent Zero"):
+            assert host in text, f"SKILL.md never mentions {host}, but ships to that ecosystem"


### PR DESCRIPTION
## Description

`skills/neuralmind/SKILL.md` is the copy three external registries read — Hermes-Agent taps, OpenClaw's ClawHub, and the Agent Zero index. Before any of those submissions can be made, two things about it were wrong.

**1. The advertised version was three majors stale.** The frontmatter said `0.5.2`; the package ships `3.4.1`. Nothing bumped it and nothing checked it. Every one of those registries publishes that field verbatim, so anyone installing NeuralMind from a registry listing would have been told they were running 0.5.2.

Fixed at the source rather than by hand. The version line now carries the `x-release-please-version` annotation and the file is registered in release-please's `extra-files`, so it moves with every release exactly the way `pyproject.toml` and `neuralmind/__init__.py` already do. Hand-editing it stays the wrong answer.

**2. There was no host block.** The skill is published *for* Hermes-Agent, OpenClaw and Agent Zero and named none of them. An agent running under those hosts got the decision tree with no idea what to do when the `neuralmind_*` tools weren't there. `CHANGELOG.md` claims a dedicated Hermes-Agent block was added in `34a3f64`; it isn't in the file today, so it looks reorganized away rather than never written.

Adds a **Host notes** section covering how NeuralMind reaches the agent in each host, and what to do when it hasn't. It also states the shared-store consequence, which is the thing most likely to be misread as a bug: every host pointed at the same project reinforces the same `.neuralmind/synapses.db`, so `neuralmind_synaptic_neighbors` can legitimately surface code the current session never touched — not a stale index to rebuild away.

### Two review findings, both real, both fixed

**The Hermes install command wasn't traceable in-repo** (Copilot). The command itself checks out — Hermes documents `hermes skills install owner/repo/skills/<name>` and our skill sits at exactly that path — but it appeared nowhere in this repo, and my original description claimed all the commands were quoted from existing docs. That was true of the MCP commands and false of this one. `a872b1e` makes it traceable instead of arguing the point: `docs/wiki/Integration-Guide.md` had MCP sections for Claude Desktop, Cursor and custom clients while naming Hermes only in prose, and now has a Hermes-Agent section covering both routes in, with the upstream docs cited.

**The MCP launch spec doesn't do what six documents said it did** (Codex). My OpenClaw line registered the server as `{"command":"neuralmind-mcp","args":["/absolute/path/to/project"]}` and that path is silently discarded. Verified before changing anything: `main()` reads only `NEURALMIND_MCP_TRANSPORT` and never touches `sys.argv` (`mcp_server.py:1259`); the canonical spec is `{"command": command, "args": []}` with a docstring explaining that tools take `project_path` per call (`mcp_install.py:30-33`); every handler resolves that argument against the *server process's* cwd.

I'd copied the line from `docs/use-cases/multi-agent.md`, so this wasn't one bad line — six places across five files told users the launch spec scopes the server, and none of them did anything. `Integration-Guide.md` built its entire shared-brain explanation on it, so the one document explaining how several agents share a synapse store explained it via a mechanism that doesn't exist. `4a04817` fixes every live surface and says what actually makes it one brain: the same absolute `project_path` passed per call. `docs/UPGRADING.md` keeps its old value — it documents what the v0.4 and v0.5 configs looked like.

### Guards, because the version drift was silent

`tests/test_skill_manifest.py` — new, stdlib-only per repo convention, 7 tests:

| Asserts | Catches |
|---|---|
| Frontmatter version equals `.release-please-manifest.json` | The drift this PR is fixing |
| The version line still carries the annotation | Someone tidying away a "stray comment" — the generic updater then silently no-ops |
| `SKILL.md` is still in `extra-files` | The other half of the same wiring |
| `SKILL.md` `name` equals `plugin.yaml` `name` | Shipping two identities for one tool; a0-plugins CI enforces this on submission |
| `plugin.yaml` name matches the legal folder shape | An a0-plugins reject, caught here instead of in a third-party PR |
| All three hosts stay named in the file | The block being reorganized away again |

Each guard was verified to fail when its own defect is reintroduced, and only its own — five separate sabotage runs, each failing exactly one test, all passing on restore.

`skills/*/SKILL.md` also joins the `test_docs_claims.py` scan. It is written for models to read and shipped into other people's runtimes where no CI of ours can reach it — the same argument that put `docs/llms.txt` under that guard. Confirmed non-vacuous rather than assumed: a forbidden absolute injected into `SKILL.md` fails the build, so the glob is genuinely resolving.

No functional change to NeuralMind itself.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 📝 Documentation update
- [x] 🔧 Configuration change
- [x] 🧪 Test update

## How Has This Been Tested?

- [x] Unit tests
- [x] Manual testing

7 new tests in `tests/test_skill_manifest.py`, plus the widened `test_docs_claims.py` glob. All 23 tests across the three guard suites pass (`test_skill_manifest`, `test_docs_claims`, `test_site_claims`), and `scripts/check_commercial_terms.py` passes.

Manual verification beyond the suite:

- **The annotated line still parses as YAML.** `version: 3.4.1 # x-release-please-version` loads as the string `'3.4.1'` — the inline comment is stripped by the parser, so registries reading the frontmatter see the version and not the annotation.
- **Sabotage runs.** Each of the five guards was checked against a reintroduction of its own defect (version reverted to 0.5.2; annotation stripped; `extra-files` removed; name changed to `neural_mind`; host block deleted). Each failed alone; the suite went green again on restore.
- **The `args` claim was read out of the source**, not inferred — `main()`, `server_entry()`, and `handle_tool_call` all confirm the launch spec is ignored and `project_path` is per call.

### Test Configuration

* **Python version**: 3.11
* **Operating System**: Linux
* **Test command**: `pytest tests/test_skill_manifest.py tests/test_docs_claims.py tests/test_site_claims.py -q`

## Documentation &amp; discoverability

- [x] Docs answer *"what does the user/agent now see?"* (not just what the code does)
- [ ] `README.md` updated (banner/sections) if user-facing — no new command, hook or env var; nothing to bump
- [ ] `docs/index.html` + `docs/about.html` updated if user-facing — no release-facing surface changes
- [x] `docs/wiki/*.md` updated — new Hermes-Agent section in `Integration-Guide.md`; corrected MCP configs in `Setup-Guide.md` and `Usage-Guide.md`
- [x] Use-case walkthrough updated — `docs/use-cases/multi-agent.md` configs corrected
- [ ] SEO refreshed — no new noun entered the product surface
- [x] I did **not** edit `CHANGELOG.md` or hand-bump the `pyproject.toml` version (release-please owns these)

The `3.4.1` in this diff is not a hand-bump: it syncs a stale file to the version release-please already published, and the same commit hands ownership of that line to release-please so it never needs touching again.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Code Quality

- [x] I have run `black .` for formatting
- [x] I have run `ruff check .` for linting
- [x] Type hints are added for new functions/methods
- [x] Docstrings are added/updated for public APIs

## Additional Notes

**One reviewer recommendation I narrowed rather than took whole.** Codex also suggested the skill pass an absolute `project_path` on every tool call. `project_path="."` is correct under Claude Code and Cursor, where the server's cwd *is* the project, and those are most installs — making every example absolute trades a real bug for worse ergonomics in the common case. The skill now says when `"."` is wrong and what to do instead, scoped to detached hosts. Making it unconditional would change behavior under Claude Code too, which is beyond this PR; flagged on the thread for the author to decide.

**This unblocks registry submission but does not perform it.** Publishing means PRs against third-party repos and, for ClawHub, an interactive `clawhub login`. What each needs, verified against the registries' own docs:

- **Hermes-Agent** — nothing to submit. Taps are just a GitHub repo of `SKILL.md` files, so `hermes skills tap add dfrostar/neuralmind` works off this branch as-is. The optional community registry (`hermesonehq/hermes-registry`, independent of Nous Research) takes a fork → `mcp/neuralmind/manifest.json` → `python scripts/validate.py` → PR.
- **Agent Zero** — fork `agent0ai/a0-plugins`, add `plugins/neuralmind/index.yaml` (`title` ≤50, `description` ≤500, `github`; file ≤2000 chars; one plugin per PR). Their CI checks the linked repo has a root `plugin.yaml` whose `name` matches the folder — this repo passes, and the guard added here keeps it passing. The open question is review, not CI: their docs expect a standalone plugin repo, and this is a Python package repo carrying a manifest.
- **OpenClaw** — `clawhub skill publish`, as a skill rather than a package. Needs one more frontmatter mapping pass: ClawHub keys on `metadata.openclaw.requires` (`env`, `bins`) and `primaryEnv`, which this file expresses in its own `runtime.binaries` / `runtime.install` shape.

**Still an open gap.** OpenClaw has the same prose-but-no-section problem in `Integration-Guide.md` that Hermes had until `a872b1e`. Not addressed here.