### PR TITLE
ci(release): guard against orphaned release tags and manifest drift

### DIFF
--- a/.github/workflows/_validate-release-tag.yml
+++ b/.github/workflows/_validate-release-tag.yml
@@ -1,0 +1,111 @@
+name: Validate Release Tag (reusable)
+
+# Single source of truth for "is this tag safe to publish from", called by
+# every workflow that triggers on a `v*` tag push: release.yml (PyPI),
+# docker-publish.yml (GHCR), and sbom.yml. Before this file existed, only
+# release.yml checked the tag; docker-publish.yml and sbom.yml had no
+# equivalent gate, so an orphaned or manifest-mismatched tag (see
+# CONTRIBUTING.md's "Release-please troubleshooting") could still get a
+# GHCR image built and an SBOM published even though release.yml correctly
+# rejected the same tag. Centralizing here means one set of checks to keep
+# correct, not three copies to keep in sync.
+
+on:
+  workflow_call:
+    inputs:
+      release_tag:
+        description: 'The v* tag being validated (e.g., v0.9.0).'
+        required: true
+        type: string
+
+jobs:
+  validate:
+    name: Validate Tag vs Package Version
+    runs-on: ubuntu-latest
+    steps:
+      # Full history, not the default shallow single-commit checkout: the
+      # ancestry check below needs enough of the graph to compute a real
+      # merge-base against `main`, and a shallow clone gives either a false
+      # "not an ancestor" or an outright "no merge base" error.
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.release_tag }}
+          fetch-depth: 0
+
+      - name: Check tag matches pyproject.toml version
+        run: |
+          set -euo pipefail
+          RELEASE_TAG="${{ inputs.release_tag }}"
+          TAG_VERSION="${RELEASE_TAG#v}"
+          PKG_VERSION="$(python - <<'EOF'
+          import re, sys
+          content = open("pyproject.toml").read()
+          m = re.search(r'^\s*version\s*=\s*"([^"]+)"', content, re.MULTILINE)
+          if not m:
+              print("ERROR: version not found in pyproject.toml", file=sys.stderr)
+              sys.exit(1)
+          print(m.group(1))
+          EOF
+          )"
+          echo "Tag version:     ${TAG_VERSION}"
+          echo "Package version: ${PKG_VERSION}"
+          if [ "${TAG_VERSION}" != "${PKG_VERSION}" ]; then
+            echo "ERROR: Git tag v${TAG_VERSION} does not match pyproject.toml version ${PKG_VERSION}."
+            echo "Please delete the wrong tag and push the correct tag matching pyproject.toml."
+            exit 1
+          fi
+          echo "OK: tag v${TAG_VERSION} matches pyproject.toml version ${PKG_VERSION}."
+
+      - name: Check tag matches the release-please manifest
+        run: |
+          set -euo pipefail
+          RELEASE_TAG="${{ inputs.release_tag }}"
+          TAG_VERSION="${RELEASE_TAG#v}"
+          MANIFEST_VERSION="$(python -c "import json; print(json.load(open('.release-please-manifest.json'))['.'])")"
+          echo "Tag version:      ${TAG_VERSION}"
+          echo "Manifest version: ${MANIFEST_VERSION}"
+          if [ "${TAG_VERSION}" != "${MANIFEST_VERSION}" ]; then
+            echo "ERROR: Git tag v${TAG_VERSION} does not match .release-please-manifest.json (${MANIFEST_VERSION})."
+            echo "release-please diffs its NEXT release from the tag matching this manifest value."
+            echo "If they disagree, its next proposed release silently walks the wrong commit range."
+            echo "Update .release-please-manifest.json to ${TAG_VERSION} in the same commit that creates this tag."
+            exit 1
+          fi
+          echo "OK: tag v${TAG_VERSION} matches .release-please-manifest.json."
+
+      - name: Check the tag is reachable from main
+        run: |
+          set -euo pipefail
+          RELEASE_TAG="${{ inputs.release_tag }}"
+          # release-please's manifest mode computes what's unreleased by
+          # diffing from the tag matching the manifest version above. If
+          # that tag's commit isn't actually on main's history -- e.g. it
+          # was committed and tagged locally, then reached main through a
+          # squash- or rebase-merged PR that gave the "same" change a
+          # different SHA -- the tag is orphaned: invisible to `git log
+          # main`, and invisible to release-please's diffing. It then falls
+          # back to whatever earlier tag IS an ancestor and walks everything
+          # since, silently pulling months of already-shipped work back into
+          # a bogus "unreleased" changelog. This happened for real on
+          # v3.9.0 (tagged 2026-09-03, diagnosed and fixed 2026-09-10) --
+          # see CONTRIBUTING.md's "Release-please troubleshooting" section.
+          git fetch origin main --quiet
+          if ! git merge-base --is-ancestor "${RELEASE_TAG}" origin/main; then
+            echo "ERROR: ${RELEASE_TAG} is not an ancestor of origin/main."
+            echo "This tag's commit was never actually merged into main -- most likely it was"
+            echo "committed and tagged locally, then reached main via a squash- or rebase-merged"
+            echo "PR that produced a different SHA for the same change. release-please cannot"
+            echo "compute a correct diff from an orphaned tag."
+            echo
+            echo "Fix: find a commit on main where pyproject.toml, the manifest, and SKILL.md all"
+            echo "agree with this tag's version (not just matching source content -- see"
+            echo "CONTRIBUTING.md's 'Release-please troubleshooting' for why those can differ),"
+            echo "then repoint the tag to it:"
+            echo "  git tag -f ${RELEASE_TAG} <correct-sha-on-main>"
+            echo "  git push --force origin ${RELEASE_TAG}"
+            echo "Retagging only rewrites a git ref -- nothing already published (the PyPI wheel,"
+            echo "the GHCR image, the SBOM, the GitHub Release notes) changes, and re-running this"
+            echo "workflow and its siblings against the corrected tag is safe (see CONTRIBUTING.md)."
+            exit 1
+          fi
+          echo "OK: ${RELEASE_TAG} is an ancestor of main."

