### PR TITLE
feat(tier2): renewal alerting, calendar-correct licence terms, and the Billing Runbook

### DIFF
--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -253,8 +253,14 @@
     <priority>0.75</priority>
   </url>
   <url>
+    <loc>https://docs.neuralmind.uk/wiki/Billing-Runbook.html</loc>
+    <lastmod>2026-08-28</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+  <url>
     <loc>https://docs.neuralmind.uk/wiki/CLI-Reference.html</loc>
-    <lastmod>2026-08-18</lastmod>
+    <lastmod>2026-08-28</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>

--- a/docs/wiki/Billing-Runbook.md
+++ b/docs/wiki/Billing-Runbook.md
@@ -1,0 +1,234 @@
+# Billing Runbook — quote to cash, manually
+
+How a Team deal actually gets from an inbound email to a signed license
+file on the customer's machine.
+
+**There is no payment processor integrated, and that is deliberate.** Team
+is $29/user/mo across 5–50 seats on an annual contract — $1,740 to $17,400
+a year per deal, sold by email. That is a signed-contract motion, not a
+self-serve one, and a checkout page would be machinery serving nobody until
+inbound volume justifies it. The pluggable payment broker is on
+[ROADMAP.md](../../ROADMAP.md); the licence portal is deferred until 3+
+customers (see the honest-scope table in
+[Tier2-Operator-Guide](Tier2-Operator-Guide.md)).
+
+Until then this page *is* the billing system. Every step below is either a
+command in this repo or a click in a tool you already have.
+
+> Canonical terms — entity, price, contact — live in
+> [`commercial-terms.json`](../../commercial-terms.json) and are CI-gated.
+> If a number here ever disagrees with that file, the file wins and this
+> page is the bug.
+
+---
+
+## Prerequisites (once, before the first deal)
+
+| What | Where | Check |
+|------|-------|-------|
+| Issuer private key | `NEURALMIND_ISSUER_PRIVATE_KEY_HEX` in your shell, never in the repo | The snippet below prints `MATCH` |
+| Its public half | Already embedded in the shipped package (`neuralmind/tier2/license.py`, fingerprint `d23aeb5ae460fede`) | — |
+| An invoicing tool | Stripe Invoicing, Wave, or your accountant's system — dashboard only, no integration | You can send an invoice from the entity's name |
+| Sales-tax position | Confirmed with your accountant, not guessed | See [Tax](#tax-confirm-before-the-first-invoice) |
+
+Confirm your private key is the one the shipped package will verify
+against — a mismatch here means every licence you issue fails activation:
+
+```bash
+python -c "
+import os
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from neuralmind.tier2.license import _ISSUER_PUBLIC_KEY_HEX
+pub = Ed25519PrivateKey.from_private_bytes(
+    bytes.fromhex(os.environ['NEURALMIND_ISSUER_PRIVATE_KEY_HEX'])
+).public_key().public_bytes_raw().hex()
+print('MATCH' if pub == _ISSUER_PUBLIC_KEY_HEX else f'MISMATCH: {pub}')
+"
+```
+
+The private key is the single point of failure for every paid customer:
+lose it and nobody can be renewed, leak it and anyone can mint licences
+against a public key that is already inside every installed copy. Keep it
+offline, keep a backup, and treat rotation as a planned exercise —
+`LicenseValidator` accepts a *list* of public keys precisely so a rotation
+can overlap.
+
+---
+
+## The path
+
+### 1. Qualify
+
+Team buys **seats beyond one (5–50), priority support, and an annual
+invoice**. It does not unlock features — governance, audit and self-hosted
+all run on the free 1-seat licence. So the honest opener is: *evaluate
+everything first, on the free tier, then buy seats when you have more than
+one person.*
+
+Under 5 seats, there is nothing to sell. Say so.
+
+### 2. Quote
+
+Prices come from the pricing table, not from memory:
+
+```bash
+python -c "
+from neuralmind.tier2.pricing import load_pricing, calculate_price
+p = load_pricing()
+print(calculate_price(p, 'team', seats=12, term_months=12))
+"
+```
+
+`calculate_price` returns the total for **all seats over the whole term**.
+Twelve seats on an annual term is `29 × 12 × 12 = $4,176`. There are no
+volume discounts in the table and none should be invented in an email — if
+a discount is genuinely warranted, change the table and say why.
+
+### 3. Agreement
+
+Send [`LICENSE-COMMERCIAL.md`](../../LICENSE-COMMERCIAL.md) as the
+template. It has to be executed before a licence is issued — the licence
+file records an `agreement_version` and an `accepted_at` timestamp on the
+assumption that it was.
+
+### 4. Invoice
+
+Raise the invoice in your invoicing tool, from **Cheval-Volant LLC (d/b/a
+NeuralMind)**, Texas. Net terms are yours to set; annual-in-advance is what
+the tier is built around.
+
+Nothing in this repo generates, sends, or reconciles an invoice. Do not
+issue the licence yet.
+
+### 5. Issue — only after payment clears
+
+```bash
+export NEURALMIND_ISSUER_PRIVATE_KEY_HEX=...   # from your password manager
+
+neuralmind license issue \
+  --customer "Acme Corp" \
+  --seats 12 \
+  --term 12 \
+  --output ./acme-corp.json
+```
+
+Terms accepted: 1, 3, 6, 12, 24, 36 months. Expiry lands on the calendar —
+a 12-month term issued on 28 August expires on 28 August the following
+year.
+
+This writes the signed licence, appends an `issue` record to the audit log,
+and records the customer in `~/.neuralmind/customers.yaml` with
+`total_paid`. That YAML file is your entire customer database right now;
+it lives on one machine and nothing backs it up. Copy it somewhere durable.
+
+### 6. Deliver
+
+Send the customer the JSON file and the two commands that consume it:
+
+```bash
+neuralmind team license activate ./acme-corp.json
+neuralmind team license status          # confirms tier, seats, expiry
+```
+
+Then seats, which they administer themselves:
+
+```bash
+neuralmind team seats add someone@acme.com
+neuralmind team seats list
+```
+
+If activation reports anything other than the expected tier and seat count,
+the file was altered in transit — reissue rather than debug it.
+
+### 7. File
+
+Keep, alongside the invoice: the executed agreement, the `license_id` from
+step 5, and the seat count. `~/.neuralmind/audit_log.jsonl` is the
+append-only record of every issue, renew and revoke, and it is the thing
+you would hand an auditor.
+
+---
+
+## Renewals
+
+**Nothing warns you that a licence is expiring.** No cron, no email, no
+dashboard. Until that exists, this is a calendar reminder plus one command:
+
+```bash
+neuralmind license list                          # all customers, status, expiry
+neuralmind license status --customer "Acme Corp" # includes days_remaining
+```
+
+Run it monthly. Anything inside 60 days gets a renewal conversation; invoice
+and collect exactly as above, then:
+
+```bash
+neuralmind license renew --customer "Acme Corp" --term 12
+```
+
+Renewal extends from the **old expiry**, not from today, so a customer who
+pays late does not silently gain free months — and one who pays early does
+not lose any.
+
+A revoked licence cannot be renewed. Issue a new one.
+
+---
+
+## Non-payment
+
+```bash
+neuralmind license revoke --customer "Acme Corp" --reason "non-payment, 60d past due"
+```
+
+This sets expiry to now and writes the reason to the audit log. It is not
+reversible by renewal, so use it when the relationship is actually over, not
+as a dunning nudge — for a late invoice, chase the invoice.
+
+---
+
+## Tax — confirm before the first invoice
+
+A Texas LLC invoicing software subscriptions, potentially to customers in
+the EU and UK, has a sales-tax and VAT position to establish. This is an
+accountant question, not a code question, and it is much cheaper to answer
+before the first invoice than to unwind afterwards. Nothing in this repo
+computes or collects tax.
+
+---
+
+## What not to promise
+
+From the `do_not_market` list in
+[`commercial-terms.json`](../../commercial-terms.json):
+
+- **No trials.** There is no trial issuance mechanism. The free 1-seat
+  tier is the evaluation path, and it never expires — that is the answer to
+  "can we try it first?"
+- **SSO / SAML** and **real-time cross-machine sync** are roadmap only.
+  Label them as roadmap or leave them out.
+- **No self-serve checkout.** The CTA is contact-based, and the pricing
+  page says so.
+
+---
+
+## Known gaps
+
+| Gap | Consequence today |
+|-----|-------------------|
+| No payment processor | Invoicing and reconciliation happen entirely outside this repo |
+| No renewal alerting | A licence can lapse unnoticed; the monthly check above is the mitigation |
+| Customer record is one YAML file on one machine | No backup, no history, no second operator |
+| No receipts or dunning | Both are the invoicing tool's job |
+| No self-serve seat purchase | Seat count changes mid-term mean a reissue and a conversation |
+
+The first of these to hurt should be the first one built — most likely
+renewal alerting, since it is the one that loses revenue silently.
+
+---
+
+## See also
+
+- [Tier2-Operator-Guide](Tier2-Operator-Guide.md) — the customer-facing Team commands
+- [Upgrade-Guide](Upgrade-Guide.md) — the free → Team flow from the user's side
+- [`commercial-terms.json`](../../commercial-terms.json) — canonical pricing and entity
+- [`LICENSING.md`](../../LICENSING.md) — the MIT / commercial boundary

--- a/docs/wiki/Billing-Runbook.md
+++ b/docs/wiki/Billing-Runbook.md
@@ -186,9 +186,20 @@ cron (silence unless there is news). `--json` emits the full report —
 with `days_remaining` per customer — for anything that wants to route by
 severity or render its own message.
 
+Cron already mails whatever a job writes to stdout, so `--quiet` is the
+whole recipe — no output on a clean week, a report when there is one:
+
 ```bash
-# crontab: mail only when something needs attention
-0 9 * * 1  neuralmind license expiring --quiet || mail -s "NeuralMind renewals" you@example.com
+MAILTO=you@example.com
+0 9 * * 1  neuralmind license expiring --quiet
+```
+
+If you would rather call `mail` yourself, capture the report first. Piping
+straight off `||` sends an empty message, because the report went to stdout
+and `mail` inherits cron's empty stdin:
+
+```bash
+0 9 * * 1  report=$(neuralmind license expiring --quiet) || printf '%s\n' "$report" | mail -s "NeuralMind renewals" you@example.com
 ```
 
 Exit 7 also covers a record whose `expires_at` cannot be parsed. That is

--- a/docs/wiki/Billing-Runbook.md
+++ b/docs/wiki/Billing-Runbook.md
@@ -108,22 +108,28 @@ export NEURALMIND_ISSUER_PRIVATE_KEY_HEX=...   # from your password manager
 neuralmind license issue \
   --customer "Acme Corp" \
   --seats 12 \
-  --term 12 \
-  --output ./acme-corp.json
+  --term 12
 ```
+
+The licence is written to `~/.neuralmind/<sanitized-customer-name>.json` —
+for the above, `~/.neuralmind/acmecorp.json`. **Licences are only ever
+written inside `~/.neuralmind`.** `--output` can rename or relocate the file
+*within* that directory; a path outside it is refused, because the same
+guard stops a hostile customer name from escaping storage. Copy the file out
+afterwards if you want it elsewhere.
 
 Terms accepted: 1, 3, 6, 12, 24, 36 months. Expiry lands on the calendar —
 a 12-month term issued on 28 August expires on 28 August the following
 year.
 
-This writes the signed licence, appends an `issue` record to the audit log,
-and records the customer in `~/.neuralmind/customers.yaml` with
-`total_paid`. That YAML file is your entire customer database right now;
-it lives on one machine and nothing backs it up. Copy it somewhere durable.
+This also appends an `issue` record to the audit log and records the
+customer in `~/.neuralmind/customers.yaml` with `total_paid`. That YAML file
+is your entire customer database right now; it lives on one machine and
+nothing backs it up. Copy it somewhere durable.
 
 ### 6. Deliver
 
-Send the customer the JSON file and the two commands that consume it:
+Send the customer that JSON file and the two commands that consume it:
 
 ```bash
 neuralmind team license activate ./acme-corp.json

--- a/docs/wiki/Billing-Runbook.md
+++ b/docs/wiki/Billing-Runbook.md
@@ -151,16 +151,48 @@ you would hand an auditor.
 
 ## Renewals
 
-**Nothing warns you that a licence is expiring.** No cron, no email, no
-dashboard. Until that exists, this is a calendar reminder plus one command:
+A lapsed licence is revenue lost quietly, so this is the one part of the
+path that does not rely on you remembering:
 
 ```bash
-neuralmind license list                          # all customers, status, expiry
-neuralmind license status --customer "Acme Corp" # includes days_remaining
+neuralmind license expiring              # anything due inside 60 days
+neuralmind license expiring --within 90  # widen the window
 ```
 
-Run it monthly. Anything inside 60 days gets a renewal conversation; invoice
-and collect exactly as above, then:
+It is read-only and needs **no issuer key**, so a scheduler can run it
+without holding anything sensitive.
+
+### Wiring it to a scheduler
+
+The command is built to be consumed rather than read: the exit code alone
+says whether anyone needs to act, so a caller never has to parse output to
+decide whether to raise an alert.
+
+| Exit | Meaning | What a scheduler should do |
+|-----:|---------|----------------------------|
+| 0 | Nothing due inside the window | Nothing |
+| 6 | Renewals due | Notify — a conversation needs starting |
+| 7 | Something already expired, or an expiry that cannot be read | Escalate — revenue or data is already broken |
+
+`--quiet` prints nothing on exit 0, which is what makes it well behaved in
+cron (silence unless there is news). `--json` emits the full report —
+`expired`, `expiring` and `unknown` buckets, each sorted most-urgent first,
+with `days_remaining` per customer — for anything that wants to route by
+severity or render its own message.
+
+```bash
+# crontab: mail only when something needs attention
+0 9 * * 1  neuralmind license expiring --quiet || mail -s "NeuralMind renewals" you@example.com
+```
+
+Exit 7 also covers a record whose `expires_at` cannot be parsed. That is
+deliberate: an expiry you cannot read is not a licence you can trust to
+alert on, so it escalates rather than passing silently.
+
+### Doing the renewal
+
+Anything the report names gets a renewal conversation; invoice and collect
+exactly as above, then:
 
 ```bash
 neuralmind license renew --customer "Acme Corp" --term 12
@@ -216,13 +248,15 @@ From the `do_not_market` list in
 | Gap | Consequence today |
 |-----|-------------------|
 | No payment processor | Invoicing and reconciliation happen entirely outside this repo |
-| No renewal alerting | A licence can lapse unnoticed; the monthly check above is the mitigation |
+| No alert *delivery* | `license expiring` reports and signals via exit code, but nothing here sends the mail — a scheduler or autopilot owns delivery |
 | Customer record is one YAML file on one machine | No backup, no history, no second operator |
 | No receipts or dunning | Both are the invoicing tool's job |
 | No self-serve seat purchase | Seat count changes mid-term mean a reissue and a conversation |
 
-The first of these to hurt should be the first one built — most likely
-renewal alerting, since it is the one that loses revenue silently.
+Renewal alerting used to head this list, because it was the one that lost
+revenue silently; `license expiring` closes it. Of what remains, the
+single-file customer record is the most exposed — one machine, no backup,
+no second operator.
 
 ---
 

--- a/docs/wiki/CLI-Reference.md
+++ b/docs/wiki/CLI-Reference.md
@@ -41,6 +41,7 @@ Complete command-line interface documentation for NeuralMind.
   - [review](#review-v0390)
   - [onboarding](#onboarding-v170)
   - [optimize-docs](#optimize-docs-v172)
+  - [license — issuer-side](#license--issuer-side)
 - [Exit Codes](#exit-codes)
 - [Environment Variables](#environment-variables)
 - [Examples](#examples)
@@ -2775,6 +2776,53 @@ Run without --dry-run to evolve JSDoc for these methods.
 
 - [`neuralmind/doc_evolver.py`](../../neuralmind/doc_evolver.py) — main module (1181 lines)
 - [`tests/test_doc_evolver.py`](../../tests/test_doc_evolver.py) — 44 tests
+
+---
+
+### license — issuer-side
+
+Mints and manages **Team licences**. These are operator commands, not
+customer commands — every subcommand that changes a licence requires the
+Ed25519 issuer private key in `NEURALMIND_ISSUER_PRIVATE_KEY_HEX` and
+exits 1 without it. Customers use `neuralmind team license …` instead
+(see [Tier2-Operator-Guide](Tier2-Operator-Guide.md)).
+
+The end-to-end selling process these fit into — quoting, invoicing,
+delivery, renewals — is the [Billing Runbook](Billing-Runbook.md).
+
+```bash
+neuralmind license issue --customer "Acme Corp" --seats 12 --term 12 [--partner ID] [--output PATH]
+neuralmind license renew --customer "Acme Corp" --term 12
+neuralmind license revoke --customer "Acme Corp" --reason "non-payment"
+neuralmind license status --customer "Acme Corp"
+neuralmind license list [--partner ID]
+```
+
+| Flag | Applies to | Meaning |
+|------|-----------|---------|
+| `--customer` | issue, renew, revoke, status | Customer name; also the licence filename, sanitized |
+| `--seats` | issue | Seat count (must be positive) |
+| `--term` | issue, renew | Term in months: 1, 3, 6, 12, 24, or 36 |
+| `--partner` | issue, list | Reseller partner ID |
+| `--output` | issue | Where to write the signed licence JSON |
+| `--reason` | revoke | Recorded in the audit log |
+
+**Term arithmetic.** Terms advance by calendar months, so a 12-month
+licence issued on 28 August expires on 28 August the following year. A
+day-of-month with no counterpart in the target month clamps to the last
+valid day (31 Jan + 1 month is 28 or 29 Feb). `renew` extends from the
+existing expiry rather than from today, so paying late does not grant free
+months and paying early does not forfeit any. A revoked licence cannot be
+renewed — issue a new one.
+
+**State written.** All under `~/.neuralmind/`:
+
+| File | Contents |
+|------|----------|
+| `<customer>.json` | The signed licence (unless `--output` redirects it) |
+| `customers.yaml` | Customer record: seats, expiry, status, `total_paid` |
+| `partners.yaml` | Reseller registry and accrued commission |
+| `audit_log.jsonl` | Append-only record of every issue, renew and revoke |
 
 ---
 

--- a/docs/wiki/CLI-Reference.md
+++ b/docs/wiki/CLI-Reference.md
@@ -2796,7 +2796,27 @@ neuralmind license renew --customer "Acme Corp" --term 12
 neuralmind license revoke --customer "Acme Corp" --reason "non-payment"
 neuralmind license status --customer "Acme Corp"
 neuralmind license list [--partner ID]
+neuralmind license expiring [--within DAYS] [--json] [--quiet]
 ```
+
+**`expiring`** is the exception to the key requirement above: it is
+read-only, needs no issuer key, and exists so a scheduler can watch for
+lapsing licences without holding anything sensitive. Nothing else in the
+system tracks expiry dates. It signals through its exit code so a caller
+never has to parse output to decide whether to alert:
+
+| Exit | Meaning |
+|-----:|---------|
+| 0 | Nothing due inside the window |
+| 6 | Renewals due inside the window |
+| 7 | Already expired, or an expiry that cannot be parsed (takes precedence over 6) |
+
+`--within` sets the look-ahead in days (default 60). `--quiet` suppresses
+output on exit 0, so a cron entry stays silent unless there is news.
+`--json` emits the full report — `expired`, `expiring` and `unknown`
+buckets, each sorted most-urgent first, with `days_remaining` per customer.
+Revoked licences are excluded: they cannot be renewed. See the
+[Billing Runbook](Billing-Runbook.md) for the scheduling recipe.
 
 | Flag | Applies to | Meaning |
 |------|-----------|---------|
@@ -2804,6 +2824,8 @@ neuralmind license list [--partner ID]
 | `--seats` | issue | Seat count (must be positive) |
 | `--term` | issue, renew | Term in months: 1, 3, 6, 12, 24, or 36 |
 | `--partner` | issue, list | Reseller partner ID |
+| `--within` | expiring | Days ahead to look (default: 60) |
+| `--json` / `--quiet` | expiring | Machine-readable output / silence when nothing is due |
 | `--output` | issue | Where to write the signed licence JSON |
 | `--reason` | revoke | Recorded in the audit log |
 
@@ -2836,6 +2858,8 @@ renewed — issue a new one.
 | 3 | graph.json not found |
 | 4 | Index not built (run `build` first) |
 | 5 | Database error |
+| 6 | `license expiring`: renewals due inside the window |
+| 7 | `license expiring`: a licence has already expired, or its expiry cannot be parsed |
 
 ---
 

--- a/docs/wiki/CLI-Reference.md
+++ b/docs/wiki/CLI-Reference.md
@@ -2826,7 +2826,7 @@ Revoked licences are excluded: they cannot be renewed. See the
 | `--partner` | issue, list | Reseller partner ID |
 | `--within` | expiring | Days ahead to look (default: 60) |
 | `--json` / `--quiet` | expiring | Machine-readable output / silence when nothing is due |
-| `--output` | issue | Where to write the signed licence JSON |
+| `--output` | issue | Filename for the signed licence, **within `~/.neuralmind`** — a path outside it is refused by the same guard that contains hostile customer names. Defaults to `<sanitized-customer-name>.json` |
 | `--reason` | revoke | Recorded in the audit log |
 
 **Term arithmetic.** Terms advance by calendar months, so a 12-month
@@ -2841,7 +2841,7 @@ renewed — issue a new one.
 
 | File | Contents |
 |------|----------|
-| `<customer>.json` | The signed licence (unless `--output` redirects it) |
+| `<customer>.json` | The signed licence (`--output` renames it, still inside this directory) |
 | `customers.yaml` | Customer record: seats, expiry, status, `total_paid` |
 | `partners.yaml` | Reseller registry and accrued commission |
 | `audit_log.jsonl` | Append-only record of every issue, renew and revoke |

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -275,6 +275,7 @@ sections.
 || **[Tier2-Operator-Guide](Tier2-Operator-Guide.md)** | Team tier commands, honest scope, troubleshooting |
 || **[Multi-Project-Scoping](Multi-Project-Scoping.md)** | Working across multiple codebases — isolation rules for NeuralMind, memU, and agent memory |
 || **[Upgrade-Guide](Upgrade-Guide.md)** | Free → Team flow, downgrade, troubleshooting |
+|| **[Billing-Runbook](Billing-Runbook.md)** | Operator: quote → invoice → issue → renew, the manual Team sales path |
 | **[Compatibility Matrix](../COMPATIBILITY.md)** | Version compatibility, Python support, known issues, upgrade paths |
 | **[Benchmarks & Results](Benchmarks)** | Every measured, CI-gated number — token reduction, faithfulness delta, synapse and onboarding lift, ChromaDB-free parity — with reproduction commands |
 

--- a/docs/wiki/Tier2-Operator-Guide.md
+++ b/docs/wiki/Tier2-Operator-Guide.md
@@ -60,6 +60,10 @@ neuralmind team license status       # current tier, seats, expiry, issued-to
 neuralmind team license activate <file>   # activate with Ed25519-signed license
 ```
 
+The signed licence file comes from the vendor. If you are the vendor, the
+issuing side — quoting, invoicing, `neuralmind license issue`, renewals —
+is the [Billing Runbook](Billing-Runbook.md).
+
 ### Seats
 
 ```bash
@@ -104,7 +108,7 @@ neuralmind team self-hosted validate-license
 | SSO/SAML/OIDC | Not shipped | PRD-scoped for future wave |
 | Real-time cross-machine sync | Not shipped | Paid tier future |
 | Customer self-serve dashboard | Not shipped | Decide later |
-| License portal | Deferred | D12: defer until 3+ customers |
+| License portal | Deferred | D12: defer until 3+ customers — the manual path is the [Billing Runbook](Billing-Runbook.md) |
 
 **Do not market Tier 2 as SSO-enabled or multi-machine-synced.** Architecture is ready; features are not shipped.
 

--- a/neuralmind/cli.py
+++ b/neuralmind/cli.py
@@ -4078,6 +4078,88 @@ def cmd_license_list(args):
         )
 
 
