### PR TITLE
docs: disclose the one LLM egress path and rule out video ingestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,16 +334,23 @@ Methodology, gold sets, and community submissions:
 
 ## 🔒 Security & Compliance
 
-- **Local engine, no telemetry.** NeuralMind transmits no repository content
-  and ships no telemetry. Only the minimal relevant slice of code ever reaches
-  your AI tool. The single outbound request it makes is a one-time fetch of a
-  public embedding model on first build, carrying nothing about your code;
-  pre-seed it and the install never reaches the network at all.
+- **Local engine, no telemetry by default.** NeuralMind transmits no
+  repository content and ships no telemetry in its default configuration.
+  Only the minimal relevant slice of code ever reaches your AI tool. The
+  only outbound requests it makes by default are a one-time fetch of a
+  public embedding model on first build (carrying nothing about your code;
+  pre-seed it and the install never reaches the network at all) and,
+  **only if you explicitly opt in** with `NEURALMIND_LLM_SEED=1` +
+  `ANTHROPIC_API_KEY`, a call that sends README/architecture-doc prose
+  (never code, never other files) to Anthropic to seed synapse edges. No
+  code path ingests video, image, or audio files at all. Full disclosure:
+  [`docs/compliance/THIRD_PARTY_LLM_DISCLOSURE.md`](docs/compliance/THIRD_PARTY_LLM_DISCLOSURE.md).
 - **CycloneDX SBOM per release**, hash-chained audit log (Team tier), signed
   licenses (Ed25519), tarball integrity instructions on every release.
 - Live posture page: [neuralmind.uk/security](https://neuralmind.uk/security/) ·
   Policy: [SECURITY.md](SECURITY.md) ·
   [Compliance summary](docs/COMPLIANCE-SUMMARY.md) ·
+  [Third-party LLM & media disclosure](docs/compliance/THIRD_PARTY_LLM_DISCLOSURE.md) ·
   [SDLC policy](docs/compliance/SDLC_POLICY.md)
 
 Behavior toggles: `NEURALMIND_BYPASS=1` (skip compression),

--- a/docs/COMPLIANCE-SUMMARY.md
+++ b/docs/COMPLIANCE-SUMMARY.md
@@ -10,9 +10,10 @@
 
 | Posture | NeuralMind support |
 |---|---|
-| Data leaves your machine | **Never** — fully local, no telemetry, no remote logging, no update checks |
-| Code uploaded to a cloud provider | **No** — all embeddings generated and stored locally via ChromaDB |
-| Outbound network at runtime | **None** — install-time only; see [air-gapped walkthrough](use-cases/air-gapped.md) |
+| Data leaves your machine | **Never by default** — fully local, no telemetry, no remote logging, no update checks. One opt-in exception: see below |
+| Code uploaded to a cloud provider | **No** — all embeddings generated and stored locally via ChromaDB or the local ONNX backend |
+| Outbound network at runtime | **None by default** — install-time only unless `NEURALMIND_LLM_SEED=1` + `ANTHROPIC_API_KEY` are explicitly set, which sends only README/architecture-doc prose (never code, never client files) to Anthropic for synapse seeding. See [`compliance/THIRD_PARTY_LLM_DISCLOSURE.md`](compliance/THIRD_PARTY_LLM_DISCLOSURE.md) and the [air-gapped walkthrough](use-cases/air-gapped.md) |
+| Video/media file ingestion | **Not supported** — no code path accepts video, image, or audio files at any layer; see [`compliance/THIRD_PARTY_LLM_DISCLOSURE.md`](compliance/THIRD_PARTY_LLM_DISCLOSURE.md) §2 |
 | Audit trail | **Built-in** — `.neuralmind/audit_events.jsonl` append-only log + query provenance |
 | Software Bill of Materials | **Auto-generated** — CycloneDX JSON attached to every tagged release |
 | License | **MIT** — full source review, no vendor lock-in |
@@ -79,9 +80,16 @@ NeuralMind processes code. Code can contain comments referencing names, emails, 
 - **Right to erasure** — synapse store and audit log are local files; `rm -rf .neuralmind/` is a complete erasure path
 - **Data residency** — entirely under operator control; no cross-border transfers initiated by NeuralMind
 - **Pseudonymisation** — audit log actor field is system-level on local queries and operator-supplied at the MCP boundary; can be a hashed token rather than a username
-- **Breach notification** — local files, no external surface area, no third-party processor
+- **Breach notification** — local files, no external surface area by default
 
-NeuralMind does **not** act as a data processor in the GDPR sense — there is no external entity to which data is transferred. The operator is the sole controller.
+NeuralMind does **not** act as a data processor in the GDPR sense in its
+default configuration — there is no external entity to which data is
+transferred, and the operator is the sole controller. The one exception is
+the opt-in `NEURALMIND_LLM_SEED=1` documentation-synapse-seeding path,
+which makes Anthropic a subprocessor for README/architecture-doc prose
+only, if and only if an operator explicitly enables it. See
+[`compliance/THIRD_PARTY_LLM_DISCLOSURE.md`](compliance/THIRD_PARTY_LLM_DISCLOSURE.md)
+for the full disclosure, including how to verify it stays disabled.
 
 ---
 
@@ -150,7 +158,7 @@ Choose the strictest your operational needs allow — all four use the same Neur
 This is the **summary** view. For depth:
 
 - [`SECURITY-GUIDE.md`](SECURITY-GUIDE.md) — threat model, encryption, secrets management, line-by-line SOC 2 control evidence
-- [`ENTERPRISE.md`](ENTERPRISE.md) — deployment patterns, scaling, multi-team usage
+- [`compliance/THIRD_PARTY_LLM_DISCLOSURE.md`](compliance/THIRD_PARTY_LLM_DISCLOSURE.md) — precise, code-cited answer to "does any client content (including media files) ever reach a third-party LLM"
 - [`use-cases/air-gapped.md`](use-cases/air-gapped.md) — strictest deployment posture, step-by-step
 - [`use-cases/offline-regulated.md`](use-cases/offline-regulated.md) — broader regulated-industry walkthrough
 - [`SECURITY.md`](../SECURITY.md) — security policy, vulnerability disclosure

--- a/docs/PRIVACY-POLICY.md
+++ b/docs/PRIVACY-POLICY.md
@@ -93,6 +93,14 @@ We do not share your data with any other third parties. We do not sell your data
 
 If a new sub-processor is added, we will update this Policy and notify existing customers via email 30 days before the new processor begins processing.
 
+**Scope note:** this section covers data collected by NeuralMind's own
+commercial operations (license portal, billing). It does not cover the
+runtime behavior of the OSS tool running against your codebase — that is
+documented separately in
+[`compliance/THIRD_PARTY_LLM_DISCLOSURE.md`](compliance/THIRD_PARTY_LLM_DISCLOSURE.md),
+including the one opt-in path where the OSS tool itself calls a
+third-party LLM (Anthropic), disabled by default.
+
 ---
 
 ## 7. International Data Transfers

--- a/docs/SECURITY-GUIDE.md
+++ b/docs/SECURITY-GUIDE.md
@@ -20,7 +20,7 @@
 
 ### Core Principles
 
-1. **No Calls Home** — NeuralMind makes no external network calls; it adds nothing to what your agent sends its model
+1. **No Calls Home by Default** — NeuralMind makes no external network calls in its default configuration; it adds nothing to what your agent sends its model. One narrow, opt-in exception exists — see below.
 2. **Local-First Processing** — All embeddings computed locally
 3. **Explainability** — Every decision is auditable
 4. **Least Privilege** — Users get minimum permissions needed
@@ -28,11 +28,20 @@
 
 ### What NeuralMind Does NOT Do
 
-❌ Send code to external APIs  
-❌ Collect telemetry or usage metrics  
-❌ Store credentials in indexes  
-❌ Cache queries in cloud storage  
-❌ Share data between customers/projects  
+❌ Ingest video, image, or audio files — no code path accepts media of any kind
+❌ Send source code to external APIs
+❌ Collect telemetry or usage metrics
+❌ Store credentials in indexes
+❌ Cache queries in cloud storage
+❌ Share data between customers/projects
+
+**The one opt-in exception:** setting both `NEURALMIND_LLM_SEED=1` and
+`ANTHROPIC_API_KEY` enables a documentation-synapse-seeding call that sends
+only the text of `README.md`/`docs/architecture.md` to Anthropic's API —
+never source code, never client data files, never media. Default is off;
+the call fails open (never blocks indexing). Full disclosure, verification
+steps, and how to keep it disabled:
+[`compliance/THIRD_PARTY_LLM_DISCLOSURE.md`](compliance/THIRD_PARTY_LLM_DISCLOSURE.md).
 
 ---
 

--- a/docs/compliance/RISK_ASSESSMENT.md
+++ b/docs/compliance/RISK_ASSESSMENT.md
@@ -31,7 +31,7 @@ Risks are scored on two dimensions:
 |----|------|------------|--------|-------|-------|------------|-------|
 | R-01 | Vulnerable dependency (Critical CVE) | 3 | 5 | 15 | HIGH | Automated Dependabot alerts, 72h patch SLA for critical | Maintainer |
 | R-02 | Malicious code injection via PR | 2 | 5 | 10 | HIGH | Code review required, branch protection, CI gates | Maintainer |
-| R-03 | Data exfiltration via MCP server | 1 | 5 | 5 | MEDIUM | Local-only by default, RBAC, audit logging, no network | Maintainer |
+| R-03 | Data exfiltration via MCP server | 1 | 5 | 5 | MEDIUM | Local-only by default, RBAC, audit logging, no network except the opt-in `NEURALMIND_LLM_SEED` doc-seeding path (see [`THIRD_PARTY_LLM_DISCLOSURE.md`](THIRD_PARTY_LLM_DISCLOSURE.md)) | Maintainer |
 | R-04 | Index corruption / data loss | 2 | 4 | 8 | MEDIUM | SQLite WAL mode, `neuralmind build --verify`, local backups | Maintainer |
 | R-05 | PyPI package compromise | 1 | 5 | 5 | MEDIUM | Trusted publishing (OIDC), 2FA on PyPI account, SBOM | Maintainer |
 | R-06 | Key person dependency (solo maintainer) | 3 | 4 | 12 | HIGH | Documented runbooks, bus factor reduction plan, paid support option | Maintainer |

--- a/docs/compliance/THIRD_PARTY_LLM_DISCLOSURE.md
+++ b/docs/compliance/THIRD_PARTY_LLM_DISCLOSURE.md
@@ -1,0 +1,170 @@
+# Third-Party LLM Disclosure & Media Ingestion Scope
+
+**Date:** 2026-08-31
+**Version:** 1.0
+**SOC 2 Controls:** CC6.1, CC7.1, P4.1, P6.1
+
+---
+
+## 1. Purpose
+
+Give clients, their DPOs, and their compliance/procurement teams a precise,
+code-cited answer to the two questions that come up whenever NeuralMind is
+evaluated as (or must be contractually excluded as) a data processor or
+subprocessor:
+
+1. Can client media files (video, images, audio) ever reach any server —
+   local or remote — through NeuralMind?
+2. Does NeuralMind transmit any client content to a public-cloud LLM as
+   part of normal operation?
+
+This document exists because other compliance docs in this repository
+(`COMPLIANCE-SUMMARY.md`, `SECURITY-GUIDE.md`) state "no external network
+calls" / "no third-party processor" as unqualified absolutes. That framing
+is correct for everything NeuralMind actually does, with exactly one
+narrow, opt-in exception documented in §3.1. This doc is the precise,
+citable version of the claim.
+
+## 2. Media file scope — video (and all other media) is out of scope entirely
+
+NeuralMind has no code path, in any deployment mode, that accepts video,
+image, or audio files for indexing:
+
+- **Structural indexing** (`neuralmind/graphgen.py`) dispatches files by
+  extension through `SUPPORTED_SUFFIXES` — an allowlist covering ~10
+  programming-language source extensions (Python, TypeScript, Go, Rust,
+  Java, C, C++, C#, Ruby, PHP) plus Markdown. Anything else is skipped.
+- **Free-form document ingestion** (`neuralmind/document_ingestion.py`,
+  used by `neuralmind ingest-document` / `NeuralMind.ingest_document()`)
+  accepts only PDF, Markdown, and plain text, capped at 10MB per file, and
+  actively **rejects binary content presented under a text-like
+  extension** via magic-byte sniffing — a guard built specifically to stop
+  something that isn't text from entering the pipeline.
+- **No dependency anywhere in `pyproject.toml`** performs video decoding,
+  frame extraction, or computer vision (no ffmpeg, opencv, moviepy, or
+  equivalent). There is no vision model in this codebase.
+
+**Conclusion:** a video file handed to NeuralMind is either silently
+skipped (unsupported extension in structural indexing) or explicitly
+rejected (binary-content guard in document ingestion). It is never parsed,
+embedded, chunked, or transmitted anywhere — local or remote — by any
+existing code path. No configuration flag adds video support; this is not
+a "disabled by default" feature, it does not exist in the codebase.
+
+If your product requirement involves indexing video (e.g. transcripts,
+frame-level metadata), that is new functionality NeuralMind does not have
+today — do not represent it as available in a client-facing document.
+
+## 3. Everything NeuralMind does process stays local, with one documented exception
+
+NeuralMind's actual product surface is source code and text/PDF/Markdown
+documents. The default data flow for that surface is:
+
+```
+Local files (code, .md, .pdf, .txt)
+   → tree-sitter / document_ingestion parsing (local, in-process)
+   → embeddings (local ONNX MiniLM model, or optional local ChromaDB)
+   → SQLite graph + synapse store (.neuralmind/, graphify-out/, on disk)
+   → served to the calling agent (Claude Code, Cursor, etc.) over local
+     MCP stdio, or via the local graph-view server bound to 127.0.0.1
+```
+
+No step in that pipeline makes a network call. This is what
+`COMPLIANCE-SUMMARY.md`'s "Outbound network at runtime: None" row and
+`SECURITY-GUIDE.md`'s "No Calls Home" principle correctly describe for the
+default configuration.
+
+### 3.1 The one opt-in exception: documentation-synapse seeding via Anthropic
+
+`neuralmind/synapses.py::seed_from_documentation()`, invoked from
+`NeuralMind.ingest_document()` in `neuralmind/core.py`, sends the **text of
+`README.md` and `docs/architecture.md`** — project documentation prose,
+never source code, never client data files, never media — to the
+Anthropic API, in order to extract architectural relationships (e.g. "the
+embedder feeds the context selector") as synapse graph edges.
+
+This path only runs when **both** conditions are met:
+
+- `NEURALMIND_LLM_SEED=1` is explicitly set (default: unset → path returns
+  immediately, no call attempted)
+- `ANTHROPIC_API_KEY` is present in the environment (the operator's own
+  key; NeuralMind ships none)
+
+It is **fail-open**: any error (network failure, malformed response,
+missing key) is caught and the function returns `0` — it never blocks or
+fails indexing, and it never retries with client data as a fallback.
+
+**For any organization operating under a DPA/BAA that prohibits
+undisclosed subprocessors:** never set `NEURALMIND_LLM_SEED` or
+`ANTHROPIC_API_KEY` in the environment where NeuralMind runs. This is the
+default state — no action is needed unless someone has already opted in.
+Verify with:
+
+```bash
+env | grep -E 'NEURALMIND_LLM_SEED|ANTHROPIC_API_KEY'   # should be empty
+ss -tnp | grep python                                     # no connections, during neuralmind build/query
+```
+
+An egress firewall rule blocking the NeuralMind process/container from
+reaching `api.anthropic.com` is effective defense-in-depth if you want a
+belt-and-suspenders guarantee beyond the env-var gate.
+
+### 3.2 Local-model path (Ollama) — local by default, operator-configurable
+
+`neuralmind/local_client.py` (`OllamaClient`) is an optional local-model
+query path, disabled unless `local_models.enabled` is set in
+`~/.config/neuralmind/config.toml`. Its default endpoint is
+`http://localhost:11434` — a local Ollama server, not a cloud endpoint.
+The endpoint is operator-configurable (`local_models.endpoint`); if your
+deployment sets it to anything other than a loopback/private address, that
+becomes a real egress path and should go through the same review as any
+other outbound connection.
+
+### 3.3 Dead configuration — not a live risk today, flagged for hygiene
+
+`neuralmind/config.py` defines `LocalModelsConfig.fallback_to_api` (default
+`True`) and `ApiConfig(provider="openrouter")`. As of this review, **no
+code path reads either field** — they are schema-only and do not cause any
+call to OpenRouter or any other API provider. This is not a current data
+exposure, but it is worth removing or wiring up deliberately: a client
+security reviewer grepping the codebase for `openrouter` will find it and
+reasonably ask whether it does something. Filed as a hygiene item, not a
+compliance blocker.
+
+## 4. Answering the specific question: client video files and LLM subprocessors
+
+Given §2 and §3: **client video files cannot reach a public-cloud LLM
+through NeuralMind, under any configuration, because NeuralMind never
+ingests video files in the first place.** This is a stronger guarantee
+than "video stays on-prem" — there is no video pipeline to confine.
+
+For the content NeuralMind *does* index (source code, README/architecture
+docs), the only third-party LLM transmission risk is the single, opt-in,
+default-off path in §3.1, and it is scoped to documentation prose, not
+arbitrary client files.
+
+## 5. Relationship to other NeuralMind compliance documents
+
+- [`../COMPLIANCE-SUMMARY.md`](../COMPLIANCE-SUMMARY.md) — one-page
+  procurement summary; its "Outbound network" and GDPR rows should be read
+  together with §3.1 above.
+- [`../SECURITY-GUIDE.md`](../SECURITY-GUIDE.md) — "No Calls Home"
+  principle; same caveat applies.
+- [`../PRIVACY-POLICY.md`](../PRIVACY-POLICY.md) §6 — covers NeuralMind's
+  own commercial/SaaS operations (license portal: Stripe, GitHub). That
+  section is scoped to the paid-license/portal side of the business, not
+  OSS-tool runtime behavior; this document is the runtime-behavior
+  disclosure for the OSS tool itself.
+- [`RISK_ASSESSMENT.md`](RISK_ASSESSMENT.md) R-03 — data exfiltration via
+  MCP server; mitigation text updated to reference this document rather
+  than assert "no network" unconditionally.
+
+This document does not constitute legal advice or contract language for a
+DPA, BAA, or service-provider addendum. It is a factual, code-verified
+description of current behavior for your counsel to build contractual
+language on.
+
+---
+
+*This disclosure is reviewed whenever a change touches LLM-call code paths
+or media/document ingestion. Last reviewed: 2026-08-31.*


### PR DESCRIPTION
## Description

Triggered by a client-facing compliance question: *can client video files ever reach a public-cloud LLM used as a processor/subprocessor?* A full code audit was done to answer it precisely rather than by assertion (see the [session's compliance findings](https://claude.ai/code/session_01B8Rv5g1Tcf4t7rbiRfCBru) for the full trail).

**Findings:**

1. **NeuralMind has no video/image/audio ingestion path anywhere in the codebase.** `graphgen.py`'s `SUPPORTED_SUFFIXES` only covers ~10 source-code extensions plus Markdown, and `document_ingestion.py` accepts PDF/Markdown/text only, capped at 10MB, with a binary-content magic-byte rejection guard. There is no dependency for video decoding/frame extraction/vision anywhere in `pyproject.toml`. The scenario the question worried about — video frames leaking to a public LLM — cannot happen because there is no code path for video to enter the system at all, in any deployment mode.

2. **There is exactly one real, opt-in exception the existing docs didn't disclose.** `neuralmind/synapses.py::seed_from_documentation()` (invoked from `core.py`'s `ingest_document()`) sends the text of `README.md`/`docs/architecture.md` — project documentation prose, never source code, never client files — to Anthropic's API, gated on **both** `NEURALMIND_LLM_SEED=1` and `ANTHROPIC_API_KEY` being explicitly set by the operator (both unset by default). It's fail-open: any error returns `0` and never blocks indexing.

3. **`COMPLIANCE-SUMMARY.md`, `SECURITY-GUIDE.md`, `PRIVACY-POLICY.md`, and `README.md` stated "no external network calls" / "no third-party processor" as unqualified absolutes**, which didn't account for #2. Corrected each to name the exception precisely, and added `docs/compliance/THIRD_PARTY_LLM_DISCLOSURE.md` as the single, code-cited, citable answer for procurement/DPA conversations — cross-linked from the other compliance surfaces and from `RISK_ASSESSMENT.md`'s R-03 row.

Also flagged out-of-band (not fixed here, filed separately): a dead `ApiConfig(provider="openrouter")` / `LocalModelsConfig.fallback_to_api` config schema in `config.py` with no consuming call site — not a live risk today, but worth removing or wiring up so it doesn't read as an undisclosed egress path to a future auditor grepping the code.

Fixes # (no linked issue — raised as a direct compliance review request)

## Type of Change

- [x] 📝 Documentation update

## How Has This Been Tested?

- [x] Unit tests — `pytest tests/test_docs_claims.py tests/test_site_claims.py` (the repo's existing anti-overclaim guards) pass against all edited files
- [x] `python scripts/check_commercial_terms.py` passes
- [ ] Manual testing — N/A, docs-only change

### Test Configuration

* **Python version**: 3.12 (container default)
* **Operating System**: Linux
* **Test command**: `pytest tests/test_docs_claims.py tests/test_site_claims.py -q`

## Documentation & discoverability

- [x] Docs answer *"what does the user/agent now see?"* — an operator or client compliance reviewer now sees the precise, code-cited scope of the one LLM egress path and an explicit statement that video/media ingestion doesn't exist
- [x] `README.md` updated (Security & Compliance section)
- [x] New doc discoverable from `COMPLIANCE-SUMMARY.md`, `SECURITY-GUIDE.md`, `PRIVACY-POLICY.md`, and `RISK_ASSESSMENT.md`
- [ ] N/A — no new CLI command, MCP tool, or hook was added; `NEURALMIND_LLM_SEED`/`ANTHROPIC_API_KEY` already existed in code, this PR only documents them accurately

## Checklist

- [x] I have performed a self-review of my changes
- [x] I have made corresponding changes to the documentation (this PR *is* the documentation change)
- [x] My changes generate no new warnings
- [x] Existing unit tests (the anti-overclaim guards) pass locally with my changes

## Additional Notes

This is a docs-only PR — no runtime behavior changed. The underlying `NEURALMIND_LLM_SEED` opt-in path itself was not modified; only its documentation across the compliance surfaces was corrected and centralized.


---
_Generated by [Claude Code](https://claude.ai/code/session_01B8Rv5g1Tcf4t7rbiRfCBru)_