--- a/.github/workflows/_validate-release-tag.yml
+++ b/.github/workflows/_validate-release-tag.yml
@@ -22,6 +22,12 @@ jobs:
   validate:
     name: Validate Tag vs Package Version
     runs-on: ubuntu-latest
+    # Read-only job: checks out a ref and inspects/diffs it, never writes
+    # anything. Explicit least-privilege block per CodeQL's workflow-
+    # permissions check, rather than inheriting whatever the repo default
+    # happens to be.
+    permissions:
+      contents: read
     steps:
       # Full history, not the default shallow single-commit checkout: the
       # ancestry check below needs enough of the graph to compute a real

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -12,6 +12,14 @@ name: Docker Publish (GHCR)
 # Triggered on the same `v*` tag push that fires release.yml, so the
 # image lands alongside the PyPI publish without a separate dispatch.
 #
+# validate-version (shared with release.yml and sbom.yml via
+# _validate-release-tag.yml) gates the actual build: this workflow runs
+# independently of release.yml's own validate-version job — GitHub Actions
+# has no cross-workflow `needs:` — so without its own gate, an orphaned or
+# manifest-mismatched tag that release.yml correctly rejects would still
+# get a GHCR image built and tagged `latest` here. See CONTRIBUTING.md's
+# "Release-please troubleshooting" for what this actually catches.
+#
 # Tag/label generation uses docker/metadata-action so:
 #   - the image name is lowercased (GHCR rejects uppercase, and a
 #     future repo rename or fork with mixed case wouldn't fail the push)
@@ -36,8 +44,15 @@ env:
   RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
 
 jobs:
+  validate-version:
+    name: Validate Tag vs Package Version
+    uses: ./.github/workflows/_validate-release-tag.yml
+    with:
+      release_tag: ${{ env.RELEASE_TAG }}
+
   build-and-push:
     name: Build + push multi-platform image
+    needs: validate-version
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,9 +25,14 @@ jobs:
     name: Validate Tag vs Package Version
     runs-on: ubuntu-latest
     steps:
+      # Full history, not the default shallow single-commit checkout: the
+      # ancestry check below needs enough of the graph to compute a real
+      # merge-base against `main`, and a shallow clone gives either a false
+      # "not an ancestor" or an outright "no merge base" error.
       - uses: actions/checkout@v7
         with:
           ref: ${{ env.RELEASE_TAG }}
+          fetch-depth: 0
 
       - name: Check tag matches pyproject.toml version
         run: |