+def cmd_license_expiring(args):
+    """`neuralmind license expiring` — licences due for renewal.
+
+    Nothing else warns that a Team licence is lapsing, so this is the
+    command a scheduler (cron, a systemd timer, autopilot) runs on a
+    recurring basis. It is built to be consumed rather than read: the exit
+    code alone says whether anyone needs to act, so a caller need not parse
+    output to decide whether to raise an alert.
+
+    Exit codes:
+        0: nothing needs attention inside the window.
+        6: renewals are due (expiring inside the window).
+        7: at least one licence has already expired, or has an expiry that
+           cannot be read. Takes precedence over 6.
+
+    Read-only — it needs no issuer private key.
+    """
+    from neuralmind.tier2.operations import LicenseOperations
+
+    storage_path = Path.home() / ".neuralmind"
+    ops = LicenseOperations("", storage_path)
+    try:
+        report = ops.list_expiring_licenses(within_days=args.within)
+    except ValueError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(2)
+
+    if args.json:
+        print(json.dumps(report, indent=2))
+    elif not args.quiet or report["needs_attention"]:
+        print(_format_expiring(report))
+
+    if report["expired"] or report["unknown"]:
+        sys.exit(7)
+    if report["expiring"]:
+        sys.exit(6)
+
+
+def _format_expiring(report: dict) -> str:
+    """Render an expiry report for a human reading a terminal or an email."""
+    within = report["within_days"]
+    if not report["needs_attention"]:
+        active = report["total_active"]
+        return (
+            f"NeuralMind licence renewals — nothing due within {within} days "
+            f"({active} active licence{'s' * (active != 1)} checked)."
+        )
+
+    def row(entry: dict, when: str) -> str:
+        seats = entry.get("seats")
+        seats_txt = f"{seats} seats" if seats is not None else "seats unknown"
+        return f"  {entry['customer']:<28} {seats_txt:<14} {when}"
+
+    n = report["needs_attention"]
+    lines = [
+        f"NeuralMind licence renewals — {n} need{'s' * (n == 1)} attention "
+        f"(window: {within} days, {report['total_active']} active).",
+    ]
+    if report["expired"]:
+        lines.append("")
+        lines.append("EXPIRED")
+        for e in report["expired"]:
+            days = abs(e["days_remaining"])
+            when = "expired today" if days == 0 else f"expired {days} day{'s' * (days != 1)} ago"
+            lines.append(row(e, f"{when} ({e['expires_at'][:10]})"))
+    if report["expiring"]:
+        lines.append("")
+        lines.append("EXPIRING")
+        for e in report["expiring"]:
+            days = e["days_remaining"]
+            when = "expires today" if days == 0 else f"{days} day{'s' * (days != 1)} remaining"
+            lines.append(row(e, f"{when} ({e['expires_at'][:10]})"))
+    if report["unknown"]:
+        lines.append("")
+        lines.append("UNREADABLE EXPIRY — check customers.yaml")
+        for e in report["unknown"]:
+            lines.append(row(e, f"expires_at={e['expires_at']!r}"))
+    lines.append("")
+    lines.append('Renew with: neuralmind license renew --customer "<name>" --term 12')
+    return "\n".join(lines)
+
+
 def cmd_partner_add(args):
     """Add a new partner."""
     from neuralmind.tier2.operations import PartnerOperations
