### PR TITLE
docs: list Hermes-Agent, OpenClaw, Agent Zero in README host table

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,11 +76,14 @@ The agent asks a question. NeuralMind retrieves only the relevant slice (~800 to
 | **Cline** | Same MCP integration. | 🔬 Theoretical |
 | **Continue** | Same MCP integration. | 🔬 Theoretical |
 | **Codex** | Same MCP integration. | 🔬 Theoretical |
+| **Hermes-Agent** | Native MCP client discovers `neuralmind-mcp` at startup — no bridge process. Or skip MCP and install the portable skill straight from GitHub: `hermes skills install dfrostar/neuralmind/skills/neuralmind`. | 🔬 Theoretical |
+| **OpenClaw** | `openclaw mcp set neuralmind '{"command":"neuralmind-mcp","args":[]}'` wires it into the same shared memory. | 🔬 Theoretical |
+| **Agent Zero** | Same MCP integration, pointed at `neuralmind-mcp`. `plugin.yaml` (repo root) is the draft manifest for the `a0-plugins` registry listing. | 🔬 Theoretical |
 | **VS Code** | Direct extension + MCP. | ✅ Tested |
 | **Vim/Neovim** | Via Claude Code CLI. | ✅ Tested |
 | **JetBrains** | Via Claude Code or MCP agent. | ✅ Validated |
 
-Theoretical = MCP is standard protocol. All MCP-compatible agents should work. We haven't physically tested display-server-dependent IDEs (Cursor, Cline, Continue) — Xvfb is not available in our CI.
+Theoretical = MCP is standard protocol. All MCP-compatible agents should work. We haven't physically tested display-server-dependent IDEs (Cursor, Cline, Continue) — Xvfb is not available in our CI. Hermes-Agent, OpenClaw, and Agent Zero are covered by host-specific notes in [`skills/neuralmind/SKILL.md`](skills/neuralmind/SKILL.md) and a CI check ([`tests/test_skill_manifest.py`](tests/test_skill_manifest.py)) that keeps the portable skill's identity in sync with each registry's rules, but none has been physically driven end-to-end yet either.
 
 ---
 


### PR DESCRIPTION
## Description

Hermes-Agent, OpenClaw, and Agent Zero already have host-specific setup notes in `skills/neuralmind/SKILL.md` and `docs/wiki/Integration-Guide.md`, and Agent Zero has a draft `plugin.yaml` registry manifest — but none of the three appeared in the README's "Who This Is For" host-support table, so a reader skimming that table would not know these integrations exist. This adds a row for each, consistent with the existing MCP-only rows (Cursor/Cline/Continue/Codex), and extends the "Theoretical" footnote to point at the SKILL.md host notes and the CI check (`tests/test_skill_manifest.py`) that keeps the portable skill's registry identity in sync.

No behavior change — documentation only.

## Type of Change

- [x] 📝 Documentation update

## How Has This Been Tested?

- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing (visual review of the rendered table)

### Test Configuration

* **Python version**: n/a (docs-only change)
* **Operating System**: n/a
* **Test command**: n/a

## Documentation & discoverability

- [x] Docs answer *"what does the user/agent now see?"* (not just what the code does)
- [x] `README.md` updated (banner/sections) if user-facing
- [ ] `docs/index.html` + `docs/about.html` updated if user-facing — N/A, no new capability shipped, just surfacing existing host notes that were already documented elsewhere
- [ ] `docs/wiki/*.md` updated for new commands/env vars — N/A, no new command/env var; `Integration-Guide.md` already documents these hosts
- [ ] Use-case walkthrough updated/added — N/A, no new workflow unlocked (tracked separately in `ROADMAP.md`'s "More integration walkthroughs" item)
- [ ] SEO refreshed — N/A, no new noun entered the product surface
- [x] I did **not** edit `CHANGELOG.md` or hand-bump the `pyproject.toml` version (release-please owns these)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Additional Notes

Draft PR — part of a broader pass on getting NeuralMind listed in the Hermes-Agent, OpenClaw, and Agent Zero (`a0-plugins`) registries. This piece is the safe, self-contained documentation fix; the actual upstream registry submissions are being researched separately and will go through the user before anything is opened against third-party repos.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VFQfLWinJ1vzYP8cfNeMoK)_