@@ -51,6 +56,56 @@ jobs:
             exit 1
           fi
           echo "OK: tag v${TAG_VERSION} matches pyproject.toml version ${PKG_VERSION}."
+
+      - name: Check tag matches the release-please manifest
+        run: |
+          set -euo pipefail
+          TAG_VERSION="${RELEASE_TAG#v}"
+          MANIFEST_VERSION="$(python -c "import json; print(json.load(open('.release-please-manifest.json'))['.'])")"
+          echo "Tag version:      ${TAG_VERSION}"
+          echo "Manifest version: ${MANIFEST_VERSION}"
+          if [ "${TAG_VERSION}" != "${MANIFEST_VERSION}" ]; then
+            echo "ERROR: Git tag v${TAG_VERSION} does not match .release-please-manifest.json (${MANIFEST_VERSION})."
+            echo "release-please diffs its NEXT release from the tag matching this manifest value."
+            echo "If they disagree, its next proposed release silently walks the wrong commit range."
+            echo "Update .release-please-manifest.json to ${TAG_VERSION} in the same commit that creates this tag."
+            exit 1
+          fi
+          echo "OK: tag v${TAG_VERSION} matches .release-please-manifest.json."
+
+      - name: Check the tag is reachable from main
+        run: |
+          set -euo pipefail
+          # release-please's manifest mode computes what's unreleased by
+          # diffing from the tag matching the manifest version above. If
+          # that tag's commit isn't actually on main's history -- e.g. it
+          # was committed and tagged locally, then reached main through a
+          # squash- or rebase-merged PR that gave the "same" change a
+          # different SHA -- the tag is orphaned: invisible to `git log
+          # main`, and invisible to release-please's diffing. It then falls
+          # back to whatever earlier tag IS an ancestor and walks everything
+          # since, silently pulling months of already-shipped work back into
+          # a bogus "unreleased" changelog. This happened for real on
+          # v3.9.0 (tagged 2026-09-03, diagnosed and fixed 2026-09-10) --
+          # see CONTRIBUTING.md's "Release-please troubleshooting" section.
+          git fetch origin main --quiet
+          if ! git merge-base --is-ancestor "${RELEASE_TAG}" origin/main; then
+            echo "ERROR: ${RELEASE_TAG} is not an ancestor of origin/main."
+            echo "This tag's commit was never actually merged into main -- most likely it was"
+            echo "committed and tagged locally, then reached main via a squash- or rebase-merged"
+            echo "PR that produced a different SHA for the same change. release-please cannot"
+            echo "compute a correct diff from an orphaned tag."
+            echo
+            echo "Fix: find the commit on main with the equivalent change (same message, compare"
+            echo "trees with 'git diff <this-tag> <candidate>' -- differences should be empty or"
+            echo "cosmetic only), then repoint the tag to it:"
+            echo "  git tag -f ${RELEASE_TAG} <correct-sha-on-main>"
+            echo "  git push --force origin ${RELEASE_TAG}"
+            echo "Retagging only rewrites a git ref -- nothing already published (the PyPI wheel,"
+            echo "the GHCR image, the SBOM, the GitHub Release notes) changes."
+            exit 1
+          fi
+          echo "OK: ${RELEASE_TAG} is an ancestor of main."
 
   smoke-test:
     name: Smoke Test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,89 +23,9 @@ env:
 jobs:
   validate-version:
     name: Validate Tag vs Package Version