@@ -5916,6 +5998,25 @@ def main():
     list_lp = license_sub.add_parser("list", help="List all licenses")
     list_lp.add_argument("--partner", default=None, help="Filter by partner ID")
     list_lp.set_defaults(func=cmd_license_list)
+
+    expiring_lp = license_sub.add_parser(
+        "expiring",
+        help="List licenses due for renewal (exit 6 = renewals due, 7 = expired)",
+    )
+    expiring_lp.add_argument(
+        "--within",
+        type=int,
+        default=60,
+        help="Days ahead to look (default: 60)",
+    )
+    expiring_lp.add_argument("--json", "-j", action="store_true", help="Machine-readable output")
+    expiring_lp.add_argument(
+        "--quiet",
+        "-q",
+        action="store_true",
+        help="Print nothing when nothing needs attention (for cron)",
+    )
+    expiring_lp.set_defaults(func=cmd_license_expiring)
 
     # partner command — add, list, licenses
     partner_p = subparsers.add_parser(

--- a/neuralmind/cli.py
+++ b/neuralmind/cli.py
@@ -6002,7 +6002,10 @@ def main():
 
     expiring_lp = license_sub.add_parser(
         "expiring",
-        help="List licenses due for renewal (exit 6 = renewals due, 7 = expired)",
+        help=(
+            "List licenses due for renewal "
+            "(exit 6 = renewals due, 7 = expired or unreadable expiry)"
+        ),
     )
     expiring_lp.add_argument(
         "--within",

--- a/neuralmind/cli.py
+++ b/neuralmind/cli.py
@@ -4132,10 +4132,11 @@ def _format_expiring(report: dict) -> str:
         return f"  {entry['customer']:<28} {seats_txt:<14} {when}"
 
     n = report["needs_attention"]
-    lines = [
+    header = (
         f"NeuralMind licence renewals — {n} need{'s' * (n == 1)} attention "
-        f"(window: {within} days, {report['total_active']} active).",
-    ]
+        f"(window: {within} days, {report['total_active']} active)."
+    )
+    lines = [header]
     if report["expired"]:
         lines.append("")
         lines.append("EXPIRED")

--- a/neuralmind/tier2/cli.py
+++ b/neuralmind/tier2/cli.py
@@ -496,7 +496,9 @@ def cmd_team_license(args) -> int:
         src_status = load_license(src_path, _ISSUER_PUBLIC_KEY_HEX)
         if src_status != "VALID":
             print(
-                f"License validation failed: {src_status}. Run `autopilot license status --license-id <id>` to check."
+                f"License validation failed: {src_status}. "
+                "Run `neuralmind team license status` to inspect the installed licence, "
+                "and contact hello@neuralmind.uk if it does not resolve."
             )
             return 1
         # Signature validated — install

--- a/neuralmind/tier2/cli.py
+++ b/neuralmind/tier2/cli.py
@@ -496,9 +496,9 @@ def cmd_team_license(args) -> int:
         src_status = load_license(src_path, _ISSUER_PUBLIC_KEY_HEX)
         if src_status != "VALID":
             print(
-                f"License validation failed: {src_status}. "
-                "Run `neuralmind team license status` to inspect the installed licence, "
-                "and contact hello@neuralmind.uk if it does not resolve."
+                f"License validation failed for {src_path}: {src_status}. "
+                "Nothing was installed. Check this is the unaltered file you were "
+                "sent, then contact hello@neuralmind.uk quoting that status."
             )
             return 1
         # Signature validated — install

--- a/neuralmind/tier2/operations.py
+++ b/neuralmind/tier2/operations.py
@@ -396,6 +396,93 @@ class LicenseOperations:
             "partner_id": cust.get("partner_id"),
         }
 
+    def list_expiring_licenses(
+        self,
+        within_days: int = 60,
+        now: datetime | None = None,
+    ) -> dict:
+        """Find licences that need a renewal conversation.
+
+        Nothing else in the system watches expiry dates, so this is the
+        query an operator (or a scheduler calling the CLI) runs to find
+        out what is about to lapse. Revoked licences are excluded: they
+        cannot be renewed, so they are not renewal opportunities.
+
+        A record whose ``expires_at`` cannot be parsed is reported under
+        ``unknown`` rather than skipped — an unreadable expiry is a data
+        problem the operator has to see, not one to swallow.
+
+        Args:
+            within_days: How far ahead to look. Must not be negative.
+            now: Evaluation instant; defaults to the current UTC time.
+                Injectable so tests need not manipulate the clock.
+
+        Returns:
+            A dict with ``checked_at``, ``within_days``, ``total_active``,
+            ``needs_attention``, and the ``expired`` / ``expiring`` /
+            ``unknown`` buckets, each sorted most-urgent first.
+        """
+        if within_days < 0:
+            raise ValueError("within_days must not be negative")
+        now = now or datetime.now(timezone.utc)
+
+        expired: list[dict] = []
+        expiring: list[dict] = []
+        unknown: list[dict] = []
+        total_active = 0
+
+        for name, cust in self._load_customers().get("customers", {}).items():
+            if cust.get("status") == "revoked":
+                continue
+            total_active += 1
+
+            expires_at = cust.get("expires_at")
+            entry = {
+                "customer": name,
+                "license_id": cust.get("license_id"),
+                "seats": cust.get("seats"),
+                "expires_at": expires_at,
+                "status": cust.get("status"),
+                "partner_id": cust.get("partner_id"),
+            }
+
+            if expires_at == "never":
+                continue
+            try:
+                exp = datetime.fromisoformat(str(expires_at))
+            except (ValueError, TypeError):
+                unknown.append(entry)
+                continue
+            if exp.tzinfo is None:
+                exp = exp.replace(tzinfo=timezone.utc)
+
+            # int() truncates toward zero, so both directions read naturally:
+            # 17.9 days left is "17 days remaining", and 4.1 days past due is
+            # "expired 4 days ago". timedelta.days would floor the latter to 5.
+            seconds_left = (exp - now).total_seconds()
+            days = int(seconds_left / 86400)
+            entry["days_remaining"] = days
+            # Bucket on the instant rather than the day count, so a licence
+            # that lapsed three hours ago is expired, not a 0-day renewal.
+            if seconds_left < 0:
+                expired.append(entry)
+            elif days <= within_days:
+                expiring.append(entry)
+
+        expired.sort(key=lambda e: e["days_remaining"])
+        expiring.sort(key=lambda e: e["days_remaining"])
+        unknown.sort(key=lambda e: e["customer"])
+
+        return {
+            "checked_at": now.isoformat(),
+            "within_days": within_days,
+            "total_active": total_active,
+            "needs_attention": len(expired) + len(expiring) + len(unknown),
+            "expired": expired,
+            "expiring": expiring,
+            "unknown": unknown,
+        }
+
     def list_customer_licenses(
         self,
         partner_id: str | None = None,

--- a/neuralmind/tier2/operations.py
+++ b/neuralmind/tier2/operations.py
@@ -5,10 +5,11 @@
 
 from __future__ import annotations
 
+import calendar
 import json
 import tempfile
 import uuid
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from pathlib import Path
 
 from . import license
@@ -17,6 +18,28 @@ from .pricing import calculate_price, load_pricing
 
 def _now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
+
+
+def _add_months(start: datetime, months: int) -> datetime:
+    """Add calendar months to ``start``, clamping to the last valid day.
+
+    Terms are sold in months, so they have to land on the calendar. Adding
+    30-day months shortchanged an annual customer by five days and drifted
+    further on longer terms. Day-of-month is clamped, so 31 Jan + 1 month is
+    28/29 Feb rather than rolling into March.
+
+    Args:
+        start: The instant the term runs from.
+        months: Number of calendar months to add.
+
+    Returns:
+        ``start`` advanced by ``months``, at the same time of day.
+    """
+    total = start.month - 1 + months
+    year = start.year + total // 12
+    month = total % 12 + 1
+    day = min(start.day, calendar.monthrange(year, month)[1])
+    return start.replace(year=year, month=month, day=day)
 
 
 class LicenseOperations:
@@ -156,7 +179,7 @@ class LicenseOperations:
         license_id = self._generate_license_id()
         customer_id = self._generate_customer_id()
         now = datetime.now(timezone.utc)
-        expires_at = now + timedelta(days=30 * term_months)
+        expires_at = _add_months(now, term_months)
 
         # Build license data
         license_data = {
@@ -243,7 +266,7 @@ class LicenseOperations:
         cust = customers["customers"][customer_name]
 
         old_expires = datetime.fromisoformat(cust["expires_at"])
-        new_expires = old_expires + timedelta(days=30 * term_months)
+        new_expires = _add_months(old_expires, term_months)
 
         # H4 fix: Do not revive revoked licenses
         if cust.get("status") == "revoked":

--- a/neuralmind/tier2/operations.py
+++ b/neuralmind/tier2/operations.py
@@ -203,10 +203,16 @@ class LicenseOperations:
         if output_path is None:
             safe_name = "".join(c for c in customer_name.lower() if c.isalnum() or c in "-_")
             output_path = self.storage / f"{safe_name}.json"
-        output_path.parent.mkdir(parents=True, exist_ok=True)
-        # Verify the resolved path is still inside storage
+        # Validate before creating anything: a rejected path used to leave its
+        # parent directory behind. The guard covers both inputs that can point
+        # outside storage — the customer name and an explicit output_path — so
+        # the message names both rather than blaming the name.
         if not str(output_path.resolve()).startswith(str(self.storage.resolve())):
-            raise ValueError("Invalid customer name: path traversal detected")
+            raise ValueError(
+                f"Refusing to write outside {self.storage}: {output_path} resolves "
+                "beyond the storage directory (check the output path, or the customer name)"
+            )
+        output_path.parent.mkdir(parents=True, exist_ok=True)
         fd, tmp = tempfile.mkstemp(dir=output_path.parent, suffix=".tmp")
         try:
             with open(fd, "w") as f:
@@ -460,13 +466,14 @@ class LicenseOperations:
             # 17.9 days left is "17 days remaining", and 4.1 days past due is
             # "expired 4 days ago". timedelta.days would floor the latter to 5.
             seconds_left = (exp - now).total_seconds()
-            days = int(seconds_left / 86400)
-            entry["days_remaining"] = days
-            # Bucket on the instant rather than the day count, so a licence
-            # that lapsed three hours ago is expired, not a 0-day renewal.
+            entry["days_remaining"] = int(seconds_left / 86400)
+            # Bucket on the instant, never the truncated day count: comparing
+            # days would stretch the window by up to a day (`--within 60`
+            # catching an expiry 60 days 23 hours out) and flip the exit code
+            # to 6 early. The truncated value is for display only.
             if seconds_left < 0:
                 expired.append(entry)
-            elif days <= within_days:
+            elif seconds_left <= within_days * 86400:
                 expiring.append(entry)
 
         expired.sort(key=lambda e: e["days_remaining"])

--- a/neuralmind/tier2/pricing.py
+++ b/neuralmind/tier2/pricing.py
@@ -38,25 +38,36 @@ def load_pricing(config_path: Path | None = None) -> dict:
     return DEFAULT_PRICING
 
 
+# Named entries in the pricing table, by term length in months. Terms the
+# CLI accepts but this table does not name (6 and 36) bill at the flat
+# monthly rate for every month of the term — they used to fall through to a
+# single month's rate, quoting a 36-month deal at 1/36th of its value.
+_TERM_KEYS = {1: "monthly", 3: "quarterly", 12: "annual", 24: "biennial"}
+
+
 def calculate_price(
     pricing: dict,
     tier: str,
     seats: int,
     term_months: int,
 ) -> float:
-    """Calculate total price for a license."""
+    """Calculate the total price for a license over its whole term.
+
+    Args:
+        pricing: Pricing table, as returned by :func:`load_pricing`.
+        tier: ``"free"`` or ``"team"``.
+        seats: Number of seats on the license.
+        term_months: Term length in months.
+
+    Returns:
+        Total price in the table's currency for all seats over the term.
+    """
     if tier == "free":
         return 0.0
     tier_pricing = pricing.get("team", {})
-    if term_months == 1:
-        base = tier_pricing.get("monthly", {}).get("base_per_seat", 29.0)
-    elif term_months == 3:
-        base = tier_pricing.get("quarterly", {}).get("base_per_seat", 87.0)
-    elif term_months == 12:
-        base = tier_pricing.get("annual", {}).get("base_per_seat", 348.0)
-    elif term_months == 24:
-        base = tier_pricing.get("biennial", {}).get("base_per_seat", 696.0)
-    else:
-        # Monthly rate for other terms
-        base = tier_pricing.get("monthly", {}).get("base_per_seat", 29.0)
+    monthly = tier_pricing.get("monthly", {}).get("base_per_seat", 29.0)
+    key = _TERM_KEYS.get(term_months)
+    base = tier_pricing.get(key, {}).get("base_per_seat") if key else None
+    if base is None:
+        base = monthly * term_months
     return base * seats

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 import pytest
 
@@ -119,6 +119,143 @@ class TestTermArithmetic:
         for term in (1, 3, 6, 12, 24, 36):
             assert calculate_price(DEFAULT_PRICING, "team", 5, term) == 29.00 * term * 5
         assert calculate_price(DEFAULT_PRICING, "free", 1, 12) == 0.0
+
+
+class TestExpiringLicenses:
+    """Renewal alerting: nothing else in the system watches expiry dates."""
+
+    NOW = datetime(2026, 6, 1, tzinfo=timezone.utc)
+
+    def _seed(self, ops, **customers):
+        """Write customer records directly, with controlled expiry dates."""
+        data = {"customers": {}}
+        for name, (days, status) in customers.items():
+            data["customers"][name] = {
+                "customer_id": f"cus_{name}",
+                "license_id": f"lic_{name}",
+                "seats": 10,
+                "tier": "team",
+                "status": status,
+                "expires_at": (self.NOW + timedelta(days=days)).isoformat(),
+            }
+        ops._save_customers(data)
+
+    def test_buckets_by_urgency(self, ops):
+        """Expired, expiring-within-window, and healthy are separated."""
+        self._seed(
+            ops,
+            lapsed=(-10, "active"),
+            soon=(20, "active"),
+            healthy=(300, "active"),
+        )
+        r = ops.list_expiring_licenses(within_days=60, now=self.NOW)
+        assert [e["customer"] for e in r["expired"]] == ["lapsed"]
+        assert [e["customer"] for e in r["expiring"]] == ["soon"]
+        assert r["needs_attention"] == 2
+        assert r["total_active"] == 3
+
+    def test_revoked_excluded(self, ops):
+        """A revoked licence cannot be renewed, so it is not a renewal lead."""
+        self._seed(ops, gone=(-5, "revoked"), live=(10, "active"))
+        r = ops.list_expiring_licenses(within_days=60, now=self.NOW)
+        assert r["total_active"] == 1
+        assert all(e["customer"] != "gone" for e in r["expired"] + r["expiring"])
+
+    def test_sorted_most_urgent_first(self, ops):
+        """Ordering is by remaining days so the top line is the worst case."""
+        self._seed(ops, a=(50, "active"), b=(5, "active"), c=(30, "active"))
+        r = ops.list_expiring_licenses(within_days=60, now=self.NOW)
+        assert [e["customer"] for e in r["expiring"]] == ["b", "c", "a"]
+
+    def test_window_is_respected(self, ops):
+        """A licence outside the window is not reported."""
+        self._seed(ops, later=(90, "active"))
+        assert ops.list_expiring_licenses(within_days=60, now=self.NOW)["needs_attention"] == 0
+        assert ops.list_expiring_licenses(within_days=120, now=self.NOW)["needs_attention"] == 1
+
+    def test_unreadable_expiry_is_surfaced_not_swallowed(self, ops):
+        """A record we cannot date is an operator problem, not a silent skip."""
+        ops._save_customers(
+            {"customers": {"broken": {"seats": 5, "status": "active", "expires_at": "soon-ish"}}}
+        )
+        r = ops.list_expiring_licenses(now=self.NOW)
+        assert [e["customer"] for e in r["unknown"]] == ["broken"]
+        assert r["needs_attention"] == 1
+
+    def test_never_expires_is_not_an_alert(self, ops):
+        """A perpetual licence is healthy, not overdue."""
+        ops._save_customers(
+            {"customers": {"perpetual": {"seats": 1, "status": "active", "expires_at": "never"}}}
+        )
+        r = ops.list_expiring_licenses(now=self.NOW)
+        assert r["needs_attention"] == 0
+        assert r["total_active"] == 1
+
+    def test_naive_timestamp_treated_as_utc(self, ops):
+        """Older records without a timezone must not raise on comparison."""
+        ops._save_customers(
+            {
+                "customers": {
+                    "legacy": {"seats": 5, "status": "active", "expires_at": "2026-06-20T00:00:00"}
+                }
+            }
+        )
+        r = ops.list_expiring_licenses(within_days=60, now=self.NOW)
+        assert [e["customer"] for e in r["expiring"]] == ["legacy"]
+
+    def test_empty_store_is_all_clear(self, ops):
+        """No customers yet is a clean result, not an error."""
+        r = ops.list_expiring_licenses(now=self.NOW)
+        assert r["needs_attention"] == 0
+        assert r["total_active"] == 0
+
+    def test_day_count_truncates_toward_zero(self, ops):
+        """4.1 days past due is 4 days ago, not 5; 17.9 left is 17, not 18."""
+        ops._save_customers(
+            {
+                "customers": {
+                    "past": {
+                        "seats": 1,
+                        "status": "active",
+                        "expires_at": (self.NOW - timedelta(days=4, hours=2)).isoformat(),
+                    },
+                    "future": {
+                        "seats": 1,
+                        "status": "active",
+                        "expires_at": (self.NOW + timedelta(days=17, hours=22)).isoformat(),
+                    },
+                }
+            }
+        )
+        r = ops.list_expiring_licenses(within_days=60, now=self.NOW)
+        assert r["expired"][0]["days_remaining"] == -4
+        assert r["expiring"][0]["days_remaining"] == 17
+
+    def test_lapsed_hours_ago_is_expired_not_due(self, ops):
+        """A licence three hours past due must not read as a 0-day renewal."""
+        ops._save_customers(
+            {
+                "customers": {
+                    "justlapsed": {
+                        "seats": 1,
+                        "status": "active",
+                        "expires_at": (self.NOW - timedelta(hours=3)).isoformat(),
+                    }
+                }
+            }
+        )
+        r = ops.list_expiring_licenses(now=self.NOW)
+        assert [e["customer"] for e in r["expired"]] == ["justlapsed"]
+        assert r["expiring"] == []
+
+    def test_negative_window_rejected(self, ops):
+        with pytest.raises(ValueError, match="within_days"):
+            ops.list_expiring_licenses(within_days=-1)
+
+    def test_needs_no_issuer_key(self, temp_storage):
+        """Alerting is read-only, so a scheduler can run it without the key."""
+        readonly = LicenseOperations("", temp_storage)
+        assert readonly.list_expiring_licenses(now=self.NOW)["needs_attention"] == 0
 
 
 class TestRenewLicense:

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -173,6 +173,53 @@ class TestExpiringLicenses:
         assert ops.list_expiring_licenses(within_days=60, now=self.NOW)["needs_attention"] == 0
         assert ops.list_expiring_licenses(within_days=120, now=self.NOW)["needs_attention"] == 1
 
+    def test_window_boundary_is_exact_not_truncated(self, ops):
+        """`--within N` means N days, not "N days plus change".
+
+        Bucketing on the truncated day count stretched the window by up to a
+        day and flipped the exit code to 6 early.
+        """
+        ops._save_customers(
+            {
+                "customers": {
+                    "outside": {
+                        "seats": 1,
+                        "status": "active",
+                        "expires_at": (self.NOW + timedelta(days=60, hours=23)).isoformat(),
+                    },
+                    "exact": {
+                        "seats": 1,
+                        "status": "active",
+                        "expires_at": (self.NOW + timedelta(days=60)).isoformat(),
+                    },
+                    "inside": {
+                        "seats": 1,
+                        "status": "active",
+                        "expires_at": (self.NOW + timedelta(days=59, hours=23)).isoformat(),
+                    },
+                }
+            }
+        )
+        r = ops.list_expiring_licenses(within_days=60, now=self.NOW)
+        assert sorted(e["customer"] for e in r["expiring"]) == ["exact", "inside"]
+
+    def test_zero_window_looks_no_distance_ahead(self, ops):
+        """`--within 0` must not report tomorrow, nor return the 'due' exit."""
+        ops._save_customers(
+            {
+                "customers": {
+                    "tomorrow": {
+                        "seats": 1,
+                        "status": "active",
+                        "expires_at": (self.NOW + timedelta(hours=23)).isoformat(),
+                    }
+                }
+            }
+        )
+        r = ops.list_expiring_licenses(within_days=0, now=self.NOW)
+        assert r["expiring"] == []
+        assert r["needs_attention"] == 0
+
     def test_unreadable_expiry_is_surfaced_not_swallowed(self, ops):
         """A record we cannot date is an operator problem, not a silent skip."""
         ops._save_customers(

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from datetime import datetime, timezone
 
 import pytest
 
@@ -80,6 +81,46 @@ class TestIssueLicense:
         assert entry["customer"] == "Acme"
 
 
+class TestTermArithmetic:
+    """Terms are sold in calendar months and must land on the calendar."""
+
+    def test_annual_term_is_a_calendar_year(self, ops):
+        """A 12-month term expires a year out, not 360 days out."""
+        lic = ops.issue_team_license("Acme", 5, 12)
+        issued = datetime.fromisoformat(lic.issued_at)
+        expires = datetime.fromisoformat(lic.expires_at)
+        assert expires.year == issued.year + 1
+        assert (expires.month, expires.day) == (issued.month, issued.day)
+
+    @pytest.mark.parametrize("term", [1, 3, 6, 12, 24, 36])
+    def test_every_offered_term_lands_on_the_calendar(self, ops, term):
+        """Each term the CLI accepts advances by exactly that many months."""
+        lic = ops.issue_team_license(f"Corp{term}", 5, term)
+        issued = datetime.fromisoformat(lic.issued_at)
+        expires = datetime.fromisoformat(lic.expires_at)
+        months = (expires.year - issued.year) * 12 + (expires.month - issued.month)
+        assert months == term
+
+    def test_month_end_issue_date_clamps(self):
+        """31 Jan + 1 month is 28 Feb, not 3 March."""
+        from neuralmind.tier2.operations import _add_months
+
+        assert _add_months(datetime(2027, 1, 31, tzinfo=timezone.utc), 1) == datetime(
+            2027, 2, 28, tzinfo=timezone.utc
+        )
+        assert _add_months(datetime(2028, 1, 31, tzinfo=timezone.utc), 1) == datetime(
+            2028, 2, 29, tzinfo=timezone.utc
+        )
+
+    def test_term_price_covers_the_whole_term(self):
+        """Every offered term bills the flat monthly rate per month."""
+        from neuralmind.tier2.pricing import DEFAULT_PRICING, calculate_price
+
+        for term in (1, 3, 6, 12, 24, 36):
+            assert calculate_price(DEFAULT_PRICING, "team", 5, term) == 29.00 * term * 5
+        assert calculate_price(DEFAULT_PRICING, "free", 1, 12) == 0.0
+
+
 class TestRenewLicense:
     def test_renew_extends_expiry(self, ops):
         """Renewal extends expires_at by term months."""
@@ -87,6 +128,15 @@ class TestRenewLicense:
         old_expiry = lic1.expires_at
         lic2 = ops.renew_license("Acme", 12)
         assert lic2.expires_at > old_expiry
+
+    def test_renew_extends_by_calendar_months(self, ops):
+        """Renewal runs from the old expiry, by calendar months."""
+        lic1 = ops.issue_team_license("Acme", 5, 12)
+        old_expiry = datetime.fromisoformat(lic1.expires_at)
+        lic2 = ops.renew_license("Acme", 12)
+        new_expiry = datetime.fromisoformat(lic2.expires_at)
+        assert new_expiry.year == old_expiry.year + 1
+        assert (new_expiry.month, new_expiry.day) == (old_expiry.month, old_expiry.day)
 
     def test_renew_nonexistent(self, ops):
         """Renewal fails for non-existent customer."""


### PR DESCRIPTION
## Description

Three things that came out of asking "is billing set up?" — it isn't, and won't be for a while, so the manual path needs writing down, the arithmetic underneath it needs to be right, and the one gap that loses revenue silently needs closing.

**1. Renewal alerting (`feat`).** Nothing in the system watched expiry dates. A Team licence could lapse with no signal at all, and the runbook's only answer was a calendar reminder — a process, not a mechanism. `neuralmind license expiring` is the mechanism, built to be *consumed* rather than read: the exit code alone says whether anyone needs to act, so a scheduler never parses output to decide whether to alert.

| Exit | Meaning |
|-----:|---------|
| 0 | Nothing due inside the window |
| 6 | Renewals due |
| 7 | Already expired, or an expiry that cannot be parsed (takes precedence over 6) |

Exit 7 covers the unreadable case deliberately — an expiry you can't read isn't one you can trust to alert on, so it escalates rather than passing silently. `--quiet` stays silent on 0 (well behaved in cron), `--json` emits `expired`/`expiring`/`unknown` buckets sorted most-urgent first, `--within` sets the look-ahead (default 60 days). Revoked licences are excluded — they can't be renewed, so they aren't renewal leads.

The query is **read-only and needs no issuer private key**, so delivery can be scheduled by cron, a systemd timer, or an external agent without that process holding anything sensitive. NeuralMind reports; the caller owns delivery. No coupling in either direction.

**2. Calendar-correct terms (`fix`).** Terms are sold in months but were computed as `timedelta(days=30 * term_months)`. A customer paying for 12 months got 360 days — five days short — widening with the term. Renewals inherited the drift and compounded it every cycle. `_add_months` advances by calendar months, clamping day-of-month so 31 Jan + 1 month is 28/29 Feb rather than rolling into March.

The same "a term is one unit" assumption was mispricing deals. `calculate_price` named only the 1/3/12/24-month entries and fell through to a *single month's* rate for anything else — but `license issue --term` accepts 6 and 36 too, so a three-year deal was quoted at 1/36th of its value and written to `total_paid` that way.

| Term | Expiry before | Expiry after | Price, 5 seats: before → after |
|------|---------------|--------------|-------------------------------|
| 6 mo | +180 d | +6 calendar months | $145 → **$870** |
| 12 mo | +360 d | +1 year | $1,740 (unchanged) |
| 36 mo | +1080 d | +3 years | $145 → **$5,220** |

**3. The Billing Runbook (`docs`).** There's no payment processor, and at 5–50 seats on an annual contract sold by email there shouldn't be one yet — but the manual path replacing it was never written down, and the commands implementing it were undocumented. `docs/wiki/Billing-Runbook.md` covers it end to end, names what still bites, and now carries the scheduling recipe for the alerting above. The issuer-side `neuralmind license` group had no reference entry despite being how every paid customer is created; CLI-Reference now documents it, separated from the customer-facing `neuralmind team license`.

**Also fixed:** a leaked internal command. A customer whose activation failed was told to run `autopilot license status` — a binary they don't have. It now points at `neuralmind team license status` and the support address.

Fixes # (no issue)

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 📝 Documentation update

Not breaking: already-issued licences are untouched and their signatures still verify. The term change applies to licences issued or renewed from here on.

## How Has This Been Tested?

- [x] Unit tests
- [x] Manual testing

`TestExpiringLicenses` (14 cases) covers bucketing by urgency, revoked exclusion, most-urgent-first ordering, the window boundary (60d vs 60d23h) and a zero window, unreadable and `never` expiries, naive timestamps, the empty store, negative-window rejection, and that it runs without an issuer key. Two more pin the day arithmetic: truncation toward zero (4.1 days past due reads as 4, not 5) and that a licence lapsed three hours ago buckets as expired rather than a 0-day renewal.

`TestTermArithmetic` asserts every offered term (1/3/6/12/24/36) advances by exactly that many calendar months, pins month-end clamping across leap and non-leap years, and checks the price table bills `29 × term × seats` for all six terms.

Manually drove the real CLI against seeded stores and asserted the full exit-code contract end to end: `0` clear, `6` due, `7` expired-or-unreadable, `2` bad args, `--quiet` silence on 0, `--json` shape, and the window boundary (`61d --within 60` → 0, `59d` → 6). Also walked the corrected runbook procedure from a normal working directory to confirm it actually runs, and drove a tampered licence through `cmd_team_license` to check the new activation error.

102 tests pass across `test_operations`, `test_tier2_license`, `test_tier2_seats`, `test_paid_seats`, `test_paid_seats_sync`, `test_license_validator_anti_tamper`, `test_e2e_seat_governance`, `test_docs_claims`, `test_site_claims`.

`tests/test_cli.py` has pre-existing failures in this sandbox from a missing `numpy`; verified identical on a clean checkout of `main`, and CI installs full deps.

### Test Configuration

* **Python version**: 3.11.15
* **Operating System**: Linux
* **Test command**: `pytest tests/ -v`

## Documentation & discoverability

- [ ] N/A — internal-only change, no user-facing surface
- [x] Docs answer *"what does the user/agent now see?"* — the runbook gives the cron recipe and the exit-code table a caller acts on; CLI-Reference states the term arithmetic so expiry is predictable before issuing
- [ ] `README.md` updated — not applicable; issuer commands are operator-only, not part of the user-facing product surface
- [ ] `docs/index.html` + `docs/about.html` updated — same reason; happy to add a Status & Future line if you'd rather this be visible there
- [x] `docs/wiki/*.md` updated — new `Billing-Runbook.md`, plus `CLI-Reference.md` (new `expiring` command, flags, exit codes 6/7), `Home.md`, `Tier2-Operator-Guide.md`
- [ ] Use-case walkthrough updated/added — no end-user workflow unlocked; this is an internal sales path
- [x] SEO refreshed — sitemap gains the new wiki page; CLI-Reference `lastmod` bumped
- [x] I did **not** edit `CHANGELOG.md` or hand-bump the `pyproject.toml` version

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Code Quality

- [x] `black --check --diff .` — clean, 316 files unchanged
- [x] `ruff check .` — clean repo-wide
- [x] Type hints are added for new functions/methods
- [x] Docstrings are added/updated for public APIs

## Additional Notes

**Scope:** the pricing correction is adjacent to the term bug rather than part of it — it surfaced while writing the quoting step of the runbook, which points operators at `calculate_price`. Shipping a runbook that tells someone to quote a 36-month deal from a function returning 1/36th of the answer seemed worse than fixing it. Easy to split out if you'd prefer.

**Review findings — five, all reproduced before fixing, all fixed in `0708024` and `caae4a1`:**

| Finding | Verdict |
|---|---|
| `--output ./acme-corp.json` in the runbook (P1) | Real, and mine. Every path outside `~/.neuralmind` is refused, so the documented post-payment step raised `ValueError`. Fixed the doc rather than loosening a guard that also contains hostile customer names |
| Window compared truncated days (P2) | Real. `--within 60` caught a 60d23h expiry and `--within 0` returned exit 6 for something 23h out — a premature exit-code flip matters most here, since schedulers route on it |
| Activation error pointed at `team license status` | Real, and my own regression from replacing the `autopilot` leak — that branch returns before anything is installed |
| Cron example mailed empty messages | Real. `mail` on the `||` branch inherits cron's empty stdin. Now leans on cron's own `MAILTO`, which is what `--quiet` was designed for |
| `--help` said exit 7 meant "expired" | Real; it also covers an unreadable expiry |

While in those lines I also fixed a pre-existing wart the P1 finding sat on: the path guard ran *after* `mkdir`, so a rejected path left its parent directory behind, and it blamed the customer name for what could be a bad output path.

**CI history — one failure mine, one not:**

- **Lint on `e506a6c`** was mine: I verified formatting with `ruff format` rather than `black`, which is what the Lint job runs, and my local ruff was older than CI's, so ISC004 never fired locally. Fixed in `b9a771e`; both commands the job runs have since been run directly.
- **`benchmark` failed twice** (`e506a6c`, `caae4a1`) and passed three times, including a **re-run of the identical commit `caae4a1`** that went green on a different runner. The failing assertion is byte-identical across both failures and the off-rate is `74.56%` in every run either way — it latches between two fixed values rather than moving, which is the bimodality the test's own docstring documents. Full evidence, including that this contradicts the docstring's `NEURALMIND_ORT_THREADS=1` fix, is in [this comment](https://github.com/dfrostar/neuralmind/pull/485#issuecomment-5457708928) (it supersedes my earlier one-off framing). Nothing here touches the synapse, embedding, or retrieval path, and the gate is green on `main`. I spent one re-run and no more.

**Still open, and yours to decide: issuer key custody.** The private key lives in an env var with no documented generation, storage, backup, or rotation procedure. Lose it and no customer can be renewed; leak it and anyone can mint licences against a public key already inside every installed copy. The runbook documents the risk and gives a snippet that verifies your key matches the shipped public key, but the custody decision isn't something code can make. Of the runbook's remaining known gaps, the single-file customer record (`~/.neuralmind/customers.yaml`, one machine, no backup) is the next most exposed.