### PR TITLE
chore: remove dead openrouter/fallback_to_api config, disclose HF has no footprint

### DIFF
--- a/docs/compliance/THIRD_PARTY_LLM_DISCLOSURE.md
+++ b/docs/compliance/THIRD_PARTY_LLM_DISCLOSURE.md
@@ -120,16 +120,36 @@ deployment sets it to anything other than a loopback/private address, that
 becomes a real egress path and should go through the same review as any
 other outbound connection.
 
-### 3.3 Dead configuration — not a live risk today, flagged for hygiene
+### 3.3 Dead configuration — removed
 
-`neuralmind/config.py` defines `LocalModelsConfig.fallback_to_api` (default
-`True`) and `ApiConfig(provider="openrouter")`. As of this review, **no
-code path reads either field** — they are schema-only and do not cause any
-call to OpenRouter or any other API provider. This is not a current data
-exposure, but it is worth removing or wiring up deliberately: a client
-security reviewer grepping the codebase for `openrouter` will find it and
-reasonably ask whether it does something. Filed as a hygiene item, not a
-compliance blocker.
+`neuralmind/config.py` previously defined `LocalModelsConfig.fallback_to_api`
+(default `True`) and an `ApiConfig(provider="openrouter")` section. As of
+this review, no code path ever read either field — they were schema-only
+and never caused a call to OpenRouter or any other API provider. They were
+removed (not wired up) precisely because leaving a dead field named after a
+hosted third-party API in the config schema is confusing for exactly the
+audience this document serves: a client security reviewer grepping the
+codebase for `openrouter` would find it and reasonably ask whether it does
+something. `neuralmind/config.py` now only carries the local-Ollama section
+described in §3.2.
+
+### 3.4 Hugging Face — not a dependency of any kind
+
+A natural follow-up to §3.3's OpenRouter finding: does NeuralMind depend on
+Hugging Face the way some "local" AI tools quietly do (fetching model
+weights from the HF Hub, or calling HF's hosted Inference API)? No. The
+only Hugging-Face-authored package anywhere in `pyproject.toml` is
+`tokenizers` (the fast-tokenizer library), and it runs entirely
+in-process to prepare text for the local ONNX MiniLM model described in
+§3 — it makes no network calls of its own. There is no `huggingface_hub` or
+`transformers` dependency, and no `HF_API_KEY`/Inference API code path
+anywhere in the codebase. The embedding model archive itself is fetched
+from a pinned, SHA256-verified URL on Chroma's own S3 bucket
+(`neuralmind/onnx_embedder.py`), not the HF Hub. Using a vendor's
+open-source library locally (this project also uses OpenAI's `tiktoken`
+the same way, for benchmark tokenization) is not the same as depending on
+that vendor's hosted service — the distinction that made §3.3's OpenRouter
+field worth removing in the first place.
 
 ## 4. Answering the specific question: client video files and LLM subprocessors
 

--- a/neuralmind/config.py
+++ b/neuralmind/config.py
@@ -2,8 +2,8 @@
 
 Reads user overrides from ``~/.config/neuralmind/config.toml`` (or
 ``$XDG_CONFIG_HOME/neuralmind/config.toml``) and merges them over the
-built-in DEFAULT_CONFIG. Used by the local-Ollama client and the
-embedding backend to resolve provider/endpoints without env-var juggling.
+built-in DEFAULT_CONFIG. Used by the local-Ollama client to resolve the
+endpoint/model without env-var juggling.
 
 Example:
     >>> from neuralmind.config import load_config
@@ -13,10 +13,11 @@ Example:
 
 See Also:
     - ``neuralmind/local_client.py`` — consumer for the local-model section
-    - ``neuralmind/embedder.py`` — consumer for the api provider section
+    - ``docs/compliance/THIRD_PARTY_LLM_DISCLOSURE.md`` — why there's no
+      cloud-API fallback section here: NeuralMind doesn't call one
 
 Version:
-    0.54.0
+    0.55.0
 """
 
 import logging
@@ -40,21 +41,6 @@ class LocalModelsConfig:
     endpoint: str = "http://localhost:11434"
     model: str = "llama3.1"
     api_key: str | None = None
-    fallback_to_api: bool = True
-
-    def get(self, key: str, default: Any = None) -> Any:
-        return getattr(self, key, default)
-
-    def __contains__(self, key: str) -> bool:
-        return hasattr(self, key)
-
-    def __getitem__(self, key: str) -> Any:
-        return getattr(self, key)
-
-
-@dataclass
-class ApiConfig:
-    provider: str = "openrouter"
 
     def get(self, key: str, default: Any = None) -> Any:
         return getattr(self, key, default)
@@ -69,7 +55,6 @@ class ApiConfig:
 @dataclass
 class NeuralMindConfig:
     local_models: LocalModelsConfig = field(default_factory=LocalModelsConfig)
-    api: ApiConfig = field(default_factory=ApiConfig)
 
     def __getitem__(self, key: str) -> Any:
         """Dict-style backward compat: config['local_models']."""
@@ -97,12 +82,10 @@ class NeuralMindConfig:
     def from_dict(cls, data: dict[str, Any]) -> "NeuralMindConfig":
         """Build a config from a raw dict, ignoring unknown keys."""
         local = data.get("local_models", {}) or {}
-        api = data.get("api", {}) or {}
         return cls(
             local_models=LocalModelsConfig(
                 **{k: v for k, v in local.items() if k in LocalModelsConfig.__dataclass_fields__}
             ),
-            api=ApiConfig(**{k: v for k, v in api.items() if k in ApiConfig.__dataclass_fields__}),
         )
 
     def to_dict(self) -> dict[str, Any]:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -50,7 +50,6 @@ class TestLoadConfig:
 
         config = load_config()
         assert "local_models" in config
-        assert "api" in config
         assert config["local_models"]["provider"] == DEFAULT_CONFIG["local_models"]["provider"]
 
     def test_loads_user_config_when_exists(self, tmp_path, monkeypatch):
@@ -88,7 +87,6 @@ class TestLoadConfig:
         from neuralmind.config import DEFAULT_CONFIG
 
         assert "local_models" in DEFAULT_CONFIG
-        assert "api" in DEFAULT_CONFIG
         assert "enabled" in DEFAULT_CONFIG["local_models"]
         assert "provider" in DEFAULT_CONFIG["local_models"]
         assert "endpoint" in DEFAULT_CONFIG["local_models"]


### PR DESCRIPTION
## Description

Follow-up to #493's compliance disclosure. That PR flagged, but didn't fix, a dead config surface: `neuralmind/config.py` defined `ApiConfig(provider="openrouter")` and `LocalModelsConfig.fallback_to_api`, but **no code path anywhere read either field** — it was pure schema, no behavior. Confirmed again for this PR by grepping the whole tree for `ApiConfig`/`fallback_to_api`/`openrouter` (the only other hits are unrelated marketing copy in `docs/BUSINESS-CASE.md`/`docs/about.html`/`site/`, discussing the general API-spend market, not NeuralMind's own behavior).

A client security reviewer grepping the codebase for `openrouter` would find a plausible-looking egress path that doesn't actually exist — exactly the kind of confusion `docs/compliance/THIRD_PARTY_LLM_DISCLOSURE.md` (added in #493) exists to prevent. Removed both fields rather than wiring them up: NeuralMind doesn't call a cloud-API fallback today, and adding one now would reopen the exact question #493 just closed.

**Also addressed a follow-up question raised during review of #493:** does NeuralMind depend on Hugging Face the way some "local" AI tools quietly do (fetching from the HF Hub, or calling HF's hosted Inference API)? No — the only Hugging-Face-authored package in the dependency tree is `tokenizers`, used entirely in-process to prep text for the local ONNX embedding model, with no `huggingface_hub`/`transformers` dependency and no HF Inference API code path anywhere. The embedding archive itself is fetched from a pinned, SHA256-verified Chroma-owned S3 URL, not the HF Hub. Documented as `THIRD_PARTY_LLM_DISCLOSURE.md` §3.4 so it's a citable answer rather than a one-off chat reply.

## Type of Change

- [x] ♻️ Refactoring (no functional changes) — the removed fields had no consumers, so behavior is unchanged
- [x] 📝 Documentation update

## How Has This Been Tested?

- [x] Unit tests — `pytest tests/test_config.py tests/test_local_client.py tests/test_daemon.py tests/test_docs_claims.py tests/test_site_claims.py` all pass
- [x] `python scripts/check_commercial_terms.py` passes
- [x] `ruff check` clean on all changed files
- [ ] Manual testing — N/A

### Test Configuration

* **Python version**: 3.11 (container default)
* **Operating System**: Linux
* **Test command**: `pytest tests/test_config.py tests/test_local_client.py tests/test_daemon.py -q`

## Documentation & discoverability

- [x] Docs answer *"what does the user/agent now see?"* — `docs/compliance/THIRD_PARTY_LLM_DISCLOSURE.md` §3.3 now says the dead config was removed (not just flagged), and a new §3.4 gives a direct, code-cited answer on Hugging Face
- [ ] N/A for README/index.html/about.html/wiki — no user-facing command, hook, or env var changed; this removes unused internal config schema and updates the compliance disclosure doc that already covers it

## Checklist

- [x] I have performed a self-review of my changes
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Existing unit tests pass locally with my changes

## Code Quality

- [x] I have run `ruff check .` for linting (on changed files)
- [x] Type hints unchanged (no new functions added)

## Additional Notes

No behavior change — `ApiConfig`/`fallback_to_api` had zero consumers before this PR, confirmed by repo-wide grep. This is purely removing dead schema and correcting the disclosure doc to match.


---
_Generated by [Claude Code](https://claude.ai/code/session_01B8Rv5g1Tcf4t7rbiRfCBru)_