-    runs-on: ubuntu-latest
-    steps:
-      # Full history, not the default shallow single-commit checkout: the
-      # ancestry check below needs enough of the graph to compute a real
-      # merge-base against `main`, and a shallow clone gives either a false
-      # "not an ancestor" or an outright "no merge base" error.
-      - uses: actions/checkout@v7
-        with:
-          ref: ${{ env.RELEASE_TAG }}
-          fetch-depth: 0
-
-      - name: Check tag matches pyproject.toml version
-        run: |
-          set -euo pipefail
-          TAG_VERSION="${RELEASE_TAG#v}"
-          PKG_VERSION="$(python - <<'EOF'
-          import re, sys
-          content = open("pyproject.toml").read()
-          m = re.search(r'^\s*version\s*=\s*"([^"]+)"', content, re.MULTILINE)
-          if not m:
-              print("ERROR: version not found in pyproject.toml", file=sys.stderr)
-              sys.exit(1)
-          print(m.group(1))
-          EOF
-          )"
-          echo "Tag version:     ${TAG_VERSION}"
-          echo "Package version: ${PKG_VERSION}"
-          if [ "${TAG_VERSION}" != "${PKG_VERSION}" ]; then
-            echo "ERROR: Git tag v${TAG_VERSION} does not match pyproject.toml version ${PKG_VERSION}."
-            echo "Please delete the wrong tag and push the correct tag matching pyproject.toml."
-            exit 1
-          fi
-          echo "OK: tag v${TAG_VERSION} matches pyproject.toml version ${PKG_VERSION}."
-
-      - name: Check tag matches the release-please manifest
-        run: |
-          set -euo pipefail
-          TAG_VERSION="${RELEASE_TAG#v}"
-          MANIFEST_VERSION="$(python -c "import json; print(json.load(open('.release-please-manifest.json'))['.'])")"
-          echo "Tag version:      ${TAG_VERSION}"
-          echo "Manifest version: ${MANIFEST_VERSION}"
-          if [ "${TAG_VERSION}" != "${MANIFEST_VERSION}" ]; then
-            echo "ERROR: Git tag v${TAG_VERSION} does not match .release-please-manifest.json (${MANIFEST_VERSION})."
-            echo "release-please diffs its NEXT release from the tag matching this manifest value."
-            echo "If they disagree, its next proposed release silently walks the wrong commit range."
-            echo "Update .release-please-manifest.json to ${TAG_VERSION} in the same commit that creates this tag."
-            exit 1
-          fi
-          echo "OK: tag v${TAG_VERSION} matches .release-please-manifest.json."
-
-      - name: Check the tag is reachable from main
-        run: |
-          set -euo pipefail
-          # release-please's manifest mode computes what's unreleased by
-          # diffing from the tag matching the manifest version above. If
-          # that tag's commit isn't actually on main's history -- e.g. it
-          # was committed and tagged locally, then reached main through a
-          # squash- or rebase-merged PR that gave the "same" change a
-          # different SHA -- the tag is orphaned: invisible to `git log
-          # main`, and invisible to release-please's diffing. It then falls
-          # back to whatever earlier tag IS an ancestor and walks everything
-          # since, silently pulling months of already-shipped work back into
-          # a bogus "unreleased" changelog. This happened for real on
-          # v3.9.0 (tagged 2026-09-03, diagnosed and fixed 2026-09-10) --
-          # see CONTRIBUTING.md's "Release-please troubleshooting" section.
-          git fetch origin main --quiet
-          if ! git merge-base --is-ancestor "${RELEASE_TAG}" origin/main; then
-            echo "ERROR: ${RELEASE_TAG} is not an ancestor of origin/main."
-            echo "This tag's commit was never actually merged into main -- most likely it was"
-            echo "committed and tagged locally, then reached main via a squash- or rebase-merged"
-            echo "PR that produced a different SHA for the same change. release-please cannot"
-            echo "compute a correct diff from an orphaned tag."
-            echo
-            echo "Fix: find the commit on main with the equivalent change (same message, compare"
-            echo "trees with 'git diff <this-tag> <candidate>' -- differences should be empty or"
-            echo "cosmetic only), then repoint the tag to it:"
-            echo "  git tag -f ${RELEASE_TAG} <correct-sha-on-main>"
-            echo "  git push --force origin ${RELEASE_TAG}"
-            echo "Retagging only rewrites a git ref -- nothing already published (the PyPI wheel,"
-            echo "the GHCR image, the SBOM, the GitHub Release notes) changes."
-            exit 1
-          fi
-          echo "OK: ${RELEASE_TAG} is an ancestor of main."
+    uses: ./.github/workflows/_validate-release-tag.yml
+    with:
+      release_tag: ${{ env.RELEASE_TAG }}
 
   smoke-test:
     name: Smoke Test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -194,6 +194,16 @@ jobs:
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         # No password needed - uses trusted publishing via OIDC
+        with:
+          # A validate-version repair (retagging an orphaned tag, see
+          # CONTRIBUTING.md's "Release-please troubleshooting") re-fires this
+          # whole workflow against a tag whose version may already be on
+          # PyPI. Without this, that re-run fails here with "400: File
+          # already exists" even though every check above it correctly
+          # passed. skip-existing makes an already-published version a
+          # successful no-op instead — the actual fix in that scenario is
+          # the tag repair itself, not a new PyPI upload.
+          skip-existing: true
 
   smoke-test-pypi:
     name: Smoke Test PyPI Package
@@ -254,6 +264,7 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
+          skip-existing: true  # explicit, not just masked by continue-on-error below
         continue-on-error: true  # Don't fail if version already exists
 
   github-release:

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -8,6 +8,14 @@ name: SBOM
 # Tracks issue #120. Uses Anchore's syft via the official action so the
 # SBOM format is consistent with what most enterprise scanners ingest
 # (Grype, Trivy, Dependency-Track, etc.).
+#
+# validate-version (shared with release.yml and docker-publish.yml via
+# _validate-release-tag.yml) gates generation: this workflow runs
+# independently of release.yml's own validate-version job — GitHub Actions
+# has no cross-workflow `needs:` — so without its own gate, an orphaned or
+# manifest-mismatched tag that release.yml correctly rejects would still
+# get an SBOM generated and published from it. See CONTRIBUTING.md's
+# "Release-please troubleshooting" for what this actually catches.
 
 on:
   push:
@@ -24,8 +32,15 @@ env:
   RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
 
 jobs:
+  validate-version:
+    name: Validate Tag vs Package Version
+    uses: ./.github/workflows/_validate-release-tag.yml
+    with:
+      release_tag: ${{ env.RELEASE_TAG }}
+
   sbom:
     name: Generate + attach SBOM
+    needs: validate-version
     runs-on: ubuntu-latest
     permissions:
       contents: write   # to upload to the GitHub Release + push the site copy

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -503,10 +503,29 @@ and `sbom.yml` all re-fire on this push (it's a real tag push, same as the
 original), but PyPI publish uses `skip-existing: true` so an already-shipped
 version succeeds as a no-op instead of failing on "file already exists",
 GHCR image tags simply get overwritten with identical content, and
-`sbom.yml` already no-ops when nothing changed. Do the retag before merging
-or re-running release-please's next proposed PR; merging it as-is would
-ship the bogus changelog and version bump. The `validate-version` gate
-described above exists specifically to stop a fresh instance of this from
+`sbom.yml` already no-ops when nothing changed. All three workflows share
+one `validate-version` gate (`_validate-release-tag.yml`, a reusable
+workflow) — before this section was written, only `release.yml` checked
+the tag, so an orphaned or mismatched tag could still get a GHCR image
+built and an SBOM published even though PyPI correctly rejected it.
+
+**"The release is immutable" does not mean the tag is locked.** Those are
+two different things. GitHub Releases are immutable in one specific,
+narrow sense: once published, there's no API path to attach *assets* to
+them afterward (see `github-release`'s job in `release.yml` — it warns and
+moves on rather than failing when that upload fails). That says nothing
+about the underlying git tag. A tag is an ordinary ref; force-pushing it
+works the same whether or not a Release object happens to reference it,
+unless this repository has an explicit tag-protection ruleset configured
+(Settings → Tags) blocking pushes to `v*` — which it does not, as of this
+writing. If a future ruleset ever changes that, the force-push above would
+simply be rejected by git with a permission error you'd see immediately,
+not silently succeed against a locked target.
+
+Do the retag before merging or re-running release-please's next proposed
+PR; merging it as-is would ship the bogus changelog and version bump. The
+`validate-version` gate described above exists specifically to stop a
+fresh instance of this from
 reaching this point silently again.
 
 ## Community

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -371,16 +371,41 @@ release-please release-pr \
 If you must release manually (e.g. a hotfix not using release-please):
 
 ```bash
-# 1. Update the version in pyproject.toml
+# 1. Update the version in pyproject.toml AND neuralmind/__init__.py
+#    (release-please-config.json's actual version-file) — keep them equal.
 # 2. Update CHANGELOG.md
 # 3. Update .release-please-manifest.json to match the new version
 # 4. Commit with: chore(release): vX.Y.Z
-# 5. Push the tag (must match pyproject.toml version):
-git tag vX.Y.Z
+# 5. Push that commit and get it onto `main` FIRST, as its own push or a
+#    fast-forward merge — never a squash- or rebase-merged PR. Either of
+#    those rewrites the commit into a new SHA on main, silently orphaning
+#    the tag you're about to create in step 6 (see "Tag the SHA that's
+#    actually on main" below).
+git push origin HEAD:main
+
+# 6. Only now, tag the commit that landed on main — re-read its SHA from
+#    main itself, don't reuse the SHA you had checked out locally:
+git fetch origin main
+git tag vX.Y.Z origin/main
 git push origin vX.Y.Z
 ```
 
-The `validate-version` gate in `release.yml` will reject the push if the tag and `pyproject.toml` version differ.
+**Tag the SHA that's actually on `main`, not the one you committed locally.**
+If step 5 goes through a PR that GitHub squash- or rebase-merges, the commit
+that lands on `main` gets a *different SHA* than the one you tagged locally
+— even with an identical message and near-identical content. The tag then
+points at a commit unreachable from `main`: orphaned, invisible to anyone
+browsing the branch, and invisible to release-please's own diffing (see the
+next section). This happened for real on `v3.9.0` — this section was rewritten
+after diagnosing it live in 2026-09.
+
+The `validate-version` gate in `release.yml` checks three things before
+anything publishes, and hard-fails the whole pipeline if any of them don't
+hold: the tag matches `pyproject.toml`'s version, the tag matches
+`.release-please-manifest.json`, and **the tag's commit is an ancestor of
+`main`**. The third check is what would have caught the `v3.9.0` incident
+immediately instead of letting it corrupt the next release-please PR two
+weeks later.
 
 ### Release-please troubleshooting
 
@@ -422,6 +447,36 @@ git commit --allow-empty -m "chore: release as v0.6.0" -m "Release-As: 0.6.0"
 ```
 
 This was used to produce v0.4.0 before the config was sorted out.
+
+**Symptom: release-please proposes a release with a huge, wrong changelog
+reaching back through already-shipped work, or an unexpected major-version
+bump.**
+
+This means the git tag matching `.release-please-manifest.json`'s current
+value is not actually an ancestor of `main` — release-please can't find it
+in the branch's history, so it silently falls back to whatever earlier tag
+*is* an ancestor and walks everything since, including work that already
+shipped under a later version. Confirm with:
+
+```bash
+git merge-base --is-ancestor v<manifest-version> origin/main && echo OK || echo ORPHANED
+```
+
+If it prints `ORPHANED`, find the commit on `main` with the equivalent
+change (same message, `git log --all --grep` or `git diff <bad-tag>
+<candidate>` to compare trees) and repoint the tag:
+
+```bash
+git tag -f v<manifest-version> <correct-sha-on-main>
+git push --force origin v<manifest-version>
+```
+
+This only rewrites a git ref — nothing already published (the PyPI wheel,
+the GHCR image, the SBOM, the GitHub Release notes) changes. Do this before
+merging or re-running release-please's next proposed PR; merging it as-is
+would ship the bogus changelog and version bump. The `validate-version` gate
+described above exists specifically to stop a fresh instance of this from
+reaching this point silently again.
 
 ## Community
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -375,15 +375,21 @@ If you must release manually (e.g. a hotfix not using release-please):
 #    (release-please-config.json's actual version-file) — keep them equal.
 # 2. Update CHANGELOG.md
 # 3. Update .release-please-manifest.json to match the new version
-# 4. Commit with: chore(release): vX.Y.Z
-# 5. Push that commit and get it onto `main` FIRST, as its own push or a
+# 4. Update skills/neuralmind/SKILL.md's `version:` line to match too —
+#    keep the `# x-release-please-version` annotation on that line intact.
+#    tests/test_skill_manifest.py checks this file against the manifest,
+#    and it's what Hermes-Agent, OpenClaw's ClawHub, and Agent Zero's
+#    registries all read; skipping this step is exactly how it drifted to
+#    three releases behind before (fixed in #508).
+# 5. Commit with: chore(release): vX.Y.Z
+# 6. Push that commit and get it onto `main` FIRST, as its own push or a
 #    fast-forward merge — never a squash- or rebase-merged PR. Either of
 #    those rewrites the commit into a new SHA on main, silently orphaning
-#    the tag you're about to create in step 6 (see "Tag the SHA that's
+#    the tag you're about to create in step 7 (see "Tag the SHA that's
 #    actually on main" below).
 git push origin HEAD:main
 
-# 6. Only now, tag the commit that landed on main — re-read its SHA from
+# 7. Only now, tag the commit that landed on main — re-read its SHA from
 #    main itself, don't reuse the SHA you had checked out locally:
 git fetch origin main
 git tag vX.Y.Z origin/main
@@ -462,9 +468,28 @@ shipped under a later version. Confirm with:
 git merge-base --is-ancestor v<manifest-version> origin/main && echo OK || echo ORPHANED
 ```
 
-If it prints `ORPHANED`, find the commit on `main` with the equivalent
-change (same message, `git log --all --grep` or `git diff <bad-tag>
-<candidate>` to compare trees) and repoint the tag:
+If it prints `ORPHANED`, find a commit on `main` that's a candidate for the
+retag. Start from the commit with the equivalent change (same message,
+`git log --all --grep`), but **don't stop at matching source content** —
+`git diff <bad-tag> <candidate>` showing only cosmetic differences is
+necessary but not sufficient. The candidate must ALSO satisfy
+`validate-version`'s other two checks at that exact commit:
+
+```bash
+git show <candidate>:pyproject.toml | grep '^version'
+git show <candidate>:.release-please-manifest.json
+git show <candidate>:skills/neuralmind/SKILL.md | grep '^version:'
+```
+
+All three must read `v<manifest-version>` **at that commit** — not on
+`main`'s current tip, at the candidate itself. This is easy to get wrong:
+the commit with the matching *source* content is often an earlier one than
+the commit where the manifest/SKILL.md bookkeeping actually got fixed (that
+fix usually lands later, bundled with unrelated work, exactly as it did for
+`v3.9.0` — the source-matching commit predated the manifest fix by a week,
+which would have failed `validate-version`'s manifest check all over again
+if tagged directly). Walk forward from the source-matching commit to the
+nearest later one where all three agree, and tag that instead. Then:
 
 ```bash
 git tag -f v<manifest-version> <correct-sha-on-main>
@@ -472,9 +497,15 @@ git push --force origin v<manifest-version>
 ```
 
 This only rewrites a git ref — nothing already published (the PyPI wheel,
-the GHCR image, the SBOM, the GitHub Release notes) changes. Do this before
-merging or re-running release-please's next proposed PR; merging it as-is
-would ship the bogus changelog and version bump. The `validate-version` gate
+the GHCR image, the SBOM, the GitHub Release notes) changes, and none of
+those republish as a side effect either: `release.yml`, `docker-publish.yml`
+and `sbom.yml` all re-fire on this push (it's a real tag push, same as the
+original), but PyPI publish uses `skip-existing: true` so an already-shipped
+version succeeds as a no-op instead of failing on "file already exists",
+GHCR image tags simply get overwritten with identical content, and
+`sbom.yml` already no-ops when nothing changed. Do the retag before merging
+or re-running release-please's next proposed PR; merging it as-is would
+ship the bogus changelog and version bump. The `validate-version` gate
 described above exists specifically to stop a fresh instance of this from
 reaching this point silently again.
 


### PR DESCRIPTION
## Description

Follow-up to [#508](https://github.com/dfrostar/neuralmind/pull/508). Checking on release-please PR [#498](https://github.com/dfrostar/neuralmind/pull/498) after that merge, its recompute proposed a bogus `4.0.0` release with a changelog reaching back through years of already-shipped work instead of the ~34 legitimate commits since `v3.9.0`.

**Root cause, fully diagnosed:** the `v3.9.0` git tag points to a commit (`d748a65`) that was never actually merged into `main`. `main` has a different commit with the identical message but a different SHA — most likely because the locally-tagged commit reached `main` via a squash- or rebase-merged PR, which gives "the same" change a new SHA. I diffed the two trees to be sure nothing was lost: every difference is Black's line-wrapping for the same SQL strings, nothing behavioral.

This isn't a one-off: `v3.6.0`, `v3.5.1`, and `v3.4.0` are orphaned the same way. It only surfaced now because the manifest had been tracking a tag that (until #508's fix) was still a valid ancestor. I also found that **every single release-please PR this repo has ever generated — all 30 of them — was closed rather than merged.** Every real release has always been cut by hand, which is exactly the path that produces this failure mode: release-please can't find an orphaned tag in `main`'s ancestry, so it silently falls back to whichever earlier tag *is* an ancestor and walks everything since into a spurious "unreleased" changelog.

**The guard.** `validate-version` in `release.yml` already checked the tag against `pyproject.toml`, but not against `.release-please-manifest.json` — the file release-please's own diffing actually keys off — and never checked that the tag is reachable from `main` at all. This adds both:
- A manifest-match check, same shape as the existing `pyproject.toml` one.
- A `git merge-base --is-ancestor` check, with an error message that names the exact fix (find the equivalent commit on `main`, repoint the tag, force-push it).

The checkout step needed `fetch-depth: 0` — ancestry checks need real history, and the default shallow single-commit clone gives either a false negative or an outright "no merge base" error.

Since the first version of this PR, the same gate was also extracted into a reusable `workflow_call` file (`_validate-release-tag.yml`) and wired into `docker-publish.yml` and `sbom.yml` too — both trigger independently on the same tag push and had no equivalent check before, so an orphaned tag that `release.yml` rejected could still produce a GHCR image and an SBOM. `pypa/gh-action-pypi-publish` also now runs with `skip-existing: true`, so re-running the release workflow against a *repaired* tag doesn't hard-fail on a version already on PyPI.

**Docs.** `CONTRIBUTING.md`'s "Manual release" steps only said "push the tag" without saying which commit to tag — the exact gap that let this happen. Rewrote it to tag the SHA that actually lands on `main`, not the one committed locally, and added a troubleshooting entry for this failure mode alongside the existing release-please symptom/fix entries, in the same style. It also now spells out that the correct commit must match `pyproject.toml`, the manifest, **and** `SKILL.md` at that exact commit — not just have matching source trees — since those can genuinely differ by a few commits (see below).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🔧 Configuration change
- [x] 📝 Documentation update

## How Has This Been Tested?

- [x] Manual testing

This is a CI workflow change, so it can't be exercised by `pytest`. Instead I validated the actual logic before trusting it:
- `python3 -c "import yaml; yaml.safe_load(...)"` — the edited workflow files parse cleanly and the new steps appear in the job in order.
- Ran the manifest-match bash logic standalone against a matching manifest (passes) and a mismatched one, `3.9.0` tag vs `3.8.0` manifest — the exact bug this PR is a response to (correctly fails).
- Ran the ancestry-check bash logic standalone against the real repo: `v3.9.0` (still live and orphaned right now) is correctly flagged as `ORPHANED`, and `v3.7.1` (a healthy tag) correctly passes.

### Test Configuration

* **Python version**: 3.11
* **Operating System**: Linux

## Documentation & discoverability

- [x] Docs answer *"what does the user/agent now see?"* — `CONTRIBUTING.md` now tells a contributor exactly which commit to tag and why, plus how to recover if this happens again
- [x] I did **not** edit `CHANGELOG.md` or hand-bump `pyproject.toml`

No CLI command, MCP tool, or hook changed, so `README.md`, `docs/index.html`, `docs/about.html`, wiki, use-cases and SEO are unaffected — this is release tooling, not a product surface.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Code Quality

- [x] Docstrings are added/updated for public APIs — the new workflow steps and CONTRIBUTING.md sections carry the same why-not-just-what explanatory comments this repo already uses throughout `release.yml` and `release-please.yml`

## Additional Notes

Still needing a human, not a further code change:

- **Retag `v3.9.0`:** `git tag -f v3.9.0 f0a7237 && git push --force origin v3.9.0`. **Correction:** an earlier version of this note said `73a4b0b` — that commit's own `.release-please-manifest.json` still reads `3.8.0` (it predates the manifest fix by about a week), so it would have failed this PR's own new manifest-match check. `f0a7237` is the commit where `pyproject.toml`, the manifest, and `SKILL.md` all actually agree on `3.9.0`. Nothing already published (PyPI wheel, GHCR image, SBOM, GitHub Release notes) changes; only the git ref moves.
- Once retagged, release-please PR #498 should recompute cleanly on the next push to `main` — the real ~34-commit range, most likely landing on a sane `3.10.0` rather than the current bogus `4.0.0`.
- `v3.6.0`, `v3.5.1`, `v3.4.0` are orphaned too, but don't currently block anything (the manifest has already moved past them). Worth a similar retag pass if anyone ever needs those specific tags to resolve correctly, but not urgent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0136ZyESQrqGpyHWJCsDBeCe

---
_Generated by [Claude Code](https://claude.ai/code/session_0136ZyESQrqGpyHWJCsDBeCe)_